### PR TITLE
prevent files from being set to undefined

### DIFF
--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -40,7 +40,6 @@ module.exports = function(app, callback) {
   }
 
   jsFiles.forEach(function(file) {
-    file = file.path;
     promises.push(function(file) {
       return new Promise(function(resolve, reject) {
         var split,

--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -40,6 +40,7 @@ module.exports = function(app, callback) {
   }
 
   jsFiles.forEach(function(file) {
+    file = file.path ? file.path : file;
     promises.push(function(file) {
       return new Promise(function(resolve, reject) {
         var split,

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -97,7 +97,6 @@ module.exports = function(app, callback) {
   });
 
   cssFiles.forEach(function(file) {
-    file = file.path;
     file = file.replace(app.get('cssPath'), '');
     promises.push(function(file) {
       return new Promise(function(resolve, reject) {

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -97,6 +97,7 @@ module.exports = function(app, callback) {
   });
 
   cssFiles.forEach(function(file) {
+    file = file.path ? file.path : file;
     file = file.replace(app.get('cssPath'), '');
     promises.push(function(file) {
       return new Promise(function(resolve, reject) {


### PR DESCRIPTION
Judging by some digging with console logs I've determined that when these functions are called on server init they are being passed the file arg properly, and then `file = file.path` results in setting them to undefined, which creates a cascade of errors when any manipulation is done to them later on. Removing these lines allows the server to run as normal.