### PR TITLE
Better error message when Java is not installed, fixed problem on Mac with validator

### DIFF
--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -39,7 +39,6 @@ module.exports = function(app, callback) {
       params.htmlValidator.validator = 'http://localhost:' + (params.htmlValidator.port ? params.htmlValidator.port : '8888');
       options = params.htmlValidator;
     }
-
     // spawn validator child process
     promise = (() => {
       return new Promise((resolve, reject) => {
@@ -53,9 +52,24 @@ module.exports = function(app, callback) {
           }
         });
 
+        validatorProcess.stderr.on('data', (data) => {
+          if (`${data}`.includes('No Java runtime present, requesting install.')) {
+            console.error('error: No Java runtime detected. Check to make sure Java is installed and in your path.');
+            reject();
+          }
+          else {
+            resolve();
+          }
+        });
+
         validatorProcess.on('error', (err) => {
-          console.error(`error: ${err}`);
-          reject();
+          if (err.code === 'ENOENT') {
+            console.error('error: No Java runtime detected. Check to make sure Java is installed and in your path.');
+          }
+          else {
+            console.error('error: ', err);
+            reject();
+          }
         });
       });
     })();


### PR DESCRIPTION
(closes #146)

Fixed problem with Java validation on Mac not displaying error messages, made error messages more clear.
