### PR TITLE
Fixed graceful shutdown not executing properly on Mac

### DIFF
--- a/roosevelt.js
+++ b/roosevelt.js
@@ -33,6 +33,7 @@ module.exports = function(params) {
       servers = [],
       i,
       sockets = {},
+      socketId,
       nextSocketId = 0;
 
   // expose initial vars
@@ -89,8 +90,7 @@ module.exports = function(params) {
 
   // add open sockets to array when connected
   httpServer.on('connection', function (socket) {
-    var socketId = nextSocketId++;
-    sockets[socketId] = socket;
+    sockets[nextSocketId++] = socket;
 
     // once the socket closes, remove socket from array
     socket.once('close', function () {
@@ -194,7 +194,7 @@ module.exports = function(params) {
         });
 
         // destroy sockets when server is killed
-        for (var socketId in sockets) {
+        for (socketId in sockets) {
           sockets[socketId].destroy();
         }
 

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -32,12 +32,9 @@ module.exports = function(params) {
       numCPUs = 1,
       servers = [],
       i,
-<<<<<<< HEAD
       connections = {},
-      key;
-=======
+      key,
       initialized = false;
->>>>>>> 2d022c6f1de92f96956e9afb47d9d8e6cd8520da
 
   // expose initial vars
   app.set('express', express);

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -203,6 +203,12 @@ module.exports = function(params) {
           exitLog();
         }
       });
+
+      // destroy connections when server is killed
+      for (key in connections) {
+        connections[key].destroy();
+      }
+
       setTimeout(function() {
         console.error(('💥  ' + (app.get('appName') || 'Roosevelt') + ' could not close all connections in time; forcefully shutting down.').red);
         process.exit(1);

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -90,7 +90,7 @@ module.exports = function(params) {
   // assign individual keys to connections when opened
   httpServer.on('connection', function (conn) {
     key = conn.remoteAddress + ':' + conn.remotePort;
-    connections[key] = conn; 
+    connections[key] = conn;
 
     // once the connection closes, remove
     conn.on('close', function () {

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -33,7 +33,6 @@ module.exports = function(params) {
       servers = [],
       i,
       connections = {},
-      key,
       initialized = false;
 
   // expose initial vars
@@ -90,7 +89,7 @@ module.exports = function(params) {
 
   // assign individual keys to connections when opened
   httpServer.on('connection', function (conn) {
-    key = conn.remoteAddress + ':' + conn.remotePort;
+    var key = conn.remoteAddress + ':' + conn.remotePort;
     connections[key] = conn;
 
     // once the connection closes, remove

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -187,6 +187,7 @@ module.exports = function(params) {
 
     // start server
     function gracefulShutdown() {
+      var key;
       function exitLog() {
         console.log(('✔️  ' + (app.get('appName') || 'Roosevelt') + ' successfully closed all connections and shut down gracefully.').magenta);
         process.exit();


### PR DESCRIPTION
(closes #149)

Fixed issue where graceful shutdown was not executing on Mac causing a long timeout before Roosevelt is finally killed. This is because there were open connections not being closed when Roosevelt receives the kill signal. 

- Added section of code that recognizes when the server establishes a socket, adding it to an array of sockets that Roosevelt has created.
- When Roosevelt receives the kill signal, Roosevelt now closes all open sockets, allowing for the graceful shutdown process to continue as intended on Mac. 