### PR TITLE
Separated Server Initialization From HTTP Server Startup

### DIFF
--- a/roosevelt.js
+++ b/roosevelt.js
@@ -31,7 +31,8 @@ module.exports = function(params) {
       passphrase,
       numCPUs = 1,
       servers = [],
-      i;
+      i,
+      initialized = false;
 
   // expose initial vars
   app.set('express', express);
@@ -109,7 +110,12 @@ module.exports = function(params) {
     params.onServerInit(app);
   }
 
-  function startServer() {
+  // Initialize Roosevelt app middleware and prepare static css,js
+  function initServer(cb) {
+    if (initialized) {
+      return cb();
+    }
+    initialized = true;
 
     // initialize HTML validator
     validateHTML();
@@ -129,102 +135,114 @@ module.exports = function(params) {
     }
 
     function compileJs() {
-      require('./lib/jsCompiler')(app, startHttpServer);
+      require('./lib/jsCompiler')(app, mapRoutes);
     }
 
-    function startHttpServer() {
+    function mapRoutes() {
       // map routes
       app = require('./lib/mapRoutes')(app);
 
       // custom error page
       app = require('./lib/500ErrorPage.js')(app);
 
-      // determine number of CPUs to use
-      process.argv.some(function(val, index, array) {
-        var arg = array[index + 1],
-            max = os.cpus().length;
+      cb();
+    }
+  }
 
-        if (val === '-cores') {
-          if (arg === 'max') {
-            numCPUs = max;
+  function startHttpServer() {
+    // determine number of CPUs to use
+    process.argv.some(function(val, index, array) {
+      var arg = array[index + 1],
+          max = os.cpus().length;
+
+      if (val === '-cores') {
+        if (arg === 'max') {
+          numCPUs = max;
+        }
+        else {
+          arg = parseInt(arg);
+          if (arg <= max && arg > 0) {
+            numCPUs = arg;
           }
           else {
-            arg = parseInt(arg);
-            if (arg <= max && arg > 0) {
-              numCPUs = arg;
-            }
-            else {
-              console.warn(('⚠️  ' + (app.get('appName') || 'Roosevelt') + ' warning: invalid value "' + array[index + 1] + '" supplied to -cores param.').red);
-              numCPUs = 1;
-            }
+            console.warn(('⚠️  ' + (app.get('appName') || 'Roosevelt') + ' warning: invalid value "' + array[index + 1] + '" supplied to -cores param.').red);
+            numCPUs = 1;
           }
-          return;
+        }
+        return;
+      }
+    });
+
+    // start server
+    function gracefulShutdown() {
+      function exitLog() {
+        console.log(('✔️  ' + (app.get('appName') || 'Roosevelt') + ' successfully closed all connections and shut down gracefully.').magenta);
+        process.exit();
+      }
+
+      app.set('roosevelt:state', 'disconnecting');
+      console.log(('\n' + '💭  ' + (app.get('appName') || 'Roosevelt') + ' received kill signal, attempting to shut down gracefully.').magenta);
+      servers[0].close(function() {
+        if (servers.length > 1) {
+          servers[1].close(exitLog);
+        }
+        else {
+          exitLog();
         }
       });
-
-      // start server
-      function gracefulShutdown() {
-        function exitLog() {
-          console.log(('✔️  ' + (app.get('appName') || 'Roosevelt') + ' successfully closed all connections and shut down gracefully.').magenta);
-          process.exit();
-        }
-
-        app.set('roosevelt:state', 'disconnecting');
-        console.log(('\n' + '💭  ' + (app.get('appName') || 'Roosevelt') + ' received kill signal, attempting to shut down gracefully.').magenta);
-        servers[0].close(function() {
-          if (servers.length > 1) {
-            servers[1].close(exitLog);
-          }
-          else {
-            exitLog();
-          }
-        });
-        setTimeout(function() {
-          console.error(('💥  ' + (app.get('appName') || 'Roosevelt') + ' could not close all connections in time; forcefully shutting down.').red);
-          process.exit(1);
-        }, app.get('params').shutdownTimeout);
-      }
-
-      var lock = {},
-          startupCallback = function(proto, port) {
-            return function() {
-              console.log('🎧  ' + (app.get('appName') + proto + ' server listening on port ' + port + ' (' + app.get('env') + ' mode)').bold);
-
-              if (!Object.isFrozen(lock)) {
-                Object.freeze(lock);
-                // fire user-defined onServerStart event
-                if (params.onServerStart && typeof params.onServerStart === 'function') {
-                  params.onServerStart(app);
-                }
-              }
-            };
-          };
-
-      if (cluster.isMaster && numCPUs > 1) {
-        for (i = 0; i < numCPUs; i++) {
-          cluster.fork();
-        }
-        cluster.on('exit', function(worker, code, signal) {
-          console.log(('⚰️  ' + (app.get('appName') || 'Roosevelt') + ' thread ' + worker.process.pid + ' died').magenta);
-        });
-      }
-      else {
-        if (!app.get('params').httpsOnly) {
-          servers.push(httpServer.listen(app.get('port'), (params.localhostOnly && app.get('env') !== 'development' ? 'localhost' : null), startupCallback(' HTTP', app.get('port'))));
-        }
-        if (app.get('params').https) {
-          servers.push(httpsServer.listen(app.get('params').httpsPort, (params.localhostOnly && app.get('env') !== 'development' ? 'localhost' : null), startupCallback(' HTTPS', app.get('params').httpsPort)));
-        }
-        process.on('SIGTERM', gracefulShutdown);
-        process.on('SIGINT', gracefulShutdown);
-      }
+      setTimeout(function() {
+        console.error(('💥  ' + (app.get('appName') || 'Roosevelt') + ' could not close all connections in time; forcefully shutting down.').red);
+        process.exit(1);
+      }, app.get('params').shutdownTimeout);
     }
-  };
+
+    var lock = {},
+        startupCallback = function(proto, port) {
+          return function() {
+            console.log('🎧  ' + (app.get('appName') + proto + ' server listening on port ' + port + ' (' + app.get('env') + ' mode)').bold);
+
+            if (!Object.isFrozen(lock)) {
+              Object.freeze(lock);
+              // fire user-defined onServerStart event
+              if (params.onServerStart && typeof params.onServerStart === 'function') {
+                params.onServerStart(app);
+              }
+            }
+          };
+        };
+
+    if (cluster.isMaster && numCPUs > 1) {
+      for (i = 0; i < numCPUs; i++) {
+        cluster.fork();
+      }
+      cluster.on('exit', function(worker, code, signal) {
+        console.log(('⚰️  ' + (app.get('appName') || 'Roosevelt') + ' thread ' + worker.process.pid + ' died').magenta);
+      });
+    }
+    else {
+      if (!app.get('params').httpsOnly) {
+        servers.push(httpServer.listen(app.get('port'), (params.localhostOnly && app.get('env') !== 'development' ? 'localhost' : null), startupCallback(' HTTP', app.get('port'))));
+      }
+      if (app.get('params').https) {
+        servers.push(httpsServer.listen(app.get('params').httpsPort, (params.localhostOnly && app.get('env') !== 'development' ? 'localhost' : null), startupCallback(' HTTPS', app.get('params').httpsPort)));
+      }
+      process.on('SIGTERM', gracefulShutdown);
+      process.on('SIGINT', gracefulShutdown);
+    }
+  }
+
+  function startServer() {
+    if (!initialized) {
+      return initServer(startHttpServer);
+    }
+    startHttpServer();
+  }
 
   return {
     httpServer: httpServer,
     httpsServer: httpsServer,
     expressApp: app,
+    initServer: initServer,
     startServer: startServer
   };
 };


### PR DESCRIPTION
Attaching Roosevelt routing and third-party middleware, and compiling of static css, js now happens in a separate public `initServer` method. The `startServer` method calls the `initServer` method if it has not been explicitly called prior. The `initServer` method logic only executes once per Roosevelt object instance, despite repeated calls to the method.

Closes #131 