### PR TITLE
Fixed error with promise when html validator is disabled

### DIFF
--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -171,16 +171,16 @@ module.exports = function(app, callback) {
   });
 
   // only resolve promise when in dev mode
-  if (app.get('envStateDev')) {
+  if (process.env.NODE_ENV === 'development') {
     Promise.all([promise]).then((result) => {
       // only print error if validator is disabled and in dev mode
       if (!params.enableValidator) {
-        console.error(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
+        console.warn(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
       }
       callback();
     }).catch((result) => {
       // only print error if in dev mode
-      console.error(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
+      console.warn(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
       validatorDisabled = true;
       callback();
     });

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -54,7 +54,7 @@ module.exports = function(app, callback) {
         validatorProcess.stdout.on('data', (data) => {
           if (`${data}`.includes('Initialization complete')) {
             clearTimeout(validatorTimeout);
-            console.log('✔️  ' + ('Validator initialization completed successfully. HTML validator listening on port: ' + params.htmlValidator.port).bold.green);
+            console.log('🎧  ' + ('HTML validator listening on port: ' + params.htmlValidator.port).bold);
             resolve();
           }
         });
@@ -98,7 +98,7 @@ module.exports = function(app, callback) {
       // get the html for this specific render
       app.render(view, model, function(err, html) {
 
-        if (process.env.NODE_ENV === 'development' && !validatorDisabled && res.get(headerException) !== 'true' && !model[modelException] && html) {
+        if (!validatorDisabled && res.get(headerException) !== 'true' && !model[modelException] && html) {
           // run HTML validator and display errors on page
           options.data = html;
 
@@ -170,11 +170,14 @@ module.exports = function(app, callback) {
     next();
   });
 
-  promise.then(function(result) {
+  Promise.all([promise]).then((result) => {
+    // only show this error if validator is not enabled
+    if (!params.enableValidator) {
+      console.error(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
+    }
     callback();
-  }).catch(function(result) {
-    // rejection
-    console.error(('HTML Validator disabled. Continuing without HTML validation...').red);
+  }).catch((result) => {
+    console.error(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
     validatorDisabled = true;
     callback();
   });

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -170,18 +170,23 @@ module.exports = function(app, callback) {
     next();
   });
 
-  Promise.all([promise]).then((result) => {
-    // only show this error if validator is not enabled and in dev mode
-    if (!params.enableValidator && app.get('envStateDev')) {
+  // only resolve promise when in dev mode
+  if (app.get('envStateDev')) {
+    Promise.all([promise]).then((result) => {
+      // only print error if validator is disabled and in dev mode
+      if (!params.enableValidator) {
+        console.error(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
+      }
+      callback();
+    }).catch((result) => {
+      // only print error if in dev mode
       console.error(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
-    }
+      validatorDisabled = true;
+      callback();
+    });
+  }
+  else {
+    // if not in dev mode, fire callback
     callback();
-  }).catch((result) => {
-    // only print error if in dev mode
-    if (app.get('envStateDev')) {
-      console.error(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
-    }
-    validatorDisabled = true;
-    callback();
-  });
+  }
 };

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -171,13 +171,16 @@ module.exports = function(app, callback) {
   });
 
   Promise.all([promise]).then((result) => {
-    // only show this error if validator is not enabled
-    if (!params.enableValidator) {
+    // only show this error if validator is not enabled and in dev mode
+    if (!params.enableValidator && app.get('envStateDev')) {
       console.error(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
     }
     callback();
   }).catch((result) => {
-    console.error(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
+    // only print error if in dev mode
+    if (app.get('envStateDev')) {
+      console.error(('⚠️  ' + 'HTML validator disabled. Continuing without HTML validation...').yellow);
+    }
     validatorDisabled = true;
     callback();
   });

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -137,6 +137,16 @@ module.exports = function(app) {
   app.set('cssCompiledOutput', path.normalize(appDir + params.cssCompiledOutput));
   app.set('jsCompiledOutput', path.normalize(appDir + params.jsCompiledOutput));
 
+  // keep track of state of env
+  if (process.env.NODE_ENV === 'development') {
+    // set the envStateDev to true if in dev mode
+    app.set('envStateDev', true);
+  }
+  else {
+    // set false if in prod mode
+    app.set('envStateDev', false);
+  }
+
   // determine statics prefix if any
   params.staticsPrefix = params.versionedStatics ? pkg.version || '' : '';
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -171,6 +171,7 @@ module.exports = function(app) {
 
   if (process.env.NODE_ENV === 'development') {
     params.noMinify = true;
+    params.enableValidator = false;
   }
 
   app.set('params', params);

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -171,6 +171,9 @@ module.exports = function(app) {
 
   if (process.env.NODE_ENV === 'development') {
     params.noMinify = true;
+  }
+
+  if (process.env.NODE_ENV === 'production') {
     params.enableValidator = false;
   }
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -137,16 +137,6 @@ module.exports = function(app) {
   app.set('cssCompiledOutput', path.normalize(appDir + params.cssCompiledOutput));
   app.set('jsCompiledOutput', path.normalize(appDir + params.jsCompiledOutput));
 
-  // keep track of state of env
-  if (process.env.NODE_ENV === 'development') {
-    // set the envStateDev to true if in dev mode
-    app.set('envStateDev', true);
-  }
-  else {
-    // set false if in prod mode
-    app.set('envStateDev', false);
-  }
-
   // determine statics prefix if any
   params.staticsPrefix = params.versionedStatics ? pkg.version || '' : '';
 

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -117,6 +117,8 @@ module.exports = function(params) {
     }
     initialized = true;
 
+    preProcessCss();
+
     function preprocessCss() {
       require('./lib/preprocessCss')(app, bundleJs);
     }
@@ -126,14 +128,11 @@ module.exports = function(params) {
     }
 
     function compileJs() {
-      require('./lib/jsCompiler')(app, mapRoutes);
+      require('./lib/jsCompiler')(app, validateHTML);
     }
 
-     // initialize HTML validator
-    validateHTML();
-
     function validateHTML() {
-      require('./lib/htmlValidator')(app, preprocessCss);
+      require('./lib/htmlValidator')(app, mapRoutes);
     }
 
     require('./lib/htmlMinify')(app);

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -117,7 +117,7 @@ module.exports = function(params) {
     }
     initialized = true;
 
-    preProcessCss();
+    preprocessCss();
 
     function preprocessCss() {
       require('./lib/preprocessCss')(app, bundleJs);

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -117,15 +117,6 @@ module.exports = function(params) {
     }
     initialized = true;
 
-    // initialize HTML validator
-    validateHTML();
-
-    function validateHTML() {
-      require('./lib/htmlValidator')(app, preprocessCss);
-    }
-
-    require('./lib/htmlMinify')(app);
-
     function preprocessCss() {
       require('./lib/preprocessCss')(app, bundleJs);
     }
@@ -137,6 +128,15 @@ module.exports = function(params) {
     function compileJs() {
       require('./lib/jsCompiler')(app, mapRoutes);
     }
+
+     // initialize HTML validator
+    validateHTML();
+
+    function validateHTML() {
+      require('./lib/htmlValidator')(app, preprocessCss);
+    }
+
+    require('./lib/htmlMinify')(app);
 
     function mapRoutes() {
       // map routes


### PR DESCRIPTION
(closes #156)

**New pull request due to corruption of the last one.**

 Moved back to resolving the promise using Promise.all. This change:

- Fixes an error that occurs when the HTML validator has been turned off prior to launching the application.
- In the case that the HTML validator was turned off, the user is now told that the HTML validator is disabled and to check to make sure that their HTML validator is turned on.
- Makes it so that the HTML validator does not run when in production mode
- No longer checks for production mode within the HTML validator code