### PR TITLE
Clearly spell out missing file error for jsCompilerWhitelist (Closes #177)

### DIFF
--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -13,13 +13,28 @@ module.exports = function(app, callback) {
   var params = app.get('params'),
       preprocessor = params.jsCompiler.nodeModule,
       preprocessorModule,
-      jsFiles = params.jsCompilerWhitelist ? params.jsCompilerWhitelist : klawSync(app.get('jsPath')),
+      jsFiles,
       usingWhitelist = params.jsCompilerWhitelist ? true : false,
       promises = [];
 
   if (params.jsCompiler === 'none') {
     callback();
     return;
+  }
+
+  // check if using whitelist before populating jsFiles
+  if (usingWhitelist) {
+    if (typeof params.jsCompilerWhitelist !== 'object') {
+      console.error('❌  jsCompilerWhitelist not configured correctly. Please ensure that it is an array. See https://github.com/rooseveltframework/roosevelt#statics-parameters for configuration instructions'.red);
+      callback();
+      return;
+    }
+    else {
+      jsFiles = params.jsCompilerWhitelist;
+    }
+  }
+  else {
+    jsFiles = klawSync(app.get('jsPath'));
   }
 
   // require preprocessor
@@ -50,6 +65,15 @@ module.exports = function(app, callback) {
           split = file.split(':');
           altdest = split[1];
           file = split[0];
+        }
+
+        // when using whitelist determine the file exists first
+        if (usingWhitelist) {
+          if (!checkFiles.fileExists(path.normalize(app.get('jsPath') + file))) {
+            console.error('❌  ' + (file + ' specified in jsCompilerWhitelist does not exist. Please ensure file is entered properly').red);
+            resolve();
+            return;
+          }
         }
 
         if (file === '.' || file === '..' || file === 'Thumbs.db' || fs.lstatSync(usingWhitelist === true ? path.normalize(app.get('jsPath') + file) : file).isDirectory()) {

--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -70,7 +70,7 @@ module.exports = function(app, callback) {
         // when using whitelist determine the file exists first
         if (usingWhitelist) {
           if (!checkFiles.fileExists(path.normalize(app.get('jsPath') + file))) {
-            console.error('❌  ' + (file + ' specified in jsCompilerWhitelist does not exist. Please ensure file is entered properly').red);
+            console.error('❌  ' + (file + ' specified in jsCompilerWhitelist does not exist. Please ensure file is entered properly.').red);
             resolve();
             return;
           }


### PR DESCRIPTION
This PR instates 2 new defensive error checks to the jscompiler
1. Checking that the `jsCompilerWhitelist` param is set properly before attempting to popular `jsFiles` with it.
2. Ensuring that the files in `jsCompilerWhitelist` exist before attempting operations on them in the promise loop.

Either of these scenarios failing will cancel the compiler operation and log the errors in red. No more unhandled promises!

(Closes #177)