### PR TITLE
parameterized and searched appDir

### DIFF
--- a/lib/getAppDir.js
+++ b/lib/getAppDir.js
@@ -3,9 +3,21 @@
 require('colors');
 
 var os = require('os'),
+    klawSync = require('klaw-sync'),
+    fs = require('fs'),
+    path = require('path'),
     parent = module,
     filepath = parent.filename,
-    appDir;
+    appDir,
+    paths,
+    found = false,
+    klawedAppDir,
+    pathCounter,
+    pkgContents,
+    keys,
+
+    // filter to remove node_modules and .git whilst klawing. (from the klaw-sync npm page)
+    filterFn = item => item.path.indexOf('node_modules') < 0 && item.path.indexOf('.git') < 0;
 
 while (filepath.indexOf('roosevelt.js') === -1) {
   parent = parent.parent;
@@ -16,7 +28,40 @@ while (filepath.indexOf('roosevelt.js') === -1) {
 parent = parent.parent;
 filepath = parent.filename;
 
-appDir = os.platform() !== 'win32' ? filepath.split('/') : filepath.split('\\');
+appDir = filepath.split(path.sep);
 appDir = filepath.replace(appDir[appDir.length - 1], '');
+
+// get all files in the current dir filtering out .git and node_modules if they are there
+paths = klawSync(appDir, {filter: filterFn, noRecurseOnFailedFilter: true});
+klawedAppDir = appDir;
+
+// find the root dir of the project from the absolute path by klawing for package.json
+sentinal:
+while(found === false) {
+  for (pathCounter = 0; pathCounter < paths.length; pathCounter++) {
+    aPath = paths[pathCounter];
+    if (aPath.path.includes('package.json')){
+      found = true;
+      break sentinal;
+    }
+  }
+
+  // get parent dir
+  klawedAppDir = klawedAppDir.split(path.sep);
+  klawedAppDir = klawedAppDir.slice(0, klawedAppDir.length-2);
+  klawedAppDir = klawedAppDir.join(path.sep);
+  klawedAppDir +=  path.sep;
+
+  // filter again as we go up
+  paths = klawSync(klawedAppDir, {filter: filterFn, noRecurseOnFailedFilter: true});
+}
+
+// look for roosevelt config in the package.json
+// JOSNify file data
+pkgContents = JSON.parse(fs.readFileSync(klawedAppDir + 'package.json'));
+keys = Object.keys(pkgContents);
+
+// choose between old(stable) and klawed
+appDir = keys.includes('rooseveltConfig') ? klawedAppDir : appDir;
 
 module.exports = appDir;

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -12,8 +12,8 @@ pkg.rooseveltConfig = pkg.rooseveltConfig || {};
 module.exports = function(app) {
   var params = app.get('params');
 
-  if (params.appDir) {
-    appDir = params.appDir;
+  if (params.appDir || pkg.rooseveltConfig.appDir) {
+    appDir = params.appDir || pkg.rooseveltConfig.appDir ;
   }
 
   app.set('appDir', appDir);

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -12,6 +12,10 @@ pkg.rooseveltConfig = pkg.rooseveltConfig || {};
 module.exports = function(app) {
   var params = app.get('params');
 
+  if (params.appDir) {
+    appDir = params.appDir;
+  }
+
   app.set('appDir', appDir);
   app.set('package', pkg);
   app.set('appName', pkg.name || 'Roosevelt Express');


### PR DESCRIPTION
Allows `appDir` to be passed as a parameter(constructor or JSON), overwriting any searched appDir. 

Via constructor:
``` javascript
app = require('roosevelt')({
    enableValidator : false,
    appDir : '/Users/project/test/folder/'
  });
```
Via package.JSON: 
``` JSON
"rooseveltConfig": {
    "appDir": "/Users/project/test/folder/",
    "port": 43711,   
    ...
}
```

Looks where roosevelt is required then walks (npm klaw-sync) up each directory looking for a roosevelt app package.json (looking for rooseveltconfig key). If found, sets the `appDir` to that of the package.json. 

If a roosevelt configuration cannot be found `appDir` falls back to the current implementation.

(closes #169 )