### PR TITLE
HTTPS CA / Accept fully-realized string input

### DIFF
--- a/roosevelt.js
+++ b/roosevelt.js
@@ -78,14 +78,22 @@ module.exports = function (params) {
         httpsOptions.passphrase = passphrase
       }
       if (ca) {
-        // String or array
-        if (typeof ca === 'string') {
-          httpsOptions.ca = fs.readFileSync(ca)
-        } else if (ca instanceof Array) {
-          httpsOptions.ca = []
-          ca.forEach(function (val, index, array) {
-            httpsOptions.ca.push(fs.readFileSync(val))
-          })
+        try {
+          // String or array
+          if (typeof ca === 'string') {
+            httpsOptions.ca = fs.readFileSync(ca)
+          } else if (ca instanceof Array) {
+            httpsOptions.ca = []
+            ca.forEach(function (val, index, array) {
+              httpsOptions.ca.push(fs.readFileSync(val))
+            })
+          }
+        } catch (err) {
+          if (err.code !== 'ENOENT') {
+            throw err
+          }
+          // assume we were passed a string or array of full certificate data, instead of file paths
+          httpsOptions.ca = ca
         }
       }
     }


### PR DESCRIPTION
#245 - Implementation of discussed option 2

- try/catch around reading CA files
- assume string keys if File Not Found
  - if any fail, apply assumption to entire array
- allow https server to deal with bad CA input

This is just a quick and dirty solution.