### PR TITLE
Full refactor of cssPreprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Statics parameters
 - `cssPath`: Subdirectory within `staticsRoot` where your CSS files are located. By default this folder will not be made public, but is instead meant to store unminified CSS source files which will be minified and stored elsewhere when the app is started.
   - Default: `css`
 - `cssCompiler`: Which CSS preprocessor, if any, to use. Must also be marked as a dependency in your app's package.json. Set to `none` to use no CSS preprocessor.
-  - Default: `{nodeModule: 'roosevelt-less', params: {cleanCSS: {advanced: true, aggressiveMerging: true}, sourceMap: {}}}`.
+  - Default: `{nodeModule: 'roosevelt-less', params: {cleanCSS: {advanced: true, aggressiveMerging: true}, sourceMap: null}`.
   - Also by default the module [roosevelt-less](https://github.com/rooseveltframework/roosevelt-less) is marked as a dependency in package.json.
     - Note: Use `cleanCSS` to configure options passed to [less-plugin-clean-css](https://github.com/jakubpawlowicz/clean-css/tree/v3.0.1#how-to-use-clean-css-programmatically).
     - Note: `sourceMap is optional. Configuration details can be found in the [LESS API documentation](http://lesscss.org/usage/index.html#programmatic-usage).

--- a/README.md
+++ b/README.md
@@ -336,10 +336,13 @@ Statics parameters
 - `cssPath`: Subdirectory within `staticsRoot` where your CSS files are located. By default this folder will not be made public, but is instead meant to store unminified CSS source files which will be minified and stored elsewhere when the app is started.
   - Default: `css`
 - `cssCompiler`: Which CSS preprocessor, if any, to use. Must also be marked as a dependency in your app's package.json. Set to `none` to use no CSS preprocessor.
-  - Default: `{nodeModule: 'roosevelt-less', params: {compress: true}}`.
+  - Default: `{nodeModule: 'roosevelt-less', params: {cleanCSS: {advanced: true, aggressiveMerging: true}, sourceMap: {}}}`.
   - Also by default the module [roosevelt-less](https://github.com/rooseveltframework/roosevelt-less) is marked as a dependency in package.json.
-- `cssCompilerWhitelist`: Whitelist of CSS files to compile as an array. Leave undefined to compile all files.
-  - Default: `undefined`
+    - Note: Use `cleanCSS` to configure options passed to [less-plugin-clean-css](https://github.com/jakubpawlowicz/clean-css/tree/v3.0.1#how-to-use-clean-css-programmatically).
+    - Note: `sourceMap is optional. Configuration details can be found in the [LESS API documentation](http://lesscss.org/usage/index.html#programmatic-usage).
+- `cssCompilerWhitelist`: Whitelist of CSS files to compile as an array. Leave undefined to compile all files. Supply a `:` character after each file name to delimit an alternate file path and/or file name for the minified file.
+  - Default: `null`
+  - Example: `less/example.less:styles/example.min.css` (customizes both file path and file name of minified file)
 - `cssCompiledOutput`: Where to place compiled CSS files. This folder will be made public by default.
   - Default: `.build/css`
 - `jsPath`: Subdirectory within `staticsRoot` where your JS files are located. By default this folder will not be made public, but is instead meant to store unminified JS source files which will be minified and stored elsewhere when the app is started.
@@ -360,7 +363,7 @@ Statics parameters
   - Also by default the module [roosevelt-uglify](https://github.com/rooseveltframework/roosevelt-uglify) is marked as a dependency in package.json.
   - Note: Set `showWarnings` to `true` to display compiler warnings.
 - `jsCompilerWhitelist`: Whitelist of JS files to compile as an array. Leave undefined to compile all files. Supply a `:` character after each file name to delimit an alternate file path and/or file name for the minified file.
-  - Default: `undefined`
+  - Default: `null`
   - Example: `library-name/example.js:lib/example.min.js` (customizes both file path and file name of minified file)
 - `jsCompiledOutput`: Where to place compiled JS files. This folder will be made public by default.
   - Default: `.build/js`

--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -9,7 +9,6 @@ const klawSync = require('klaw-sync')
 const prequire = require('parent-require')
 const fileExists = require('./fileExists')
 const getFunctionArgs = require('./getFunctionArgs')
-const util = require('util')
 
 module.exports = function (app, callback) {
   const params = app.get('params')
@@ -26,19 +25,6 @@ module.exports = function (app, callback) {
   if (params.jsCompiler === 'none') {
     callback()
     return
-  }
-
-  // check if using whitelist before populating jsFiles
-  if (usingWhitelist) {
-    if (typeof params.jsCompilerWhitelist !== 'object') {
-      console.error('❌  jsCompilerWhitelist not configured correctly. Please ensure that it is an array. See https://github.com/rooseveltframework/roosevelt#statics-parameters for configuration instructions'.red)
-      callback()
-      return
-    } else {
-      jsFiles = params.jsCompilerWhitelist
-    }
-  } else {
-    jsFiles = klawSync(jsPath)
   }
 
   // require preprocessor
@@ -64,6 +50,27 @@ module.exports = function (app, callback) {
     process.exit()
   }
 
+  // make js directory if not present
+  if (!fileExists(jsPath)) {
+    fse.mkdirsSync(jsPath)
+    if (!app.get('params').suppressLogs.rooseveltLogs) {
+      console.log(`📁  ${appName} making new directory ${jsPath}`.yellow)
+    }
+  }
+
+  // check if using whitelist before populating jsFiles
+  if (usingWhitelist) {
+    if (typeof params.jsCompilerWhitelist !== 'object') {
+      console.error('❌  jsCompilerWhitelist not configured correctly. Please ensure that it is an array. See https://github.com/rooseveltframework/roosevelt#statics-parameters for configuration instructions'.red)
+      callback()
+      return
+    } else {
+      jsFiles = params.jsCompilerWhitelist
+    }
+  } else {
+    jsFiles = klawSync(jsPath)
+  }
+
   // make js compiled output directory if not present
   if (params.jsCompiler && params.jsCompiler.nodeModule && !fileExists(jsCompiledOutput)) {
     fse.mkdirsSync(jsCompiledOutput)
@@ -73,60 +80,60 @@ module.exports = function (app, callback) {
   }
 
   jsFiles.forEach(function (file) {
-    file = file.path ? file.path : file
+    file = file.path || file
     promises.push(function (file) {
       return new Promise(function (resolve, reject) {
         let split
         let altdest
         let newFile
-        let newJs
+        let newJS
 
-        if (usingWhitelist === true) {
+        // parse whitelist and determine files exist
+        if (usingWhitelist) {
           split = file.split(':')
           altdest = split[1]
           file = split[0]
-        }
 
-        // when using whitelist determine the file exists first
-        if (usingWhitelist) {
           if (!fileExists(path.join(jsPath, file))) {
             reject(new Error(`${file} specified in jsCompilerWhitelist does not exist. Please ensure file is entered properly.`))
           }
         }
 
-        if (file === '.' || file === '..' || file === 'Thumbs.db' || fs.lstatSync(usingWhitelist === true ? path.join(jsPath, file) : file).isDirectory()) {
+        if (file.charAt(0) === '.' || file === 'Thumbs.db' || fs.lstatSync(usingWhitelist ? path.join(jsPath, file) : file).isDirectory()) {
           resolve()
-          return
         }
+
         file = file.replace(jsPath, '')
         newFile = path.join(jsCompiledOutput, (altdest || file))
 
         // disable minify if noMinify param is present in roosevelt
         if (app.get('params').noMinify) {
-          fs.createReadStream(path.join(jsPath, file)).pipe(fs.createWriteStream(newFile))
-          newJs = fs.readFileSync(path.join(jsPath, file), 'utf-8')
+          newJS = fs.readFileSync(path.join(jsPath, file), 'utf-8')
         } else {
           // compress the js via the compiler set in roosevelt params
           try {
-            newJs = preprocessorModule.parse(app, file)
-          } catch (e) {
-            reject(new Error(`${appName} failed to parse ${file}. Please ensure that it is coded correctly\n ${util.inspect(e)}`))
+            newJS = preprocessorModule.parse(app, file)
+          } catch (err) {
+            reject(new Error(`${appName} failed to parse ${file}. Please ensure that it is coded correctly\n` + err))
           }
         }
 
-        // create build directory and write js file
+        // create build directory
         fse.mkdirsSync(path.dirname(newFile))
-        fs.openSync(newFile, 'a') // create it if it does not already exist
-        if (fs.readFileSync(newFile, 'utf8') !== newJs) {
-          fs.writeFile(newFile, newJs, function (err) {
+
+        // create file if it doesn't exist
+        fs.openSync(newFile, 'a')
+
+        // check existing file for matching content before writing
+        if (fs.readFileSync(newFile, 'utf8') !== newJS) {
+          fs.writeFile(newFile, newJS, (err) => {
             if (err) {
               reject(new Error(`${appName} failed to write new JS file ${newFile}\n ${err}`))
-            } else {
-              if (!app.get('params').suppressLogs.rooseveltLogs) {
-                console.log(`📝  ${appName} writing new JS file ${newFile}`.green)
-              }
-              resolve()
             }
+            if (!app.get('params').suppressLogs.rooseveltLogs) {
+              console.log(`📝  ${appName} writing new JS file ${newFile}`.green)
+            }
+            resolve()
           })
         } else {
           resolve()
@@ -136,11 +143,11 @@ module.exports = function (app, callback) {
   })
 
   Promise.all(promises)
-    .then(function () {
+    .then(() => {
       callback()
     })
-    .catch(function (e) {
-      console.error(`❌  ${util.inspect(e)}`.red)
+    .catch((err) => {
+      console.error('❌ ', `${err}`.red)
       process.exit()
     })
 }

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -3,26 +3,29 @@
 require('colors')
 
 const fs = require('fs')
+const path = require('path')
 const fse = require('fs-extra')
 const klawSync = require('klaw-sync')
 const prequire = require('parent-require')
-const path = require('path')
 const fileExists = require('./fileExists')
+const getFunctionArgs = require('./getFunctionArgs')
 
 module.exports = function (app, callback) {
   const params = app.get('params')
   const appName = app.get('appName')
+  const preprocessor = params.cssCompiler.nodeModule
   const cssPath = app.get('cssPath')
   const cssCompiledOutput = app.get('cssCompiledOutput')
-  const preprocessor = params.cssCompiler.nodeModule
+  const usingWhitelist = !!params.cssCompilerWhitelist
+  let cssFiles
   let preprocessorModule
-  let cssFiles = []
-  let cssDirectories = []
+  let preprocessorArgs
   let versionFile
   let versionCode = '/* do not edit; generated automatically by Roosevelt */ '
   let promises = []
 
   if (params.cssCompiler === 'none') {
+    callback()
     return
   }
 
@@ -32,26 +35,42 @@ module.exports = function (app, callback) {
   } catch (err) {
     console.error(`❌  ${appName} failed to include your CSS preprocessor! Please ensure that it is declared properly in your package.json and that it has been properly insalled to node_modules.`.red)
     console.error(err)
+    callback()
+    return
   }
 
-  // get css files to compile
-  if (params.cssCompilerWhitelist) {
-    cssFiles = params.cssCompilerWhitelist
+  // examine API of preprocessor to ensure compatibility
+  if (typeof preprocessorModule.parse === 'function') {
+    preprocessorArgs = getFunctionArgs(preprocessorModule.parse)
+
+    if ((preprocessorArgs.length !== 2) || (preprocessorArgs[0] !== 'app') || (preprocessorArgs[1] !== 'fileName')) {
+      console.error(`❌  selected CSS compiler module ${preprocessor} out of date or incompatible with this version of Roosevelt.`.red.bold)
+      process.exit()
+    }
+  } else {
+    console.error(`❌  selected CSS compiler module ${preprocessor} out of date or incompatible with this version of Roosevelt.`.red.bold)
+    process.exit()
+  }
+
+  // make css directory if not present
+  if (!fileExists(cssPath)) {
+    fse.mkdirsSync(cssPath)
+    if (!app.get('params').suppressLogs.rooseveltLogs) {
+      console.log(`📁  ${appName} making new directory ${cssPath}`.yellow)
+    }
+  }
+
+  // check if using whitelist before populating cssFiles
+  if (usingWhitelist) {
+    if (typeof params.cssCompilerWhitelist !== 'object') {
+      console.error('❌  cssCompilerWhitelist not configured correctly. Please ensure that it is an array. See https://github.com/rooseveltframework/roosevelt#statics-parameters for configuration instructions'.red)
+      callback()
+      return
+    } else {
+      cssFiles = params.cssCompilerWhitelist
+    }
   } else {
     cssFiles = klawSync(cssPath)
-
-    cssDirectories = cssFiles.filter(function (arrayElement) {
-      arrayElement = arrayElement.path
-      if (fs.statSync(arrayElement).isDirectory()) {
-        return arrayElement
-      }
-    })
-    cssFiles = cssFiles.filter(function (arrayElement) {
-      arrayElement = arrayElement.path
-      if (fs.statSync(arrayElement).isFile()) {
-        return arrayElement
-      }
-    })
   }
 
   // make css directory if not present
@@ -96,32 +115,46 @@ module.exports = function (app, callback) {
     }
   }
 
-  // make css compiled output subdirectory tree
-  cssDirectories.forEach(function (directory) {
-    fse.mkdirsSync(path.join(cssCompiledOutput, directory))
-  })
-
   cssFiles.forEach(function (file) {
-    file = file.path ? file.path : file
-    file = path.basename(file)
+    file = file.path || file
     promises.push(function (file) {
-      return new Promise(function (resolve, reject) {
-        if (file.charAt(0) === '.' || file === 'Thumbs.db') {
+      return new Promise((resolve, reject) => {
+        let split
+        let altdest
+
+        // parse whitelist and determine files exist
+        if (usingWhitelist) {
+          split = file.split(':')
+          altdest = split[1]
+          file = split[0]
+
+          if (!fileExists(path.join(cssPath, file))) {
+            reject(new Error(`${file} specified in cssCompilerWhitelist does not exist. Please ensure file is entered properly.`))
+          }
+        }
+
+        if (file.charAt(0) === '.' || file === 'Thumbs.db' || fs.lstatSync(usingWhitelist ? path.join(cssPath, file) : file).isDirectory()) {
           resolve()
           return
         }
-        preprocessorModule.parse(app, file, function (err, newFile, newCss) {
-          if (err) {
-            console.error(`❌  ${appName} failed to parse ${file}. Please ensure that it is coded correctly.`.red)
-            console.error(err)
-            resolve()
-          } else {
-            fs.openSync(newFile, 'a') // create it if it does not already exist
-            if (fs.readFileSync(newFile, 'utf8') !== newCss) {
-              fs.writeFile(newFile, newCss, function (err) {
+
+        file = file.replace(cssPath, '')
+
+        preprocessorModule.parse(app, file)
+          .then(([newFile, newCSS]) => {
+            newFile = path.join(cssCompiledOutput, (altdest || newFile))
+
+            // create build directory
+            fse.mkdirsSync(path.dirname(newFile))
+
+            // create file if it doesn't exist
+            fs.openSync(newFile, 'a')
+
+            // check existing file for matching content before writing
+            if (fs.readFileSync(newFile, 'utf8') !== newCSS) {
+              fs.writeFile(newFile, newCSS, function (err) {
                 if (err) {
-                  console.error(`❌  ${appName} failed to write new CSS file ${newFile}`.red)
-                  console.error(err)
+                  reject(new Error(`${appName} failed to write new CSS file ${newFile}` + err))
                 } else {
                   if (!app.get('params').suppressLogs.rooseveltLogs) {
                     console.log(`📝  ${appName} writing new CSS file ${newFile}`.green)
@@ -132,13 +165,20 @@ module.exports = function (app, callback) {
             } else {
               resolve()
             }
-          }
-        })
+          })
+          .catch((err) => {
+            reject(new Error(`${appName} failed to parse ${file}. Please ensure that it is coded correctly.\n` + err))
+          })
       })
     }(file))
   })
 
-  Promise.all(promises).then(function () {
-    callback()
-  })
+  Promise.all(promises)
+    .then(() => {
+      callback()
+    })
+    .catch((err) => {
+      console.error('❌ ', `${err}`.red)
+      process.exit()
+    })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "roosevelt",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -87,7 +87,7 @@
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.0"
+        "color-convert": "1.9.1"
       }
     },
     "app-module-path": {
@@ -167,9 +167,9 @@
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "asn1.js": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
       "requires": {
         "bn.js": "4.11.8",
         "inherits": "2.0.3",
@@ -363,7 +363,7 @@
         "concat-stream": "1.5.2",
         "console-browserify": "1.1.0",
         "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.11.1",
+        "crypto-browserify": "3.12.0",
         "defined": "1.0.0",
         "deps-sort": "2.0.0",
         "domain-browser": "1.1.7",
@@ -400,26 +400,6 @@
         "util": "0.10.3",
         "vm-browserify": "0.0.4",
         "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "browserify-zlib": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-          "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-          "requires": {
-            "pako": "1.0.6"
-          }
-        },
-        "os-browserify": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-          "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
-        },
-        "pako": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-          "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
-        }
       }
     },
     "browserify-aes": {
@@ -476,6 +456,14 @@
         "elliptic": "6.4.0",
         "inherits": "2.0.3",
         "parse-asn1": "5.1.0"
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "requires": {
+        "pako": "1.0.6"
       }
     },
     "buffer": {
@@ -625,9 +613,9 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -664,12 +652,9 @@
       }
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "requires": {
-        "graceful-readlink": "1.0.1"
-      }
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "compressible": {
       "version": "2.0.12",
@@ -855,9 +840,9 @@
       }
     },
     "crypto-browserify": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
-      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
         "browserify-cipher": "1.0.0",
         "browserify-sign": "4.0.4",
@@ -868,7 +853,8 @@
         "inherits": "2.0.3",
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.5",
+        "randomfill": "1.0.3"
       }
     },
     "d": {
@@ -1224,7 +1210,7 @@
         "debug": "2.6.9",
         "doctrine": "2.0.0",
         "escope": "3.6.0",
-        "espree": "3.5.1",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -1405,19 +1391,19 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-          "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
           "dev": true
         }
       }
@@ -1510,12 +1496,13 @@
       "dev": true
     },
     "express": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.5.tgz",
-      "integrity": "sha1-ZwI1ypWYiQpa6BcLg9tyK4Qu2Sc=",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
         "cookie": "0.3.1",
@@ -1525,29 +1512,30 @@
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.0.6",
+        "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.15.6",
-        "serve-static": "1.12.6",
-        "setprototypeof": "1.0.3",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
+        "utils-merge": "1.0.1",
         "vary": "1.1.2"
       },
       "dependencies": {
-        "qs": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
         "statuses": {
           "version": "1.3.1",
@@ -1557,11 +1545,11 @@
       }
     },
     "express-minify-html": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/express-minify-html/-/express-minify-html-0.11.4.tgz",
-      "integrity": "sha1-YpXtvbyGfAznGtL3BKnSmGf7Lz4=",
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/express-minify-html/-/express-minify-html-0.11.5.tgz",
+      "integrity": "sha512-Vw0WmdaRMc8TjS18jkwVu6YePrVhUvkG0JJSAdDMDzQ8o+iXXiUYAk2n9sA8YNrikd8ub5Fxv6y0TAkxn12wAA==",
       "requires": {
-        "html-minifier": "3.5.2",
+        "html-minifier": "3.5.6",
         "lodash.merge": "4.6.0"
       }
     },
@@ -1602,9 +1590,9 @@
       }
     },
     "finalhandler": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
-      "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "1.0.1",
@@ -1792,11 +1780,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-    },
     "har-schema": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
@@ -1891,18 +1874,18 @@
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "html-minifier": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.2.tgz",
-      "integrity": "sha1-1zvD/0SJQkCIGM5gm/P7DqfvTrc=",
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.6.tgz",
+      "integrity": "sha512-88FjtKrlak2XjczhxrBomgzV4jmGzM3UnHRBScRkJcmcRum0kb+IwhVAETJ8AVp7j0p3xugjSaw9L+RmI5/QOA==",
       "requires": {
         "camel-case": "3.0.0",
         "clean-css": "4.1.9",
-        "commander": "2.9.0",
+        "commander": "2.11.0",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.0.28"
+        "uglify-js": "3.1.9"
       }
     },
     "html-validator": {
@@ -2090,9 +2073,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -2446,14 +2429,6 @@
         "p-map": "1.2.0",
         "staged-git-files": "0.0.4",
         "stringify-object": "3.2.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-          "dev": true
-        }
       }
     },
     "listr": {
@@ -2761,9 +2736,9 @@
       }
     },
     "mime": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
       "version": "1.30.0",
@@ -2920,7 +2895,7 @@
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
       "dev": true,
       "requires": {
-        "commander": "2.9.0",
+        "commander": "2.11.0",
         "npm-path": "2.0.3",
         "which": "1.3.0"
       }
@@ -3039,6 +3014,11 @@
         }
       }
     },
+    "os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -3072,6 +3052,11 @@
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
+    "pako": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+    },
     "param-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
@@ -3098,7 +3083,7 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "requires": {
-        "asn1.js": "4.9.1",
+        "asn1.js": "4.9.2",
         "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
@@ -3292,12 +3277,12 @@
       "dev": true
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.4.0"
+        "ipaddr.js": "1.5.2"
       }
     },
     "pseudomap": {
@@ -3343,6 +3328,15 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "requires": {
+        "randombytes": "2.0.5",
         "safe-buffer": "5.1.1"
       }
     },
@@ -3553,9 +3547,9 @@
       "dev": true
     },
     "send": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
-      "integrity": "sha1-IPI6nJJbdiq4JwX+L52yUqzkfjQ=",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "requires": {
         "debug": "2.6.9",
         "depd": "1.1.1",
@@ -3565,7 +3559,7 @@
         "etag": "1.8.1",
         "fresh": "0.5.2",
         "http-errors": "1.6.2",
-        "mime": "1.3.4",
+        "mime": "1.4.1",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
@@ -3592,14 +3586,14 @@
       }
     },
     "serve-static": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",
-      "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.15.6"
+        "send": "0.16.1"
       }
     },
     "setprototypeof": {
@@ -4070,18 +4064,18 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.28.tgz",
-      "integrity": "sha512-0h/qGay016GG2lVav3Kz174F3T2Vjlz2v6HCt+WDQpoXfco0hWwF5gHK9yh88mUYvIC+N7Z8NT8WpjSp1yoqGA==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.9.tgz",
+      "integrity": "sha512-ari2E89bD7f+fMU173NgF12JBcOhgoxeyuCs97h5K58IBENrnG9eVj2lFadrOPdqf0KifsxVmUQfzA2cHNxCZQ==",
       "requires": {
         "commander": "2.11.0",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -4157,9 +4151,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.1.0",


### PR DESCRIPTION
This PR refactors the cssPreprocessor in similar style to the recent refactor of the jsCompiler. In an effort to keep these libraries consistent some consistency tweaks were also made to the jsCompiler as well. This also fixes app crashes when `cssCompiler` is set to `"none"`.

As a companion to this PR, `roosevelt-less` is also overhauled here: https://github.com/rooseveltframework/roosevelt-less/pull/22