### PR TITLE
WIP: Process to kill detached validator after set time

### DIFF
--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -20,6 +20,7 @@ module.exports = function (app, callback) {
   const errorPage = path.join(__dirname, '/../defaultErrorPages/views/validatorErrors')
   const logger = require('./logger')(app)
   let params = app.get('params')
+  let killValidatorTimer
   let validatorProcess
   let validatorShutdown
   let headerException = params.validatorExceptions.requestHeader
@@ -128,6 +129,9 @@ module.exports = function (app, callback) {
         validatorProcess = spawn(
           'java', ['-Xss1024k', '-cp', vnu, 'nu.validator.servlet.Main', params.htmlValidator.port ? params.htmlValidator.port : '8888'], { detached: params.htmlValidator.separateProcess }
         )
+        if (params.htmlValidator.separateProcess === true) {
+          spawnKillValidatorTimer()
+        }
         logger.log('⌛', 'Starting HTML validator...'.bold.yellow)
 
         validatorProcess.stderr.on('data', (data) => {
@@ -212,6 +216,15 @@ module.exports = function (app, callback) {
       clearTimeout(validatorTimeout)
       logger.error(`${error}`.red)
       callback()
+    })
+  }
+  function spawnKillValidatorTimer () {
+    killValidatorTimer = spawn('node', ['./node_modules/roosevelt/lib/killValidatorTimer.js'])
+
+    killValidatorTimer.stderr.on('data', (data) => {
+      if (`${data}`.includes('TIMEOUT!')) {
+        console.log('timeout complete')
+      }
     })
   }
 

--- a/lib/killValidatorTimer.js
+++ b/lib/killValidatorTimer.js
@@ -1,0 +1,5 @@
+let timeout = 15000
+
+setTimeout(function () {
+  console.log('TIMEOUT!')
+}, timeout)


### PR DESCRIPTION
The goal of this change is in the case that a developer kills their roosevelt app but forgets to run the command to kill the validator (`npm run kill-validator`), a background process will kill it for them.

With this change, upon starting a detached validator, a background process is spawned which:

- Begins a timer
- Once time expires, background process kills the validator, then exits itself.

The time is reset in dev mode only by:
- start/restart of any roosevelt server
- Roosevelt apps set an interval to refresh timer process so validator will not get killed accidentally
