### PR TITLE
WIP: Overhaul Roosevelt params

### DIFF
--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -1,361 +1,72 @@
 {
-  "port": {
-    "name": "port",
-    "optional": false,
-    "value": 43711
-  },
-
-  "appDir": {
-    "name": "appDir",
-    "optional": true,
-    "value": null
-  },
-
-  "localhostOnly": {
-    "name": "localhostOnly",
-    "optional": false,
-    "value": true
-  },
-
+  "port": 43711,
+  "generateFolderStructure": true,
+  "localhostOnly": true,
   "suppressLogs": {
-    "name": "suppressLogs",
-    "optional": false,
-    "value": {
-      "httpLogs": {
-        "name": "httpLogs",
-        "parent": "suppressLogs",
-        "optional": false,
-        "value": false
-      },
-      "rooseveltLogs": {
-        "name": "rooseveltLogs",
-        "parent": "suppressLogs",
-        "optional": false,
-        "value": false
-      },
-      "rooseveltWarnings": {
-        "name": "rooseveltWarnings",
-        "parent": "suppressLogs",
-        "optional": false,
-        "value": false
-      }
-    }
+    "httpLogs": false,
+    "rooseveltLogs": false,
+    "rooseveltWarnings": false
   },
-
-  "noMinify": {
-    "name": "noMinify",
-    "optional": false,
-    "value": false
-  },
-
-  "enableValidator": {
-    "name": "enableValidator",
-    "optional": false,
-    "value": false
-  },
-
-  "validatorExceptions": {
-    "name": "validatorExceptions",
-    "optional": false,
-    "value": {
-      "requestHeader": {
-        "name": "requestHeader",
-        "parent": "validatorExceptions",
-        "optional": false,
-        "value": "Partial"
-      },
-      "modelValue": {
-        "name": "modelValue",
-        "parent": "validatorExceptions",
-        "optional": false,
-        "value": "_disableValidator"
-      }
-    }
-  },
-
+  "noMinify": false,
   "htmlValidator": {
-    "name": "htmlValidator",
-    "optional": false,
-    "value": {
-      "port": {
-        "name": "port",
-        "parent": "htmlValidator",
-        "optional": false,
-        "value": 8888
-      },
-
-      "separateProcess": {
-        "name": "separateProcess",
-        "parent": "htmlValidator",
-        "optional": false,
-        "value": false
-      },
-
-      "format": {
-        "name": "format",
-        "parent": "htmlValidator",
-        "optional": false,
-        "value": "text"
-      },
-
-      "suppressWarnings": {
-        "name": "suppressWarnings",
-        "parent": "htmlValidator",
-        "optional": false,
-        "value": false
-      }
+    "enabled": false,
+    "separateProcess": true,
+    "port": 8888,
+    "suppressWarnings": false,
+    "exceptions": {
+      "requestHeader": "Partial",
+      "modelValue": "_disableValidator"
     }
   },
-
   "multipart": {
-    "name": "multipart",
-    "optional": false,
-    "value": {
-      "multiples": {
-        "name": "multiples",
-        "parent": "multipart",
-        "optional": false,
-        "value": true
-      }
-    }
+    "multiples": true
   },
-
-  "maxLagPerRequest": {
-    "name": "maxLagPerRequest",
-    "optional": false,
-    "value": 70
-  },
-
-  "shutdownTimeout": {
-    "name": "shutdownTimeout",
-    "optional": false,
-    "value": 30000
-  },
-
+  "maxLagPerRequest": 70,
+  "shutdownTimeout": 30000,
   "bodyParserUrlencodedParams": {
-    "name": "bodyParserUrlencodedParams",
-    "optional": false,
-    "value": {
-      "extended": {
-        "name": "extended",
-        "parent": "bodyParserUrlencodedParams",
-        "optional": false,
-        "value": true
-      }
-    }
+    "extended": true
   },
-
-  "bodyParserJsonParams": {
-    "name": "bodyParserJsonParams",
-    "optional": false,
-    "value": {}
-  },
-
-  "generateFolderStructure": {
-    "name": "generateFolderStructure",
-    "optional": false,
-    "audit": false,
-    "value": true
-  },
-
-  "https": {
-    "name": "https",
-    "optional": false,
-    "value": false
-  },
-
-  "modelsPath": {
-    "name": "modelsPath",
-    "optional": false,
-    "value": "mvc/models"
-  },
-
-  "viewsPath": {
-    "name": "viewsPath",
-    "optional": false,
-    "value": "mvc/views"
-  },
-
-  "viewEngine": {
-    "name": "viewEngine",
-    "optional": false,
-    "value": "none"
-  },
-
-  "controllersPath": {
-    "name": "controllersPath",
-    "optional": false,
-    "value": "mvc/controllers"
-  },
-
-  "error404": {
-    "name": "error404",
-    "optional": false,
-    "value": "404.js"
-  },
-
-  "error5xx": {
-    "name": "error5xx",
-    "optional": false,
-    "value": "5xx.js"
-  },
-
-  "error503": {
-    "name": "error503",
-    "optional": false,
-    "value": "503.js"
-  },
-
-  "staticsRoot": {
-    "name": "staticsRoot",
-    "optional": false,
-    "value": "statics"
-  },
-
+  "bodyParserJsonParams": {},
+  "https": false,
+  "modelsPath": "mvc/models",
+  "viewsPath": "mvc/views",
+  "controllersPath": "mvc/controllers",
+  "viewEngine": "none",
+  "error404": "404.js",
+  "error5xx": "5xx.js",
+  "error503": "503.js",
+  "staticsRoot": "statics",
   "htmlMinify": {
-    "name": "htmlMinify",
-    "optional": false,
-    "value": {
-      "override": {
-        "name": "override",
-        "parent": "htmlMinify",
-        "optional": false,
-        "value": true
-      },
-
-      "exception_url": {
-        "name": "exception_url",
-        "parent": "htmlMinify",
-        "optional": false,
-        "value": false
-      },
-
-      "htmlMinifier": {
-        "name": "htmlMinifier",
-        "parent": "htmlMinify",
-        "optional": true,
-        "value": {
-          "html5": true
-        }
-      }
+    "override": true,
+    "exception_url": false,
+    "htmlMinifier": {}
+  },
+  "css": {
+    "sourceDir": "css",
+    "compiler": "none",
+    "whitelist": null,
+    "output": ".build/css"
+  },
+  "js": {
+    "sourceDir": "js",
+    "compiler": "none",
+    "whitelist": null,
+    "blacklist": null,
+    "output": ".build/js",
+    "bundler": {
+      "bundles": [],
+      "output": ".bundled",
+      "expose": true
     }
   },
-
-  "cssPath": {
-    "name": "cssPath",
-    "optional": false,
-    "value": "css"
-  },
-
-  "cssCompiler": {
-    "name": "cssCompiler",
-    "optional": false,
-    "value": "none"
-  },
-
-  "cssCompilerWhitelist": {
-    "name": "cssCompilerWhitelist",
-    "optional": false,
-    "value": null
-  },
-
-  "cssCompiledOutput": {
-    "name": "cssCompiledOutput",
-    "optional": false,
-    "value": ".build/css"
-  },
-
-  "jsPath": {
-    "name": "jsPath",
-    "optional": false,
-    "value": "js"
-  },
-
-  "browserifyBundles": {
-    "name": "browserifyBundles",
-    "optional": false,
-    "value": []
-  },
-
-  "bundledJsPath": {
-    "name": "bundledJsPath",
-    "optional": false,
-    "value": ".bundled"
-  },
-
-  "exposeBundles": {
-    "name": "exposeBundles",
-    "optional": false,
-    "value": true
-  },
-
-  "jsCompiler": {
-    "name": "jsCompiler",
-    "optional": false,
-    "value": "none"
-  },
-
-  "jsCompilerWhitelist": {
-    "name": "jsCompilerWhitelist",
-    "optional": false,
-    "value": null
-  },
-
-  "jsCompilerBlacklist": {
-    "name": "jsCompilerBlacklist",
-    "optional": false,
-    "value": null
-  },
-
-  "jsCompiledOutput": {
-    "name": "jsCompiledOutput",
-    "optional": false,
-    "value": ".build/js"
-  },
-
-  "nodeEnv": {
-    "name": "nodeEnv",
-    "optional": true,
-    "value": null
-  },
-
-  "publicFolder": {
-    "name": "publicFolder",
-    "optional": false,
-    "value": "public"
-  },
-
-  "favicon": {
-    "name": "favicon",
-    "optional": false,
-    "value": "none"
-  },
-
-  "symlinksToStatics": {
-    "name": "symlinksToStatics",
-    "optional": false,
-    "value": [
-      "css: .build/css",
-      "images",
-      "js: .build/js"
-    ]
-  },
-
-  "versionedStatics": {
-    "name": "versionedStatics",
-    "optional": false,
-    "value": false
-  },
-
-  "versionedCssFile": {
-    "name": "versionedCssFile",
-    "optional": false,
-    "value": null
-  },
-
-  "alwaysHostPublic": {
-    "name": "alwaysHostPublic",
-    "optional": false,
-    "value": false
-  }
+  "publicFolder": "public",
+  "favicon": "none",
+  "staticsSymlinksToPublic": [
+    "images",
+    "css: .build/css",
+    "js: .build/js"
+  ],
+  "versionedPublic": false,
+  "versionedCSSFile": null,
+  "alwaysHostPublic": false
 }

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -21,7 +21,10 @@
   "multipart": {
     "multiples": true
   },
-  "maxLagPerRequest": 70,
+  "toobusy": {
+    "maxLagPerRequest": 70,
+    "lagCheckInterval": 500
+  },
   "shutdownTimeout": 30000,
   "bodyParserUrlencodedParams": {
     "extended": true

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -10,7 +10,7 @@
   "noMinify": false,
   "htmlValidator": {
     "enabled": false,
-    "separateProcess": true,
+    "separateProcess": false,
     "port": 8888,
     "suppressWarnings": false,
     "exceptions": {

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -45,7 +45,8 @@
     "sourceDir": "css",
     "compiler": "none",
     "whitelist": null,
-    "output": ".build/css"
+    "output": ".build/css",
+    "versionFile": null
   },
   "js": {
     "sourceDir": "js",
@@ -67,6 +68,5 @@
     "js: .build/js"
   ],
   "versionedPublic": false,
-  "versionedCSSFile": null,
   "alwaysHostPublic": false
 }

--- a/lib/defaults/scripts.json
+++ b/lib/defaults/scripts.json
@@ -36,7 +36,7 @@
     "value": "npm run kill-validator",
     "priority": "ignore"
   },
-  "cleanup": {
+  "clean": {
     "value": "node ./node_modules/roosevelt/lib/scripts/appCleanup.js",
     "priority": "error",
     "inspect": true

--- a/lib/defaults/scripts.json
+++ b/lib/defaults/scripts.json
@@ -1,46 +1,85 @@
 {
   "start": {
-    "value": "npm run prod",
+    "value": "npm run production",
     "priority": "error"
   },
-  "kill-validator": {
-    "value": "node ./node_modules/roosevelt/lib/killValidator.js",
+  "production": {
+    "value": "nodemon app.js --production-mode",
     "priority": "error"
   },
   "prod": {
-    "value": "nodemon app.js -prod",
+    "value": "npm run production",
+    "priority": "ignore"
+  },
+  "p": {
+    "value": "npm run production",
+    "priority": "ignore"
+  },
+  "development": {
+    "value": "nodemon app.js --development-mode",
     "priority": "error"
   },
   "dev": {
-    "value": "nodemon app.js -dev",
-    "priority": "error"
+    "value": "npm run development",
+    "priority": "ignore"
+  },
+  "d": {
+    "value": "npm run development",
+    "priority": "ignore"
+  },
+  "kill-validator": {
+    "value": "node ./node_modules/roosevelt/lib/scripts/killValidator.js",
+    "priority": "error",
+    "inspect": true
+  },
+  "kv": {
+    "value": "npm run kill-validator",
+    "priority": "ignore"
   },
   "cleanup": {
-    "value": "node ./node_modules/roosevelt/lib/appCleanup.js",
-    "priority": "error"
+    "value": "node ./node_modules/roosevelt/lib/scripts/appCleanup.js",
+    "priority": "error",
+    "inspect": true
+  },
+  "c": {
+    "value": "npm run cleanup",
+    "priority": "ignore"
   },
   "audit": {
-    "value": "node ./node_modules/roosevelt/lib/configAuditor.js",
-    "priority": "error"
+    "value": "node ./node_modules/roosevelt/lib/scripts/configAuditor.js",
+    "priority": "error",
+    "inspect": true
   },
-  "test": {
-    "value": "npm run lint",
-    "priority": "warning"
+  "a": {
+    "value": "npm run audit",
+    "priority": "ignore"
   },
-  "eslint": {
+  "standard": {
     "value": "standard",
     "priority": "ignore"
   },
   "stylelint": {
-    "value": "./node_modules/.bin/stylelint \"statics/css/**/*.less\" --syntax less",
+    "value": "stylelint \"statics/css/**/*.less\" --syntax less",
     "priority": "ignore"
   },
   "lint": {
-    "value": "npm run stylelint && npm run eslint",
+    "value": "npm run standard && npm run stylelint",
+    "priority": "ignore"
+  },
+  "l": {
+    "value": "npm run lint",
     "priority": "ignore"
   },
   "precommit": {
     "value": "lint-staged",
     "priority": "ignore"
+  },
+  "pc": {
+    "value": "lint-staged",
+    "priority": "ignore"
+  },
+  "test": {
+    "value": "npm run lint",
+    "priority": "warning"
   }
 }

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -17,9 +17,8 @@ module.exports = function (app, callback) {
   let params = app.get('params')
   let validatorProcess
   let validatorShutdown
-  let headerException = params.validatorExceptions.requestHeader
-  let modelException = params.validatorExceptions.modelValue
-  let options
+  let headerException = params.htmlValidator.exceptions.requestHeader
+  let modelException = params.htmlValidator.exceptions.modelValue
   let i
   let isError = false
   let calledKill = false
@@ -32,20 +31,14 @@ module.exports = function (app, callback) {
     }
   }
 
-  if (!params.enableValidator) {
+  if (!params.htmlValidator.enable) {
     if (app.get('env') !== 'production') {
       logger.warn('HTML validator disabled. Continuing without HTML validation...'.yellow)
     }
     callback()
   } else {
-    params.htmlValidator.validator = 'http://localhost:' + params.htmlValidator.port
     validatorOptions.port = params.htmlValidator.port
-    options = params.htmlValidator
-
-    // only run validator if in dev mode
-    if (process.env.NODE_ENV === 'development') {
-      callValidator()
-    }
+    callValidator()
   }
 
   function callValidator () {
@@ -53,9 +46,8 @@ module.exports = function (app, callback) {
       isError = false
 
       // see if there's one already running
-      http.get(validatorOptions, function (res) {
+      http.get(validatorOptions, (res) => {
         const { statusCode } = res
-
         let error
         let rawData = ''
         if (statusCode !== 200) {
@@ -127,7 +119,7 @@ module.exports = function (app, callback) {
                 }
               })
 
-              validatorShutdown.on('exit', function () {
+              validatorShutdown.on('exit', () => {
                 // signal validator to restart
                 resolve('Restart')
               })
@@ -143,7 +135,7 @@ module.exports = function (app, callback) {
             }
           }
           if (`${data}`.includes('INFO:oejs.Server:main: Started')) {
-            setTimeout(function () {
+            setTimeout(() => {
               if (isError === false) {
                 clearTimeout(validatorTimeout)
                 if (params.htmlValidator.separateProcess) {
@@ -166,7 +158,7 @@ module.exports = function (app, callback) {
           }
         })
 
-        validatorTimeout = setTimeout(function () {
+        validatorTimeout = setTimeout(() => {
           reject(new Error('HTML validator has timed out.'))
         }, 30000)
       }
@@ -199,6 +191,10 @@ module.exports = function (app, callback) {
     }
 
     app.use(tamper((req, res) => {
+      let options = {
+        format: 'text',
+        validator: `http://localhost:${params.htmlValidator.port}`
+      }
       let detectErrors
       let errorList
       let warnings
@@ -261,7 +257,7 @@ module.exports = function (app, callback) {
                 errorList += '</pre>'
                 warningList += '</pre>'
 
-                if (!options.suppressWarnings || !warnings) {
+                if (!params.htmlValidator.suppressWarnings || !warnings) {
                   warningList = undefined
                 }
 

--- a/lib/jsBundler.js
+++ b/lib/jsBundler.js
@@ -10,7 +10,7 @@ module.exports = function (app, callback) {
   const appDir = app.get('appDir')
   const appName = app.get('appName')
   const jsPath = app.get('jsPath')
-  const bundleBuildDir = path.join(app.get('jsCompiledOutput'), (params.bundledJsPath.replace(params.jsPath, '')))
+  const bundleBuildDir = path.join(app.get('jsCompiledOutput'), (params.js.bundler.output.replace(params.jsPath, '')))
   const logger = require('./tools/logger')(app)
   const fsr = require('./tools/fsr')(app)
   let bundleEnv
@@ -24,14 +24,14 @@ module.exports = function (app, callback) {
   }
 
   // make js bundled output directory if not present
-  if (params.browserifyBundles.length && !fsr.fileExists(params.bundledJsPath)) {
-    if (fsr.ensureDirSync(params.bundledJsPath)) {
-      logger.log('📁', `${appName} making new directory ${path.join(appDir, params.bundledJsPath)}`.yellow)
+  if (params.js.bundler.bundles.length && !fsr.fileExists(params.js.bundler.output)) {
+    if (fsr.ensureDirSync(params.js.bundler.output)) {
+      logger.log('📁', `${appName} making new directory ${path.join(appDir, params.js.bundler.output)}`.yellow)
     }
   }
 
   // make js bundled output directory in build directory if not present
-  if (params.browserifyBundles.length && params.exposeBundles && !fsr.fileExists(bundleBuildDir)) {
+  if (params.js.bundler.bundles.length && params.js.bundler.expose && !fsr.fileExists(bundleBuildDir)) {
     if (fsr.ensureDirSync(bundleBuildDir)) {
       logger.log('📁', `${appName} making new directory ${bundleBuildDir}`.yellow)
     }
@@ -44,10 +44,10 @@ module.exports = function (app, callback) {
     bundleEnv = 'prod'
   }
 
-  params.browserifyBundles.forEach(function (bundle) {
+  params.js.bundler.bundles.forEach((bundle) => {
     if (bundle.env === bundleEnv || !bundle.env) {
-      promises.push(function (bundle) {
-        return new Promise(function (resolve, reject) {
+      promises.push(
+        new Promise((resolve, reject) => {
           let i
 
           for (i in bundle.files) {
@@ -66,13 +66,13 @@ module.exports = function (app, callback) {
             ]
           }
 
-          browserify(bundle.files, bundle.params).bundle(function (err, jsCode) {
+          browserify(bundle.files, bundle.params).bundle((err, jsCode) => {
             if (err) {
-              logger.error(`${appName} failed to write new JS file ${path.join(appDir, params.bundledJsPath, bundle.outputFile)} due to syntax errors in the source JavaScript\n`.red, err)
-              throw err
+              logger.error(`${appName} failed to write new JS file ${path.join(appDir, params.js.bundler.output, bundle.outputFile)} due to syntax errors in the source JavaScript`.red)
+              reject(err)
             } else {
-              if (fsr.writeFileSync(path.join(appDir, params.bundledJsPath, bundle.outputFile), jsCode, 'utf8')) {
-                logger.log('📝', `${appName} writing new JS file ${path.join(appDir, params.bundledJsPath, bundle.outputFile)}`.green)
+              if (fsr.writeFileSync(path.join(appDir, params.js.bundler.output, bundle.outputFile), jsCode, 'utf8')) {
+                logger.log('📝', `${appName} writing new JS file ${path.join(appDir, params.js.bundler.output, bundle.outputFile)}`.green)
               }
               if (params.exposeBundles) {
                 if (fsr.writeFileSync(path.join(bundleBuildDir, bundle.outputFile), jsCode, 'utf8')) {
@@ -83,11 +83,16 @@ module.exports = function (app, callback) {
             resolve()
           })
         })
-      }(bundle))
+      )
     }
   })
 
-  Promise.all(promises).then(function () {
-    callback()
-  })
+  Promise.all(promises)
+    .then(() => {
+      callback()
+    })
+    .catch((err) => {
+      logger.error(`${err}`.red)
+      process.exit(1)
+    })
 }

--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -13,8 +13,8 @@ module.exports = function (app, callback) {
   const appName = app.get('appName')
   const jsPath = app.get('jsPath')
   const jsCompiledOutput = app.get('jsCompiledOutput')
-  const usingWhitelist = !!params.jsCompilerWhitelist
-  const blacklist = params.jsCompilerBlacklist || []
+  const usingWhitelist = !!params.js.whitelist
+  const blacklist = params.js.whitelist || []
   const logger = require('./tools/logger')(app)
   const fsr = require('./tools/fsr')(app)
   let preprocessor
@@ -23,12 +23,12 @@ module.exports = function (app, callback) {
   let preprocessorArgs
   let promises = []
 
-  if (params.jsCompiler === 'none' || params.jsCompiler === null) {
+  if (params.js.compiler === 'none' || params.js.compiler === null) {
     callback()
     return
   }
 
-  preprocessor = params.jsCompiler.nodeModule
+  preprocessor = params.js.compiler.nodeModule
 
   // require preprocessor
   try {
@@ -36,7 +36,7 @@ module.exports = function (app, callback) {
   } catch (err) {
     logger.error(`${appName} failed to include your JS compiler! Please ensure that it is declared properly in your package.json and that it has been properly installed to node_modules.`.red)
     logger.warn('JS compiler has been disabled'.yellow)
-    params.jsCompiler = 'none'
+    params.js.compiler = 'none'
     callback()
     return
   }
@@ -46,11 +46,11 @@ module.exports = function (app, callback) {
     preprocessorArgs = getFunctionArgs(preprocessorModule.parse)
 
     if ((preprocessorArgs.length !== 2) || (preprocessorArgs[0] !== 'app') || (preprocessorArgs[1] !== 'fileName')) {
-      logger.error(`Selected JavaScript compiler module ${preprocessor} out of date or incompatible with this version of Roosevelt.`.red.bold)
+      logger.error(`Selected JS compiler module ${preprocessor} out of date or incompatible with this version of Roosevelt.`.red.bold)
       process.exit(1)
     }
   } else {
-    logger.error(`Selected JavaScript compiler module ${preprocessor} out of date or incompatible with this version of Roosevelt.`.red.bold)
+    logger.error(`Selected JS compiler module ${preprocessor} out of date or incompatible with this version of Roosevelt.`.red.bold)
     process.exit(1)
   }
 
@@ -63,19 +63,19 @@ module.exports = function (app, callback) {
 
   // check if using whitelist before populating jsFiles
   if (usingWhitelist) {
-    if (typeof params.jsCompilerWhitelist !== 'object') {
-      logger.error('jsCompilerWhitelist not configured correctly. Please ensure that it is an array. See https://github.com/rooseveltframework/roosevelt#statics-parameters for configuration instructions'.red)
+    if (typeof params.js.whitelist !== 'object') {
+      logger.error('JS whitelist not configured correctly. Please ensure that it is an array. See https://github.com/rooseveltframework/roosevelt#statics-parameters for configuration instructions'.red)
       callback()
       return
     } else {
-      jsFiles = params.jsCompilerWhitelist
+      jsFiles = params.js.whitelist
     }
   } else {
     jsFiles = klawSync(jsPath)
   }
 
   // make js compiled output directory if not present
-  if (params.jsCompiler && params.jsCompiler.nodeModule && !fsr.fileExists(jsCompiledOutput)) {
+  if (!fsr.fileExists(jsCompiledOutput)) {
     if (fsr.ensureDirSync(jsCompiledOutput)) {
       logger.log('📁', `${appName} making new directory ${jsCompiledOutput}`.yellow)
     }
@@ -97,7 +97,7 @@ module.exports = function (app, callback) {
           file = split[0]
 
           if (!fsr.fileExists(path.join(jsPath, file))) {
-            reject(new Error(`${file} specified in jsCompilerWhitelist does not exist. Please ensure file is entered properly.`))
+            reject(new Error(`${file} specified in JS whitelist does not exist. Please ensure file is entered properly.`))
           }
         }
 

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -24,7 +24,7 @@ module.exports = function (app) {
   toobusy.maxLag(params.maxLagPerRequest)
 
   // serve 503 page if the process is too busy
-  app.use(function (req, res, next) {
+  app.use((req, res, next) => {
     if (toobusy()) {
       require(params.error503)(app, req, res)
     } else {
@@ -44,7 +44,7 @@ module.exports = function (app) {
 
   // bind user-defined middleware which fires after request ends if supplied
   if (params.onReqAfterRoute && typeof params.onReqAfterRoute === 'function') {
-    app.use(function (req, res, next) {
+    app.use((req, res, next) => {
       let afterEnd = function () {
         params.onReqAfterRoute(req, res)
       }
@@ -76,21 +76,21 @@ module.exports = function (app) {
   }
 
   // if js and/or css compilers are disabled, check that jsPath and cssPath are set to be symlinked
-  if (params.cssCompiler === 'none' || params.cssCompiler === null) {
-    basicCSSPath = params.cssPath.replace(params.staticsRoot, '').replace(/^[\\/]+/, '')
-    if (!(params.symlinksToStatics.includes(basicCSSPath))) {
-      params.symlinksToStatics.unshift(basicCSSPath)
+  if (params.css.compiler === 'none' || params.css.compiler === null) {
+    basicCSSPath = params.css.sourceDir.replace(params.staticsRoot, '').replace(/^[\\/]+/, '')
+    if (!(params.staticsSymlinksToPublic.includes(basicCSSPath))) {
+      params.staticsSymlinksToPublic.unshift(basicCSSPath)
     }
   }
-  if (params.jsCompiler === 'none' || params.jsCompiler === null) {
-    basicJSPath = params.jsPath.replace(params.staticsRoot, '').replace(/^[\\/]+/, '')
-    if (!(params.symlinksToStatics.includes(basicJSPath))) {
-      params.symlinksToStatics.unshift(basicJSPath)
+  if (params.js.compiler === 'none' || params.js.compiler === null) {
+    basicJSPath = params.js.sourceDir.replace(params.staticsRoot, '').replace(/^[\\/]+/, '')
+    if (!(params.staticsSymlinksToPublic.includes(basicJSPath))) {
+      params.staticsSymlinksToPublic.unshift(basicJSPath)
     }
   }
 
   // make symlinks to public statics
-  params.symlinksToStatics.forEach(function (pubStatic) {
+  params.staticsSymlinksToPublic.forEach((pubStatic) => {
     pubStatic = pubStatic.split(':')
     let staticTarget = path.join(appDir, params.staticsRoot, (pubStatic[1] || pubStatic[0]).trim())
     let linkTarget = path.join(publicDir, pubStatic[0].trim())
@@ -144,7 +144,7 @@ module.exports = function (app) {
     }
 
     // load all controllers
-    controllerFiles.forEach(function (controllerName) {
+    controllerFiles.forEach((controllerName) => {
       let controller
       controllerName = controllerName.path
 

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -21,7 +21,10 @@ module.exports = function (app) {
   let ec = 0
 
   // define maximum number of miliseconds to wait for a given request to finish
-  toobusy.maxLag(params.maxLagPerRequest)
+  toobusy.maxLag(params.toobusy.maxLagPerRequest)
+
+  // define interval in miliseconds to check for event loop lag
+  toobusy.interval(params.toobusy.lagCheckInterval)
 
   // serve 503 page if the process is too busy
   app.use((req, res, next) => {

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -82,14 +82,14 @@ module.exports = function (app, callback) {
     }
   }
 
-  // write versionedCSSFile
-  if (params.versionedCSSFile) {
-    if (!params.versionedCSSFile.fileName || typeof params.versionedCSSFile.fileName !== 'string') {
-      logger.error(`${appName} failed to write versionedCSSFile file! fileName missing or invalid`.red)
-    } else if (!params.versionedCSSFile.varName || typeof params.versionedCSSFile.varName !== 'string') {
-      logger.error(`${appName} failed to write versionedCSSFile file! varName missing or invalid'`.red)
+  // write versionFile
+  if (params.css.versionFile) {
+    if (!params.css.versionFile.fileName || typeof params.css.versionFile.fileName !== 'string') {
+      logger.error(`${appName} failed to write versioned CSS file! fileName missing or invalid`.red)
+    } else if (!params.css.versionFile.varName || typeof params.css.versionFile.varName !== 'string') {
+      logger.error(`${appName} failed to write versioned CSS file! varName missing or invalid'`.red)
     } else {
-      versionFile = path.join(cssPath, params.versionedCSSFile.fileName)
+      versionFile = path.join(cssPath, params.css.versionFile.fileName)
       versionCode += preprocessorModule.versionCode(app)
 
       // create it if it does not already exist
@@ -97,7 +97,7 @@ module.exports = function (app, callback) {
 
       if (fs.readFileSync(versionFile, 'utf8') !== versionCode) {
         if (fsr.writeFileSync(versionFile, versionCode)) {
-          logger.log('📝', `${appName} writing new versionedCssFile to reflect new version ${app.get('appVersion')} to ${versionFile}`.green)
+          logger.log('📝', `${appName} writing new versioned CSS file to reflect new version ${app.get('appVersion')} to ${versionFile}`.green)
         }
       }
     }

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -13,7 +13,7 @@ module.exports = function (app, callback) {
   const appName = app.get('appName')
   const cssPath = app.get('cssPath')
   const cssCompiledOutput = app.get('cssCompiledOutput')
-  const usingWhitelist = !!params.cssCompilerWhitelist
+  const usingWhitelist = !!params.css.whitelist
   const logger = require('./tools/logger')(app)
   const fsr = require('./tools/fsr')(app)
   let preprocessor
@@ -24,12 +24,12 @@ module.exports = function (app, callback) {
   let versionCode = '/* do not edit; generated automatically by Roosevelt */ '
   let promises = []
 
-  if (params.cssCompiler === 'none' || params.cssCompiler === null) {
+  if (params.css.compiler === 'none' || params.css.compiler === null) {
     callback()
     return
   }
 
-  preprocessor = params.cssCompiler.nodeModule
+  preprocessor = params.css.compiler.nodeModule
 
   // require preprocessor
   try {
@@ -37,7 +37,7 @@ module.exports = function (app, callback) {
   } catch (err) {
     logger.error(`${appName} failed to include your CSS preprocessor! Please ensure that it is declared properly in your package.json and that it has been properly installed to node_modules.`.red)
     logger.warn('CSS preprocessor has been disabled'.yellow)
-    params.cssCompiler = 'none'
+    params.css.compiler = 'none'
     callback()
     return
   }
@@ -64,32 +64,32 @@ module.exports = function (app, callback) {
 
   // check if using whitelist before populating cssFiles
   if (usingWhitelist) {
-    if (typeof params.cssCompilerWhitelist !== 'object') {
-      logger.error('cssCompilerWhitelist not configured correctly. Please ensure that it is an array. See https://github.com/rooseveltframework/roosevelt#statics-parameters for configuration instructions'.red)
+    if (typeof params.css.whitelist !== 'object') {
+      logger.error('CSS whitelist not configured correctly. Please ensure that it is an array. See https://github.com/rooseveltframework/roosevelt#statics-parameters for configuration instructions'.red)
       callback()
       return
     } else {
-      cssFiles = params.cssCompilerWhitelist
+      cssFiles = params.css.whitelist
     }
   } else {
     cssFiles = klawSync(cssPath)
   }
 
   // make css compiled output directory if not present
-  if (params.cssCompiler && params.cssCompiler.nodeModule && !fsr.fileExists(cssCompiledOutput)) {
+  if (!fsr.fileExists(cssCompiledOutput)) {
     if (fsr.ensureDirSync(cssCompiledOutput)) {
       logger.log('📁', `${appName} making new directory ${cssCompiledOutput}`.yellow)
     }
   }
 
-  // write versionedCssFile
-  if (params.versionedCssFile) {
-    if (!params.versionedCssFile.fileName || typeof params.versionedCssFile.fileName !== 'string') {
-      logger.error(`${appName} failed to write versionedCssFile file! fileName missing or invalid`.red)
-    } else if (!params.versionedCssFile.varName || typeof params.versionedCssFile.varName !== 'string') {
-      logger.error(`${appName} failed to write versionedCssFile file! varName missing or invalid'`.red)
+  // write versionedCSSFile
+  if (params.versionedCSSFile) {
+    if (!params.versionedCSSFile.fileName || typeof params.versionedCSSFile.fileName !== 'string') {
+      logger.error(`${appName} failed to write versionedCSSFile file! fileName missing or invalid`.red)
+    } else if (!params.versionedCSSFile.varName || typeof params.versionedCSSFile.varName !== 'string') {
+      logger.error(`${appName} failed to write versionedCSSFile file! varName missing or invalid'`.red)
     } else {
-      versionFile = path.join(cssPath, params.versionedCssFile.fileName)
+      versionFile = path.join(cssPath, params.versionedCSSFile.fileName)
       versionCode += preprocessorModule.versionCode(app)
 
       // create it if it does not already exist
@@ -117,7 +117,7 @@ module.exports = function (app, callback) {
           file = split[0]
 
           if (!fsr.fileExists(path.join(cssPath, file))) {
-            reject(new Error(`${file} specified in cssCompilerWhitelist does not exist. Please ensure file is entered properly.`))
+            reject(new Error(`${file} specified in CSS whitelist does not exist. Please ensure file is entered properly.`))
           }
         }
 

--- a/lib/scripts/appCleanup.js
+++ b/lib/scripts/appCleanup.js
@@ -12,11 +12,11 @@ const pkg = require(path.join(appDir, 'package.json'))
 const appName = pkg.name || 'Roosevelt Express'
 const params = pkg.rooseveltConfig
 const statics = params.staticsRoot
-const jsPath = params.jsPath
+const jsPath = params.js.sourceDir
 const publicDir = path.join(appDir, params.publicFolder)
-const compiledJsDir = path.join(appDir, statics, params.jsCompiledOutput.split(path.sep)[0] || params.jsCompiledOutput)
-const compiledCssDir = path.join(appDir, statics, params.cssCompiledOutput.split(path.sep)[0] || params.cssCompiledOutput)
-const bundledJsDir = path.join(appDir, statics, jsPath, params.bundledJsPath)
+const compiledJsDir = path.join(appDir, statics, params.js.output.split(path.sep)[0] || params.js.output)
+const compiledCssDir = path.join(appDir, statics, params.css.output.split(path.sep)[0] || params.css.output)
+const bundledJsDir = path.join(appDir, statics, jsPath, params.js.bundler.output)
 let cleanupDirs = []
 let rl
 

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -47,35 +47,33 @@ function configAudit (app) {
 
   logger.log('📋', 'Starting roosevelt user configuration audit...'.bold)
 
-  defaultConfigKeys.forEach(function (key) {
+  defaultConfigKeys.forEach((key) => {
     defaultParam = defaultConfig[key]
 
-    if (!(defaultParam.optional) && defaultParam.audit !== false) {
-      if (userConfig[key] === undefined) {
-        logger.error('⚠️', `Missing param ${key}!`.red.bold)
+    if (userConfig[key] === undefined) {
+      logger.error('⚠️', `Missing param "${key}"!`.red.bold)
+      errors = true
+    } else if (defaultParam instanceof Object && !(Array.isArray(defaultParam)) && Object.keys(defaultParam).length > 0 && defaultParam !== null) {
+      if (checkParamObject(userConfig[key], defaultParam, key)) {
         errors = true
-      } else if (defaultParam.value instanceof Object && !(Array.isArray(defaultParam.value)) && Object.keys(defaultParam.value).length > 0 && defaultParam.value !== null) {
-        if (checkParamObject(userConfig[key], defaultParam, 'audit')) {
-          errors = true
-        }
       }
     }
   })
 
-  userConfigKeys.forEach(function (userParam) {
+  userConfigKeys.forEach((userParam) => {
     if (defaultConfig[userParam] === undefined) {
-      logger.error('⚠️', `Extra param ${userParam} found, this can be removed.`.red.bold)
+      logger.error('⚠️', `Extra param "${userParam}" found, this can be removed.`.red.bold)
       errors = true
     }
   })
 
-  defaultScriptKeys.forEach(function (defaultScript) {
+  defaultScriptKeys.forEach((defaultScript) => {
     if (userScripts[defaultScript] === undefined) {
       if (defaultScripts[defaultScript].priority === 'error') {
-        logger.error('⚠️', `Missing script ${defaultScript}!`.red.bold)
+        logger.error('⚠️', `Missing script "${defaultScript}"!`.red.bold)
         errors = true
       } else if (defaultScripts[defaultScript].priority === 'warning') {
-        logger.warn(`Missing recommended script ${defaultScript}!`.bold)
+        logger.warn(`Missing recommended script "${defaultScript}"!`.bold)
       }
     }
   })

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -47,9 +47,9 @@ function configAudit (app) {
 
   logger.log('📋', 'Starting roosevelt user configuration audit...'.bold)
 
+  // inspect for missing params
   defaultConfigKeys.forEach((key) => {
     defaultParam = defaultConfig[key]
-
     if (userConfig[key] === undefined) {
       logger.error('⚠️', `Missing param "${key}"!`.red.bold)
       errors = true
@@ -60,6 +60,7 @@ function configAudit (app) {
     }
   })
 
+  // inspect for extra params
   userConfigKeys.forEach((userParam) => {
     if (defaultConfig[userParam] === undefined) {
       logger.error('⚠️', `Extra param "${userParam}" found, this can be removed.`.red.bold)
@@ -67,6 +68,7 @@ function configAudit (app) {
     }
   })
 
+  // inspect for missing or outdated scripts
   defaultScriptKeys.forEach((defaultScript) => {
     if (userScripts[defaultScript] === undefined) {
       if (defaultScripts[defaultScript].priority === 'error') {
@@ -75,11 +77,16 @@ function configAudit (app) {
       } else if (defaultScripts[defaultScript].priority === 'warning') {
         logger.warn(`Missing recommended script "${defaultScript}"!`.bold)
       }
+    } else if (defaultScripts[defaultScript].inspect === true) {
+      if (userScripts[defaultScript].includes('roosevelt') && userScripts[defaultScript] !== defaultScripts[defaultScript].value) {
+        logger.error('⚠️', `Detected outdated script "${defaultScript}". Update contents to "${defaultScripts[defaultScript].value}" to restore functionality.`.red.bold)
+      }
     }
   })
 
   if (errors) {
-    logger.error('Issues have been detected in roosevelt config, please consult https://github.com/rooseveltframework/roosevelt#configure-your-app-with-parameters for details on each param.'.bold.red)
+    logger.error('Issues have been detected in roosevelt config, please consult https://github.com/rooseveltframework/roosevelt#configure-your-app-with-parameters for details on each param.'.red.bold)
+    logger.error('Or see https://github.com/rooseveltframework/roosevelt/blob/master/lib/defaults/config.json for the latest sample rooseveltConfig.'.red.bold)
   } else {
     logger.log('✔️', 'Configuration audit completed with no errors found.')
   }

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -128,7 +128,6 @@ module.exports = function (app) {
     favicon: checkParams(params.favicon, pkg.rooseveltConfig.favicon, defaultConfig.favicon),
     staticsSymlinksToPublic: checkParams(params.staticsSymlinksToPublic, pkg.rooseveltConfig.staticsSymlinksToPublic, defaultConfig.staticsSymlinksToPublic),
     versionedPublic: checkParams(params.versionedPublic, pkg.rooseveltConfig.versionedPublic, defaultConfig.versionedPublic),
-    versionedCSSFile: checkParams(params.versionedCSSFile, pkg.rooseveltConfig.versionedCSSFile, defaultConfig.versionedCSSFile),
     alwaysHostPublic: checkParams(params.alwaysHostPublic, pkg.rooseveltConfig.alwaysHostPublic, defaultConfig.alwaysHostPublic),
 
     // events

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -98,7 +98,7 @@ module.exports = function (app) {
     noMinify: checkParams(params.noMinify, pkg.rooseveltConfig.noMinify, defaultConfig.noMinify),
     htmlValidator: checkParams(params.htmlValidator, pkg.rooseveltConfig.htmlValidator, defaultConfig.htmlValidator),
     multipart: checkParams(params.multipart, pkg.rooseveltConfig.multipart, defaultConfig.multipart),
-    maxLagPerRequest: checkParams(params.maxLagPerRequest, pkg.rooseveltConfig.maxLagPerRequest, defaultConfig.maxLagPerRequest),
+    toobusy: checkParams(params.toobusy, pkg.rooseveltConfig.toobusy, defaultConfig.toobusy),
     shutdownTimeout: checkParams(params.shutdownTimeout, pkg.rooseveltConfig.shutdownTimeout, defaultConfig.shutdownTimeout),
     bodyParserUrlencodedParams: checkParams(params.bodyParserUrlencodedParams, pkg.rooseveltConfig.bodyParserUrlencodedParams, defaultConfig.bodyParserUrlencodedParams),
     bodyParserJsonParams: checkParams(params.bodyParserJsonParams, pkg.rooseveltConfig.bodyParserJsonParams, defaultConfig.bodyParserJsonParams),

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -33,30 +33,39 @@ module.exports = function (app) {
     }
   }
 
-  // give priority to params overridden by CLI/env
-  if (process.env.NODE_ENV === 'development') {
-    params.noMinify = true
-    params.nodeEnv = 'development'
-  } else if (process.env.NODE_ENV === 'production') {
+  // determine node env
+  if (flags.productionMode) {
     params.nodeEnv = 'production'
+  } else if (flags.developmentMode) {
+    params.nodeEnv = 'development'
+  } else {
+    // default env to production
+    process.env.NODE_ENV = 'production'
+    params.nodeEnv = checkParams(params.nodeEnv, pkg.rooseveltConfig.nodeEnv, process.env.NODE_ENV, defaultConfig.nodeEnv)
   }
 
+  // override NODE_ENV with nodeEnv param
+  process.env.NODE_ENV = params.nodeEnv
+  app.set('env', process.env.NODE_ENV)
+
+  // give priority to params overridden by CLI/env
+  params.htmlValidator = params.htmlValidator || {}
   if (flags.enableValidator) {
-    params.enableValidator = true
+    params.htmlValidator.enable = true
   } else if (flags.disableValidator) {
-    params.enableValidator = false
+    params.htmlValidator.enable = false
   }
   if (flags.backgroundValidator) {
-    params.htmlValidator = {
-      separateProcess: true
-    }
+    params.htmlValidator.seperateProcess = true
   } else if (flags.attachValidator) {
-    params.htmlValidator = {
-      separateProcess: false
-    }
+    params.htmlValidator.seperateProcess = false
   }
   if (flags.productionMode) {
     params.alwaysHostPublic = true // only with --production-mode flag, not when NODE_ENV is naturally set to production
+  }
+  if (process.env.NODE_ENV === 'development') {
+    params.htmlValidator.enable = false
+    params.noMinify = true
   }
 
   pkg.rooseveltConfig = pkg.rooseveltConfig || {}
@@ -80,22 +89,19 @@ module.exports = function (app) {
   // source remaining params from params argument, then package.json, then defaults
 
   params = {
-
     // behavior
     port: checkParams(process.env.HTTP_PORT, process.env.NODE_PORT, params.port, pkg.rooseveltConfig.port, defaultConfig.port),
+    nodeEnv: params.nodeEnv,
+    generateFolderStructure: checkParams(params.generateFolderStructure, pkg.rooseveltConfig.generateFolderStructure, defaultConfig.generateFolderStructure),
     localhostOnly: checkParams(params.localhostOnly, pkg.rooseveltConfig.localhostOnly, defaultConfig.localhostOnly),
     suppressLogs: params.suppressLogs,
     noMinify: checkParams(params.noMinify, pkg.rooseveltConfig.noMinify, defaultConfig.noMinify),
-    enableValidator: checkParams(params.enableValidator, pkg.rooseveltConfig.enableValidator, defaultConfig.enableValidator),
-    validatorExceptions: checkParams(params.validatorExceptions, pkg.rooseveltConfig.validatorExceptions, defaultConfig.validatorExceptions),
     htmlValidator: checkParams(params.htmlValidator, pkg.rooseveltConfig.htmlValidator, defaultConfig.htmlValidator),
     multipart: checkParams(params.multipart, pkg.rooseveltConfig.multipart, defaultConfig.multipart),
     maxLagPerRequest: checkParams(params.maxLagPerRequest, pkg.rooseveltConfig.maxLagPerRequest, defaultConfig.maxLagPerRequest),
     shutdownTimeout: checkParams(params.shutdownTimeout, pkg.rooseveltConfig.shutdownTimeout, defaultConfig.shutdownTimeout),
     bodyParserUrlencodedParams: checkParams(params.bodyParserUrlencodedParams, pkg.rooseveltConfig.bodyParserUrlencodedParams, defaultConfig.bodyParserUrlencodedParams),
     bodyParserJsonParams: checkParams(params.bodyParserJsonParams, pkg.rooseveltConfig.bodyParserJsonParams, defaultConfig.bodyParserJsonParams),
-    nodeEnv: checkParams(params.nodeEnv, pkg.rooseveltConfig.nodeEnv, process.env.NODE_ENV, defaultConfig.nodeEnv),
-    generateFolderStructure: checkParams(params.generateFolderStructure, pkg.rooseveltConfig.generateFolderStructure, defaultConfig.generateFolderStructure),
 
     // https behavior - generally no defaults, user-defined
     https: checkParams(params.https, pkg.rooseveltConfig.https, defaultConfig.https),
@@ -114,25 +120,15 @@ module.exports = function (app) {
     // statics
     staticsRoot: checkParams(params.staticsRoot, pkg.rooseveltConfig.staticsRoot, defaultConfig.staticsRoot),
     htmlMinify: checkParams(params.htmlMinify, pkg.rooseveltConfig.htmlMinify, defaultConfig.htmlMinify),
-    cssPath: checkParams(params.cssPath, pkg.rooseveltConfig.cssPath, defaultConfig.cssPath),
-    cssCompiler: checkParams(params.cssCompiler, pkg.rooseveltConfig.cssCompiler, defaultConfig.cssCompiler),
-    cssCompilerWhitelist: checkParams(params.cssCompilerWhitelist, pkg.rooseveltConfig.cssCompilerWhitelist, defaultConfig.cssCompilerWhitelist),
-    cssCompiledOutput: checkParams(params.cssCompiledOutput, pkg.rooseveltConfig.cssCompiledOutput, defaultConfig.cssCompiledOutput),
-    jsPath: checkParams(params.jsPath, pkg.rooseveltConfig.jsPath, defaultConfig.jsPath),
-    browserifyBundles: checkParams(params.browserifyBundles, pkg.rooseveltConfig.browserifyBundles, defaultConfig.browserifyBundles),
-    bundledJsPath: checkParams(params.bundledJsPath, pkg.rooseveltConfig.bundledJsPath, defaultConfig.bundledJsPath),
-    exposeBundles: checkParams(params.exposeBundles, pkg.rooseveltConfig.exposeBundles, defaultConfig.exposeBundles),
-    jsCompiler: checkParams(params.jsCompiler, pkg.rooseveltConfig.jsCompiler, defaultConfig.jsCompiler),
-    jsCompilerWhitelist: checkParams(params.jsCompilerWhitelist, pkg.rooseveltConfig.jsCompilerWhitelist, defaultConfig.jsCompilerWhitelist),
-    jsCompilerBlacklist: checkParams(params.jsCompilerBlacklist, pkg.rooseveltConfig.jsCompilerBlacklist, defaultConfig.jsCompilerBlacklist),
-    jsCompiledOutput: checkParams(params.jsCompiledOutput, pkg.rooseveltConfig.jsCompiledOutput, defaultConfig.jsCompiledOutput),
+    css: checkParams(params.css, pkg.rooseveltConfig.css, defaultConfig.css),
+    js: checkParams(params.js, pkg.rooseveltConfig.js, defaultConfig.js),
 
     // public
     publicFolder: params.publicFolder,
     favicon: checkParams(params.favicon, pkg.rooseveltConfig.favicon, defaultConfig.favicon),
-    symlinksToStatics: checkParams(params.symlinksToStatics, pkg.rooseveltConfig.symlinksToStatics, defaultConfig.symlinksToStatics),
-    versionedStatics: checkParams(params.versionedStatics, pkg.rooseveltConfig.versionedStatics, defaultConfig.versionedStatics),
-    versionedCssFile: checkParams(params.versionedCssFile, pkg.rooseveltConfig.versionedCssFile, defaultConfig.versionedCssFile),
+    staticsSymlinksToPublic: checkParams(params.staticsSymlinksToPublic, pkg.rooseveltConfig.staticsSymlinksToPublic, defaultConfig.staticsSymlinksToPublic),
+    versionedPublic: checkParams(params.versionedPublic, pkg.rooseveltConfig.versionedPublic, defaultConfig.versionedPublic),
+    versionedCSSFile: checkParams(params.versionedCSSFile, pkg.rooseveltConfig.versionedCSSFile, defaultConfig.versionedCSSFile),
     alwaysHostPublic: checkParams(params.alwaysHostPublic, pkg.rooseveltConfig.alwaysHostPublic, defaultConfig.alwaysHostPublic),
 
     // events
@@ -143,16 +139,6 @@ module.exports = function (app) {
     onReqAfterRoute: params.onReqAfterRoute || undefined
   }
 
-  // sets nodeEnv params
-  if (params.nodeEnv !== undefined) {
-    if (params.nodeEnv === 'development') {
-      process.env.NODE_ENV = 'development'
-    } else if (params.nodeEnv === 'production') {
-      process.env.NODE_ENV = 'production'
-      params.alwaysHostPublic = true // only with -prod flag, not when NODE_ENV is naturally set to production
-    }
-  }
-
   // map mvc paths
   app.set('modelsPath', path.join(appDir, params.modelsPath))
   app.set('viewsPath', path.join(appDir, params.viewsPath))
@@ -160,18 +146,18 @@ module.exports = function (app) {
 
   // map statics paths
   app.set('staticsRoot', path.normalize(params.staticsRoot))
-  params.cssPath = path.join(params.staticsRoot, params.cssPath)
-  params.jsPath = path.join(params.staticsRoot, params.jsPath)
-  params.cssCompiledOutput = path.join(params.staticsRoot, params.cssCompiledOutput)
-  params.jsCompiledOutput = path.join(params.staticsRoot, params.jsCompiledOutput)
-  params.bundledJsPath = path.join(params.jsPath, params.bundledJsPath)
-  app.set('cssPath', path.join(appDir, params.cssPath))
-  app.set('jsPath', path.join(appDir, params.jsPath))
-  app.set('cssCompiledOutput', path.join(appDir, params.cssCompiledOutput))
-  app.set('jsCompiledOutput', path.join(appDir, params.jsCompiledOutput))
+  params.css.sourceDir = path.join(params.staticsRoot, params.css.sourceDir)
+  params.js.sourceDir = path.join(params.staticsRoot, params.js.sourceDir)
+  params.css.output = path.join(params.staticsRoot, params.css.output)
+  params.js.output = path.join(params.staticsRoot, params.js.output)
+  params.js.bundler.output = path.join(params.js.sourceDir, params.js.bundler.output)
+  app.set('cssPath', path.join(appDir, params.css.sourceDir))
+  app.set('jsPath', path.join(appDir, params.js.sourceDir))
+  app.set('cssCompiledOutput', path.join(appDir, params.css.output))
+  app.set('jsCompiledOutput', path.join(appDir, params.js.output))
 
   // determine statics prefix if any
-  params.staticsPrefix = params.versionedStatics ? pkg.version || '' : ''
+  params.staticsPrefix = params.versionedPublic ? pkg.version || '' : ''
 
   // ensure 404 page exists
   params.error404 = path.join(app.get('controllersPath'), params.error404)
@@ -204,11 +190,6 @@ module.exports = function (app) {
 
   // make the controllers directory requirable
   appModulePath.addPath(path.join(appDir, params.controllersPath, '../'))
-
-  // always disabled in prod mode
-  if (process.env.NODE_ENV === 'production') {
-    params.enableValidator = false
-  }
 
   app.set('params', params)
 

--- a/lib/tools/checkParamObject.js
+++ b/lib/tools/checkParamObject.js
@@ -1,49 +1,29 @@
 // Utility module for validating Roosevelt param objects
 const logger = require('./logger')()
 
-module.exports = function (userParam, defaultParam, mode) {
-  if (typeof userParam !== 'object' || userParam === null) {
-    return
-  }
-
+module.exports = function (userParam, defaultParam, auditKey) {
+  let defaultKeys = Object.keys(defaultParam)
   let userKeys = Object.keys(userParam)
-  let defaultParamValue = defaultParam.value
-  let defaultKeys = Object.keys(defaultParamValue)
   let defaultProp
 
-  if (mode === 'setDefault') {
-    defaultKeys.forEach((key) => {
-      defaultProp = defaultParamValue[key]
-
-      if (!defaultProp.optional) {
-        if (defaultProp.value instanceof Object && !(Array.isArray(defaultProp.value)) && Object.keys(defaultProp.value).length > 0 && defaultProp.value !== null) {
-          module.exports(userParam[key].value, defaultProp, mode)
-        } else {
-          userParam[key] = defaultProp.value
-        }
-      } else {
-        delete userParam[key]
+  if (auditKey) {
+    userKeys.forEach((key) => {
+      if (defaultParam[key] === undefined) {
+        logger.error('⚠️', `Extra param "${key}" found in "${auditKey}", this can be removed.`.red.bold)
       }
     })
-  } else {
-    if (userKeys.length < defaultKeys.length) {
-      defaultKeys.forEach((key) => {
-        defaultProp = defaultParamValue[key]
-
-        if (!defaultProp.optional) {
-          if (!(key in userParam)) {
-            if (mode === 'audit') {
-              if (defaultProp.audit !== false) {
-                logger.error('⚠️', `Missing param ${key} in ${defaultProp.parent}!`.red.bold)
-              }
-            } else if (defaultProp.value instanceof Object && !(Array.isArray(defaultProp.value)) && Object.keys(defaultProp.value).length > 0 && defaultProp.value !== (null || undefined)) {
-              module.exports(userParam[key], defaultProp, mode)
-            } else {
-              userParam[key] = defaultProp.value
-            }
-          }
-        }
-      })
-    }
   }
+
+  defaultKeys.forEach((key) => {
+    defaultProp = defaultParam[key]
+    if (userParam[key] === undefined) {
+      if (auditKey) {
+        logger.error('⚠️', `Missing param "${key}" in "${auditKey}"!`.red.bold)
+      } else {
+        userParam[key] = defaultProp
+      }
+    } else if (defaultProp instanceof Object && !(Array.isArray(defaultProp)) && Object.keys(defaultProp).length > 0 && defaultProp !== null) {
+      module.exports(userParam[key], defaultProp, auditKey ? key : undefined)
+    }
+  })
 }

--- a/lib/tools/checkParams.js
+++ b/lib/tools/checkParams.js
@@ -13,14 +13,9 @@ module.exports = function () {
     paramSource = arguments[i]
 
     if (paramSource !== undefined) {
-      // if no user param is passed, ensure that it's required before setting the default
       if (paramSource === defaultParam && param === undefined) {
         usingDefault = true
-        if (!defaultParam.optional) {
-          param = paramSource.value
-        } else {
-          param = null
-        }
+        param = paramSource
       } else {
         if (param === undefined) {
           param = paramSource
@@ -29,11 +24,9 @@ module.exports = function () {
     }
   }
 
-  if (defaultParam.value instanceof Object && !(Array.isArray(defaultParam.value)) && Object.keys(defaultParam.value).length > 0 && defaultParam.value !== null) {
+  if (defaultParam instanceof Object && !(Array.isArray(defaultParam)) && Object.keys(defaultParam).length > 0 && defaultParam !== null) {
     if (!usingDefault) {
       checkParamObject(param, defaultParam)
-    } else if (!defaultParam.optional) {
-      checkParamObject(param, defaultParam, 'setDefault')
     }
   }
 

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -17,16 +17,6 @@ module.exports = function (params) {
   // appDir is either specified by the user or sourced from the parent require
   params.appDir = params.appDir || path.dirname(module.parent.filename)
 
-  // check for command line overrides for NODE_ENV
-  if (flags.productionMode) {
-    process.env.NODE_ENV = 'production'
-  } else if (flags.developmentMode) {
-    process.env.NODE_ENV = 'development'
-  } else {
-    // default to production mode
-    process.env.NODE_ENV = 'production'
-  }
-
   let app = express() // initialize express
   let logger
   let appName


### PR DESCRIPTION
This is the big one that finally addresses the necessary quality of life updates to the user param structure. Sweeping changes are made. (Closes #194)

- `enableValidator`, and `validatorExceptions` have been made children of `htmlValidator`.
  - Renamed to `enable`, and `exceptions`.
- New param `css`. The following have been made children of it:
  - `cssPath`, `cssCompiler`, `cssCompilerWhitelist`, `cssCompiledOutput`, and `versionedCssFile` renamed to `sourceDir`, `compiler`, `whitelist`, `output`, and `versionFile`.
- New param `js`. The following have been made children of it:
  - `jsPath`, `jsCompiler`, `jsCompilerWhiteList`, `jsCompilerBlacklist`, and `jsCompiledOutput` renamed to `sourceDir`, `compiler`, `whitelist`, `blacklist`, and `output`.
  - New param `bundler`. The following have been made children of it:
    - `browserifyBundles`, `bundledJsPath`, and `exposeBundles` renamed to `bundles`, `output`, and `expose`.
- `symlinksToStatics` renamed to `staticsSymlinksToPublic`.
- `versionedStatics` renamed to `versionedPublic`.
- `nodeEnv` param now properly overrides `NODE_ENV` and express `env` variable.
- Brought `defaults/config.json` back to a simple structure. This makes it easier to use, and also allows it to be used as a reference to the current API.
- Add more default npm scripts. (Closes #294)
- Added inspection of scripts that utilize built in files to the config auditor.
- Rename `cleanup` script to `clean`.