### PR TITLE
Add the first ever mocha tests!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ jsdoc
 nbproject
 
 .jscodehints
+test/app/*

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ jsdoc
 nbproject
 
 .jscodehints
-test/app/*
+test/app

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -7,10 +7,10 @@ const checkParams = require('./tools/checkParams')
 const appModulePath = require('app-module-path')
 const defaultConfig = require('./defaults/config')
 const fsr = require('./tools/fsr')()
-const logger = require('./tools/logger')()
 let pkg
 
 module.exports = function (app) {
+  const logger = require('./tools/logger')(app)
   let params = app.get('params')
   let flags = app.get('flags')
   let appDir = params.appDir

--- a/lib/tools/logger.js
+++ b/lib/tools/logger.js
@@ -27,8 +27,10 @@ function parseLogs (input, type) {
 class Logger {
   constructor (app) {
     if (app) {
-      this.suppressLogs = app.get('params').suppressLogs.rooseveltLogs
-      this.suppressWarnings = app.get('params').suppressLogs.rooseveltWarnings
+      if (typeof app.get('params').suppressLogs === 'object') {
+        this.suppressLogs = app.get('params').suppressLogs.rooseveltLogs
+        this.suppressWarnings = app.get('params').suppressLogs.rooseveltWarnings
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -369,6 +369,12 @@
         }
       }
     },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
     "browserify": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-15.0.0.tgz",
@@ -1037,6 +1043,12 @@
           "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
         }
       }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -1845,6 +1857,12 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
     },
     "har-schema": {
       "version": "1.0.5",
@@ -2917,6 +2935,50 @@
         }
       }
     },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "module-deps": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-5.0.0.tgz",
@@ -3177,10 +3239,13 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -3188,13 +3253,19 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "pako": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "husky": "~0.14.2",
     "lint-staged": "~6.0.0",
+    "mocha": "~4.1.0",
     "standard": "~10.0.0"
   },
   "repository": {
@@ -57,7 +58,8 @@
   "gitHead": "",
   "scripts": {
     "postinstall": "node ./lib/scripts/configAuditor.js",
-    "test": "standard",
+    "standard": "standard",
+    "test": "mocha --recursive test && npm run standard",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/test/lib/testConstructorConfig.json
+++ b/test/lib/testConstructorConfig.json
@@ -1,0 +1,71 @@
+{
+  "port": "constructor",
+  "generateFolderStructure": false,
+  "localhostOnly": "constructor",
+  "suppressLogs": {
+    "httpLogs": true,
+    "rooseveltLogs": true,
+    "rooseveltWarnings": true
+  },
+  "noMinify": "constructor",
+  "htmlValidator": {
+    "enable": "constructor",
+    "separateProcess": "constructor",
+    "port": "constructor",
+    "suppressWarnings": "constructor",
+    "exceptions": {
+      "requestHeader": "constructor",
+      "modelValue": "constructor"
+    }
+  },
+  "multipart": {
+    "multiples": "constructor"
+  },
+  "toobusy": {
+    "maxLagPerRequest": "constructor",
+    "lagCheckInterval": "constructor"
+  },
+  "shutdownTimeout": "constructor",
+  "bodyParserUrlencodedParams": {
+    "extended": "constructor"
+  },
+  "bodyParserJsonParams": "constructor",
+  "https": "constructor",
+  "modelsPath": "constructor",
+  "viewsPath": "constructor",
+  "controllersPath": "constructor",
+  "viewEngine": null,
+  "error404": "constructor",
+  "error5xx": "constructor",
+  "error503": "constructor",
+  "staticsRoot": "constructor",
+  "htmlMinify": {
+    "override": "constructor",
+    "exception_url": "constructor",
+    "htmlMinifier": "constructor"
+  },
+  "css": {
+    "sourceDir": "constructor",
+    "compiler": "constructor",
+    "whitelist": "constructor",
+    "output": "constructor",
+    "versionFile": "constructor"
+  },
+  "js": {
+    "sourceDir": "constructor",
+    "compiler": "constructor",
+    "whitelist": "constructor",
+    "blacklist": "constructor",
+    "output": "constructor",
+    "bundler": {
+      "bundles": "constructor",
+      "output": "constructor",
+      "expose": "constructor"
+    }
+  },
+  "publicFolder": "constructor",
+  "favicon": "constructor",
+  "staticsSymlinksToPublic": "constructor",
+  "versionedPublic": "constructor",
+  "alwaysHostPublic": "constructor"
+}

--- a/test/lib/testPkgConfig.json
+++ b/test/lib/testPkgConfig.json
@@ -1,0 +1,71 @@
+{
+  "port": "package",
+  "generateFolderStructure": false,
+  "localhostOnly": "package",
+  "suppressLogs": {
+    "httpLogs": true,
+    "rooseveltLogs": true,
+    "rooseveltWarnings": true
+  },
+  "noMinify": "package",
+  "htmlValidator": {
+    "enable": "package",
+    "separateProcess": "package",
+    "port": "package",
+    "suppressWarnings": "package",
+    "exceptions": {
+      "requestHeader": "package",
+      "modelValue": "package"
+    }
+  },
+  "multipart": {
+    "multiples": "package"
+  },
+  "toobusy": {
+    "maxLagPerRequest": "package",
+    "lagCheckInterval": "package"
+  },
+  "shutdownTimeout": "package",
+  "bodyParserUrlencodedParams": {
+    "extended": "package"
+  },
+  "bodyParserJsonParams": "package",
+  "https": "package",
+  "modelsPath": "package",
+  "viewsPath": "package",
+  "controllersPath": "package",
+  "viewEngine": "none",
+  "error404": "package",
+  "error5xx": "package",
+  "error503": "package",
+  "staticsRoot": "package",
+  "htmlMinify": {
+    "override": "package",
+    "exception_url": "package",
+    "htmlMinifier": "package"
+  },
+  "css": {
+    "sourceDir": "package",
+    "compiler": "package",
+    "whitelist": "package",
+    "output": "package",
+    "versionFile": "package"
+  },
+  "js": {
+    "sourceDir": "package",
+    "compiler": "package",
+    "whitelist": "package",
+    "blacklist": "package",
+    "output": "package",
+    "bundler": {
+      "bundles": "package",
+      "output": "package",
+      "expose": "package"
+    }
+  },
+  "publicFolder": "package",
+  "favicon": "package",
+  "staticsSymlinksToPublic": "package",
+  "versionedPublic": "package",
+  "alwaysHostPublic": "package"
+}

--- a/test/params/constructor.js
+++ b/test/params/constructor.js
@@ -1,0 +1,44 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+const rimraf = require('rimraf')
+
+describe('Constructor params', function () {
+  const appDir = path.join(__dirname, '../app/constructorParam')
+  const config = require('../lib/testConstructorConfig.json')
+  const pkgConfig = require('../lib/testPkgConfig.json')
+  const pkg = {
+    rooseveltConfig: pkgConfig
+  }
+  let app
+
+  before(function () {
+    fs.mkdirSync(path.join(appDir))
+    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(pkg))
+
+    app = require('../../roosevelt')({
+      appDir: appDir,
+      ...config
+    })
+  })
+
+  after(function (done) {
+    rimraf(appDir, (err) => {
+      if (err) {
+        throw err
+      } else {
+        done()
+      }
+    })
+  })
+
+  it('should set param "port" from constructor', function () {
+    assert.equal(app.expressApp.get('params').port, config.port)
+  })
+
+  it('should set param "localhostOnly" from constructor', function () {
+    assert.equal(app.expressApp.get('params').localhostOnly, config.localhostOnly)
+  })
+})

--- a/test/params/constructor.js
+++ b/test/params/constructor.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert')
 const fs = require('fs')
+const fse = require('fs-extra')
 const path = require('path')
 const rimraf = require('rimraf')
 
@@ -15,7 +16,7 @@ describe('Constructor params', function () {
   let app
 
   before(function () {
-    fs.mkdirSync(path.join(appDir))
+    fse.ensureDirSync(path.join(appDir))
     fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(pkg))
 
     app = require('../../roosevelt')({

--- a/test/params/defaults.js
+++ b/test/params/defaults.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const path = require('path')
+const defaults = require('../../lib/defaults/config.json')
+const app = require('../../roosevelt')({
+  appDir: path.join(__dirname, '../app'),
+  suppressLogs: {
+    httpsLogs: true,
+    rooseveltLogs: true,
+    rooseveltWarnings: true
+  }
+})
+
+describe('Default Params', function () {
+  const params = app.expressApp.get('params')
+
+  it('should set correct default for param "port"', function () {
+    assert.equal(params.port, defaults.port)
+  })
+
+  it('should set correct default for param "localhostOnly"', function () {
+    assert.equal(params.localhostOnly, defaults.localhostOnly)
+  })
+})

--- a/test/params/defaults.js
+++ b/test/params/defaults.js
@@ -2,24 +2,27 @@
 
 const assert = require('assert')
 const path = require('path')
-const defaults = require('../../lib/defaults/config.json')
-const app = require('../../roosevelt')({
-  appDir: path.join(__dirname, '../app'),
-  suppressLogs: {
-    httpsLogs: true,
-    rooseveltLogs: true,
-    rooseveltWarnings: true
-  }
-})
 
 describe('Default Params', function () {
-  const params = app.expressApp.get('params')
+  const defaults = require('../../lib/defaults/config.json')
+  let app
+
+  before(function () {
+    app = require('../../roosevelt')({
+      appDir: path.join(__dirname, '../app/defaultParam'),
+      suppressLogs: {
+        httpsLogs: true,
+        rooseveltLogs: true,
+        rooseveltWarnings: true
+      }
+    })
+  })
 
   it('should set correct default for param "port"', function () {
-    assert.equal(params.port, defaults.port)
+    assert.equal(app.expressApp.get('params').port, defaults.port)
   })
 
   it('should set correct default for param "localhostOnly"', function () {
-    assert.equal(params.localhostOnly, defaults.localhostOnly)
+    assert.equal(app.expressApp.get('params').localhostOnly, defaults.localhostOnly)
   })
 })

--- a/test/params/package.js
+++ b/test/params/package.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const rimraf = require('rimraf')
 
-describe('packags.json params', function () {
+describe('package.json params', function () {
   const appDir = path.join(__dirname, '../app/packageParam')
   const pkgConfig = require('../lib/testPkgConfig.json')
   const pkg = {

--- a/test/params/package.js
+++ b/test/params/package.js
@@ -1,0 +1,42 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+const rimraf = require('rimraf')
+
+describe('packags.json params', function () {
+  const appDir = path.join(__dirname, '../app/packageParam')
+  const pkgConfig = require('../lib/testPkgConfig.json')
+  const pkg = {
+    rooseveltConfig: pkgConfig
+  }
+  let app
+
+  before(function () {
+    fs.mkdirSync(path.join(appDir))
+    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(pkg))
+
+    app = require('../../roosevelt')({
+      appDir: appDir
+    })
+  })
+
+  after(function (done) {
+    rimraf(appDir, (err) => {
+      if (err) {
+        throw err
+      } else {
+        done()
+      }
+    })
+  })
+
+  it('should set param "port" from package.json', function () {
+    assert.equal(app.expressApp.get('params').port, pkgConfig.port)
+  })
+
+  it('should set param "localhostOnly" from package.json', function () {
+    assert.equal(app.expressApp.get('params').localhostOnly, pkgConfig.localhostOnly)
+  })
+})

--- a/test/params/package.js
+++ b/test/params/package.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert')
 const fs = require('fs')
+const fse = require('fs-extra')
 const path = require('path')
 const rimraf = require('rimraf')
 
@@ -14,7 +15,7 @@ describe('package.json params', function () {
   let app
 
   before(function () {
-    fs.mkdirSync(path.join(appDir))
+    fse.ensureDirSync(path.join(appDir))
     fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(pkg))
 
     app = require('../../roosevelt')({


### PR DESCRIPTION
With this PR mocha is now officially a devDep of Roosevelt, and that can only mean one thing... Tests!

Starting us off is some simple tests to ensure that params are set properly. This comes in 3 flavors:
- Constructor: Test that params sent to the constructor are instantiated in a new app, tossing a package.json into the mix also ensures that they take priority.
- Package: Test that params in rooseveltConfig of a local package.json are set properly.
- Defaults: Test that default params are set when they are not set via the constructor or the package.

Some things to note:
- There are some exceptions which break the conventions of these test cases which will either directly or indirectly be tested in the future:
  - Setting suppressLogs in every test case defies the default test.
  - Implicit `generateFolderStructure: false` in default tests as a result of no package.json.
- To mitigate the possibility of race conditions polluting the isolation of app environments between tests each `appDir` is a different directory specific to that test suite.