### PR TITLE
Fix incoming unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ Roosevelt supplies several variables to Express that you may find handy. Access 
 | `jsPath`                             | Full path on the file system to where your app's JS source files are located. |
 | `cssCompiledOutput`                  | Full path on the file system to where your app's minified CSS files are located. |
 | `jsCompiledOutput`                   | Full path on the file system to where your app's minified JS files are located. |
+| `jsBundledOutput`                    | Full path on the file system to where your app's bundled JS files are located. |
 | `modelsPath`                         | Full path on the file system to where your app's models folder is located. |
 | `viewsPath`                          | Full path on the file system to where your app's views folder is located. |
 | `controllersPath`                    | Full path on the file system to where your app's controllers folder is located. |

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -66,9 +66,7 @@
   "publicFolder": "public",
   "favicon": "none",
   "staticsSymlinksToPublic": [
-    "images",
-    "css: .build/css",
-    "js: .build/js"
+    "images"
   ],
   "versionedPublic": false,
   "alwaysHostPublic": false

--- a/lib/jsBundler.js
+++ b/lib/jsBundler.js
@@ -10,7 +10,7 @@ module.exports = function (app, callback) {
   const appDir = app.get('appDir')
   const appName = app.get('appName')
   const jsPath = app.get('jsPath')
-  const bundleBuildDir = path.join(app.get('jsCompiledOutput'), (params.js.bundler.output.replace(params.jsPath, '')))
+  const bundleBuildDir = path.join(app.get('jsCompiledOutput'), (app.get('jsBundledOutput').replace(params.jsPath, '')))
   const logger = require('./tools/logger')(app)
   const fsr = require('./tools/fsr')(app)
   let bundleEnv

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -20,6 +20,24 @@ module.exports = function (app) {
   let publicDir
   let ec = 0
 
+  // ensure 404 page exists
+  params.error404 = path.join(app.get('controllersPath'), params.error404)
+  if (!fsr.fileExists(params.error404)) {
+    params.error404 = path.join(__dirname, '../defaultErrorPages/controllers/404.js')
+  }
+
+  // ensure 500 page exists
+  params.error5xx = path.join(app.get('controllersPath'), params.error5xx)
+  if (!fsr.fileExists(params.error5xx)) {
+    params.error5xx = path.join(__dirname, '../defaultErrorPages/controllers/5xx.js')
+  }
+
+  // ensure 503 page exists
+  params.error503 = path.join(app.get('controllersPath'), params.error503)
+  if (!fsr.fileExists(params.error503)) {
+    params.error503 = path.join(__dirname, '../defaultErrorPages/controllers/503.js')
+  }
+
   // define maximum number of miliseconds to wait for a given request to finish
   toobusy.maxLag(params.toobusy.maxLagPerRequest)
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -35,47 +35,6 @@ module.exports = function (app) {
 
   pkg.rooseveltConfig = pkg.rooseveltConfig || {}
 
-  // determine node env
-  if (flags.productionMode) {
-    params.nodeEnv = 'production'
-  } else if (flags.developmentMode) {
-    params.nodeEnv = 'development'
-  } else {
-    // default env to production
-    process.env.NODE_ENV = 'production'
-    params.nodeEnv = checkParams(params.nodeEnv, pkg.rooseveltConfig.nodeEnv, process.env.NODE_ENV, defaultConfig.nodeEnv)
-  }
-
-  // override NODE_ENV with nodeEnv param
-  process.env.NODE_ENV = params.nodeEnv
-  app.set('env', process.env.NODE_ENV)
-
-  // give priority to params overridden by CLI/env
-  params.htmlValidator = params.htmlValidator || {}
-  if (flags.enableValidator) {
-    params.htmlValidator.enable = true
-  } else if (flags.disableValidator) {
-    params.htmlValidator.enable = false
-  }
-  if (flags.backgroundValidator) {
-    params.htmlValidator.separateProcess = true
-  } else if (flags.attachValidator) {
-    params.htmlValidator.separateProcess = false
-  }
-  if (flags.productionMode) {
-    params.alwaysHostPublic = true
-  }
-  if (process.env.NODE_ENV === 'development') {
-    params.noMinify = true
-  } else if (process.env.NODE_ENV === 'production') {
-    params.htmlValidator.enable = false
-  }
-
-  // reset htmlValidator param if no flags modify it
-  if (!Object.keys(params.htmlValidator).length) {
-    delete params.htmlValidator
-  }
-
   app.set('appDir', appDir)
   app.set('package', pkg)
   app.set('appName', pkg.name || 'Roosevelt Express')
@@ -96,7 +55,7 @@ module.exports = function (app) {
   params = {
     // behavior
     port: checkParams(process.env.HTTP_PORT, process.env.NODE_PORT, params.port, pkg.rooseveltConfig.port, defaultConfig.port),
-    nodeEnv: params.nodeEnv,
+    nodeEnv: checkParams(params.nodeEnv, pkg.rooseveltConfig.nodeEnv, process.env.NODE_ENV, defaultConfig.nodeEnv),
     generateFolderStructure: checkParams(params.generateFolderStructure, pkg.rooseveltConfig.generateFolderStructure, defaultConfig.generateFolderStructure),
     localhostOnly: checkParams(params.localhostOnly, pkg.rooseveltConfig.localhostOnly, defaultConfig.localhostOnly),
     suppressLogs: params.suppressLogs,
@@ -143,6 +102,40 @@ module.exports = function (app) {
     onReqAfterRoute: params.onReqAfterRoute || undefined
   }
 
+  // determine node env
+  if (flags.productionMode) {
+    params.nodeEnv = 'production'
+  } else if (flags.developmentMode) {
+    params.nodeEnv = 'development'
+  } else {
+    // default env to production
+    process.env.NODE_ENV = 'production'
+  }
+
+  // override NODE_ENV with nodeEnv param
+  process.env.NODE_ENV = params.nodeEnv
+  app.set('env', process.env.NODE_ENV)
+
+  // give priority to params overridden by CLI/env
+  if (flags.enableValidator) {
+    params.htmlValidator.enable = true
+  } else if (flags.disableValidator) {
+    params.htmlValidator.enable = false
+  }
+  if (flags.backgroundValidator) {
+    params.htmlValidator.separateProcess = true
+  } else if (flags.attachValidator) {
+    params.htmlValidator.separateProcess = false
+  }
+  if (flags.productionMode) {
+    params.alwaysHostPublic = true
+  }
+  if (process.env.NODE_ENV === 'development') {
+    params.noMinify = true
+  } else if (process.env.NODE_ENV === 'production') {
+    params.htmlValidator.enable = false
+  }
+
   // map mvc paths
   app.set('modelsPath', path.join(appDir, params.modelsPath))
   app.set('viewsPath', path.join(appDir, params.viewsPath))
@@ -150,36 +143,14 @@ module.exports = function (app) {
 
   // map statics paths
   app.set('staticsRoot', path.normalize(params.staticsRoot))
-  params.css.sourceDir = path.join(params.staticsRoot, params.css.sourceDir)
-  params.js.sourceDir = path.join(params.staticsRoot, params.js.sourceDir)
-  params.css.output = path.join(params.staticsRoot, params.css.output)
-  params.js.output = path.join(params.staticsRoot, params.js.output)
-  params.js.bundler.output = path.join(params.js.sourceDir, params.js.bundler.output)
-  app.set('cssPath', path.join(appDir, params.css.sourceDir))
-  app.set('jsPath', path.join(appDir, params.js.sourceDir))
-  app.set('cssCompiledOutput', path.join(appDir, params.css.output))
-  app.set('jsCompiledOutput', path.join(appDir, params.js.output))
+  app.set('cssPath', path.join(appDir, params.staticsRoot, params.css.sourceDir))
+  app.set('jsPath', path.join(appDir, params.staticsRoot, params.js.sourceDir))
+  app.set('cssCompiledOutput', path.join(appDir, params.staticsRoot, params.css.output))
+  app.set('jsCompiledOutput', path.join(appDir, params.staticsRoot, params.js.output))
+  app.set('jsBundledOutput', path.join(app.get('jsPath'), params.js.bundler.output))
 
   // determine statics prefix if any
   params.staticsPrefix = params.versionedPublic ? pkg.version || '' : ''
-
-  // ensure 404 page exists
-  params.error404 = path.join(app.get('controllersPath'), params.error404)
-  if (!fsr.fileExists(params.error404)) {
-    params.error404 = path.join(__dirname, '../defaultErrorPages/controllers/404.js')
-  }
-
-  // ensure 500 page exists
-  params.error5xx = path.join(app.get('controllersPath'), params.error5xx)
-  if (!fsr.fileExists(params.error5xx)) {
-    params.error5xx = path.join(__dirname, '../defaultErrorPages/controllers/5xx.js')
-  }
-
-  // ensure 503 page exists
-  params.error503 = path.join(app.get('controllersPath'), params.error503)
-  if (!fsr.fileExists(params.error503)) {
-    params.error503 = path.join(__dirname, '../defaultErrorPages/controllers/503.js')
-  }
 
   // ensure formidableSettings is an object
   if (params.multipart !== false && typeof params.multipart !== 'object') {

--- a/test/dirStructure/folderTest.js
+++ b/test/dirStructure/folderTest.js
@@ -131,7 +131,7 @@ describe('Folder Tests', function () {
   })
 
   it('should generate "js" source directory', function (done) {
-    const foldertest = path.join(appDir, app.expressApp.get('params').js.sourceDir)
+    const foldertest = path.join(app.expressApp.get('jsPath'))
     fs.lstat(foldertest, (err, stats) => {
       if (err) {
         done(err)
@@ -143,7 +143,7 @@ describe('Folder Tests', function () {
   })
 
   it('should generate "css" source directory', function (done) {
-    const foldertest = path.join(appDir, app.expressApp.get('params').css.sourceDir)
+    const foldertest = path.join(app.expressApp.get('cssPath'))
     fs.lstat(foldertest, (err, stats) => {
       if (err) {
         done(err)
@@ -202,13 +202,13 @@ describe('Folder Tests', function () {
     })
   })
 
-  it.skip('should set "cssPath" express variable to absolute path of "css.sourceDir"', function () {
+  it('should set "cssPath" express variable to absolute path of "css.sourceDir"', function () {
     const folderCheck = path.join(appDir, app.expressApp.get('params').staticsRoot, app.expressApp.get('params').css.sourceDir)
     const test = folderCheck === app.expressApp.get('cssPath')
     assert.equal(test, true, 'the path given by the combined paths and the path given by cssPath do not match')
   })
 
-  it.skip('should set "jsPath" express variable to absolute path of "js.sourceDir"', function () {
+  it('should set "jsPath" express variable to absolute path of "js.sourceDir"', function () {
     const folderCheck = path.join(appDir, app.expressApp.get('params').staticsRoot, app.expressApp.get('params').js.sourceDir)
     const test = folderCheck === app.expressApp.get('jsPath')
     assert.equal(test, true, 'the path given by the combined paths and the path given by jsPath do not match')
@@ -217,8 +217,10 @@ describe('Folder Tests', function () {
   it('should not generate extra directories or files into the appDir', function () {
     const dirs = klawSync(appDir)
     dirs.forEach((dir) => {
-      let test = expectedFolders.includes(dir.path)
-      assert.equal(test, true, `There is an extra directory or file at ${dir.path}`)
+      if (!dir.path.includes('.DS_Store')) {
+        let test = expectedFolders.includes(dir.path)
+        assert.equal(test, true, `There is an extra directory or file at ${dir.path}`)
+      }
     })
   })
 })


### PR DESCRIPTION
This PR aims to prevent future issues by making params much easier to predict.
- `NODE_ENV` and flag param overrides happen after the params are set.
- `css.sourceDir` and `js.sourceDir` are no longer modified internally to include `staticsRoot`.
- `js.bundler.output` is no longer modified to include `staticsRoot` and `js.sourceDir`.
-  Add express variable for `jsBundledOutput`.
- Remove `.build/css` and `.build/js` from internal default of `staticsSymlinksToPublic` (Because the compilers are off by default).
- Don't modify the internal error page params until we get to `mapRoutes`.