### PR TITLE
Refactor jsBundler to fix bugs and increase clarity

### DIFF
--- a/lib/jsBundler.js
+++ b/lib/jsBundler.js
@@ -6,32 +6,32 @@ const browserify = require('browserify')
 const path = require('path')
 
 module.exports = function (app, callback) {
-  let params = app.get('params')
+  const params = app.get('params')
   const appDir = app.get('appDir')
   const appName = app.get('appName')
   const jsPath = app.get('jsPath')
-  const bundleBuildDir = app.get('jsBundledOutput')
+  const jsBundledOutput = app.get('jsBundledOutput')
+  const bundleBuildDir = path.join(app.get('jsCompiledOutput'), jsBundledOutput.replace(app.get('jsPath'), ''))
   const logger = require('./tools/logger')(app)
   const fsr = require('./tools/fsr')(app)
   let bundleEnv
   let promises = []
 
-  // make js directory if not present
-  if (!fsr.fileExists(jsPath)) {
-    if (fsr.ensureDirSync(jsPath)) {
-      logger.log('📁', `${appName} making new directory ${jsPath}`.yellow)
-    }
+  // use existence of bundles array members to determine if bundler is enabled
+  if (!params.js.bundler.bundles.length) {
+    callback()
+    return
   }
 
   // make js bundled output directory if not present
-  if (params.js.bundler.bundles.length && !fsr.fileExists(bundleBuildDir)) {
-    if (fsr.ensureDirSync(bundleBuildDir)) {
-      logger.log('📁', `${appName} making new directory ${bundleBuildDir}`.yellow)
+  if (!fsr.fileExists(jsBundledOutput)) {
+    if (fsr.ensureDirSync(jsBundledOutput)) {
+      logger.log('📁', `${appName} making new directory ${jsBundledOutput}`.yellow)
     }
   }
 
-  // make js bundled output directory in build directory if not present
-  if (params.js.bundler.bundles.length && params.js.bundler.expose && !fsr.fileExists(bundleBuildDir)) {
+  // make js bundled output directory in build directory if not present and expose is true
+  if (params.js.bundler.expose && !fsr.fileExists(bundleBuildDir)) {
     if (fsr.ensureDirSync(bundleBuildDir)) {
       logger.log('📁', `${appName} making new directory ${bundleBuildDir}`.yellow)
     }
@@ -44,6 +44,7 @@ module.exports = function (app, callback) {
     bundleEnv = 'prod'
   }
 
+  // process bundles
   params.js.bundler.bundles.forEach((bundle) => {
     if (bundle.env === bundleEnv || !bundle.env) {
       promises.push(
@@ -68,13 +69,17 @@ module.exports = function (app, callback) {
 
           browserify(bundle.files, bundle.params).bundle((err, jsCode) => {
             if (err) {
-              logger.error(`${appName} failed to write new JS file ${path.join(bundleBuildDir, bundle.outputFile)} due to syntax errors in the source JavaScript`.red)
+              logger.error(`${appName} failed to write new JS file ${path.join(jsBundledOutput, bundle.outputFile)} due to syntax errors in the source JavaScript`.red)
               reject(err)
+              return
             } else {
-              if (fsr.writeFileSync(path.join(bundleBuildDir, bundle.outputFile), jsCode, 'utf8')) {
-                logger.log('📝', `${appName} writing new JS file ${path.join(bundleBuildDir, bundle.outputFile)}`.green)
+              // write bundled js file to js bundled output
+              if (fsr.writeFileSync(path.join(jsBundledOutput, bundle.outputFile), jsCode, 'utf8')) {
+                logger.log('📝', `${appName} writing new JS file ${path.join(jsBundledOutput, bundle.outputFile)}`.green)
               }
-              if (params.exposeBundles) {
+
+              // also write bundled js file to build directory if expose param is true
+              if (params.js.bundler.expose) {
                 if (fsr.writeFileSync(path.join(bundleBuildDir, bundle.outputFile), jsCode, 'utf8')) {
                   logger.log('📝', `${appName} writing new JS file ${path.join(bundleBuildDir, bundle.outputFile)}`.green)
                 }
@@ -88,11 +93,11 @@ module.exports = function (app, callback) {
   })
 
   Promise.all(promises)
-    .then(() => {
-      callback()
-    })
-    .catch((err) => {
-      logger.error(`${err}`.red)
-      process.exit(1)
-    })
+  .then(() => {
+    callback()
+  })
+  .catch((err) => {
+    logger.error(err)
+    process.exit(1)
+  })
 }

--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -36,6 +36,7 @@ module.exports = function (app, callback) {
       preprocessorModule = prequire(preprocessor)
     } catch (err) {
       logger.error(`${appName} failed to include your JS compiler! Please ensure that it is declared properly in your package.json and that it has been properly installed to node_modules.`.red)
+      logger.error(err)
       logger.warn('JS compiler has been disabled'.yellow)
       params.js.compiler = 'none'
       callback()
@@ -99,7 +100,8 @@ module.exports = function (app, callback) {
           file = split[0]
 
           if (!fsr.fileExists(path.join(jsPath, file))) {
-            reject(new Error(`${file} specified in JS whitelist does not exist. Please ensure file is entered properly.`))
+            reject(new Error(`${file} specified in JS whitelist does not exist. Please ensure file is entered properly.`.red))
+            return
           }
         }
 
@@ -118,8 +120,9 @@ module.exports = function (app, callback) {
           try {
             newJS = preprocessorModule.parse(app, file)
           } catch (err) {
-            logger.error(`${appName} failed to parse ${file}. Please ensure that it is coded correctly`.red)
+            logger.error(`${appName} failed to parse ${path.join(jsPath, file)}. Please ensure that it is coded correctly`.red)
             reject(err)
+            return
           }
         }
 
@@ -147,11 +150,11 @@ module.exports = function (app, callback) {
   })
 
   Promise.all(promises)
-    .then(() => {
-      callback()
-    })
-    .catch((err) => {
-      logger.error(`${err}`.red)
-      process.exit(1)
-    })
+  .then(() => {
+    callback()
+  })
+  .catch((err) => {
+    logger.error(err)
+    process.exit(1)
+  })
 }

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -118,6 +118,7 @@ module.exports = function (app, callback) {
 
           if (!fsr.fileExists(path.join(cssPath, file))) {
             reject(new Error(`${file} specified in CSS whitelist does not exist. Please ensure file is entered properly.`))
+            return
           }
         }
 
@@ -129,33 +130,33 @@ module.exports = function (app, callback) {
         file = file.replace(cssPath, '')
 
         preprocessorModule.parse(app, file)
-          .then(([newFile, newCSS]) => {
-            newFile = path.join(cssCompiledOutput, (altdest || newFile))
+        .then(([newFile, newCSS]) => {
+          newFile = path.join(cssCompiledOutput, (altdest || newFile))
 
-            // create build directory if it doesn't exist
-            if (!fsr.fileExists(path.dirname(newFile))) {
-              if (fsr.ensureDirSync(path.dirname(newFile))) {
-                logger.log('📁', `${appName} making new directory ${path.dirname(newFile)}`.yellow)
-              }
+          // create build directory if it doesn't exist
+          if (!fsr.fileExists(path.dirname(newFile))) {
+            if (fsr.ensureDirSync(path.dirname(newFile))) {
+              logger.log('📁', `${appName} making new directory ${path.dirname(newFile)}`.yellow)
             }
+          }
 
-            // create file if it doesn't exist
-            fsr.openSync(newFile, 'a')
+          // create file if it doesn't exist
+          fsr.openSync(newFile, 'a')
 
-            // check existing file for matching content before writing
-            if (fs.readFileSync(newFile, 'utf8') !== newCSS) {
-              if (fsr.writeFileSync(newFile, newCSS)) {
-                logger.log('📝', `${appName} writing new CSS file ${newFile}`.green)
-              }
-              resolve()
-            } else {
-              resolve()
+          // check existing file for matching content before writing
+          if (fs.readFileSync(newFile, 'utf8') !== newCSS) {
+            if (fsr.writeFileSync(newFile, newCSS)) {
+              logger.log('📝', `${appName} writing new CSS file ${newFile}`.green)
             }
-          })
-          .catch((err) => {
-            console.error(`${appName} failed to parse ${file}. Please ensure that it is coded correctly.`.red)
-            reject(err)
-          })
+            resolve()
+          } else {
+            resolve()
+          }
+        })
+        .catch((err) => {
+          console.error(`${appName} failed to parse ${file}. Please ensure that it is coded correctly.`.red)
+          reject(err)
+        })
       })
     )
   })
@@ -165,7 +166,7 @@ module.exports = function (app, callback) {
       callback()
     })
     .catch((err) => {
-      logger.error(`${err}`.red)
+      logger.error(err)
       process.exit(1)
     })
 }


### PR DESCRIPTION
- Fix `expose` feature.
- Check if bundler is enabled at the start.
- Update comments for clarity.
- Ensure error objects print entirely. (Closes #341)

Note: Coverage decreases slightly here due hitting the callback at the start when there are no bundles. Once the bundler tests are finished this will be much more covered.