### PR TITLE
Patch https passphrase

### DIFF
--- a/roosevelt.js
+++ b/roosevelt.js
@@ -61,7 +61,7 @@ module.exports = function (params) {
     }
     ca = app.get('params').https.ca
     cafile = app.get('params').https.cafile !== false
-    passphrase = app.get('params').passphrase
+    passphrase = app.get('params').https.passphrase
 
     if (app.get('params').https.keyPath) {
       if (app.get('params').https.pfx) {


### PR DESCRIPTION
Closes #348 - Ensures `.https.passphrase` is used instead of `.passphrase`