### PR TITLE
add ignoreCLIFlags param

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ App behavior parameters
   - Default: *[Number]* `43711`.
 - `nodeEnv`: *[String]* Param to override the `NODE_ENV` environment variable.
   - Default: `undefined`.
+- `ignoreCLIFlags`: *[Boolean]* Disables parsing of command line flags.
+  - Default: `undefined`.
 - `generateFolderStructure`: When enabled Roosevelt will generate user specified directories (e.g. MVC parameters and statics parameters).
   - Default: *[Boolean]* `true`.
     - Note: When `package.json` is not present or `rooseveltConfig` is not present in `package.json`, this param will be reset to `false` by default. This is a defensive measure to minimize the risk of files and folders being created in scenarios when they are not wanted.

--- a/lib/sourceFlags.js
+++ b/lib/sourceFlags.js
@@ -4,12 +4,13 @@ require('colors')
 
 const logger = require('./tools/logger')()
 
-module.exports = function (sourceName) {
-  // only process flags when we are sure roosevelt was directly initialized by the command line
-  if (!process.argv[1].includes(sourceName)) {
+module.exports = function (ignoreCLIFlags) {
+  // ignore flags if ignoreCLIFlags param is true
+  if (ignoreCLIFlags) {
     return {}
   }
 
+  let commandLineArgs = process.argv.slice(2)
   let flags = {}
   // convenience blacklist of common words to avoid when sniffing for arg chains
   let blacklist = ['-dev', '-prod', '-help']
@@ -28,7 +29,7 @@ module.exports = function (sourceName) {
     }
   }
 
-  process.argv.forEach((arg, index, array) => {
+  commandLineArgs.forEach((arg, index, array) => {
     switch (arg) {
       // soon to be deprecated flags first
       case '-dev':
@@ -119,8 +120,6 @@ module.exports = function (sourceName) {
                 break
             }
           })
-        } else if (arg.startsWith('-') || arg.startsWith('--')) {
-          logger.warn(`Detected use of unrecognized argument ${arg}. See https://github.com/rooseveltframework/roosevelt#other-useful-scripts for a list of supported arguments.`.yellow)
         }
         break
     }

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -12,7 +12,7 @@ let pkg
 module.exports = function (app) {
   const logger = require('./tools/logger')(app)
   let params = app.get('params')
-  let flags = app.get('flags')
+  let flags
   let appDir = params.appDir
 
   // determine if app has a package.json
@@ -33,15 +33,8 @@ module.exports = function (app) {
     }
   }
 
-  // determine node env
-  if (flags.productionMode) {
-    params.nodeEnv = 'production'
-  } else if (flags.developmentMode) {
-    params.nodeEnv = 'development'
-  } else {
-    // default env to production
-    process.env.NODE_ENV = 'production'
-  }
+  // default env to production
+  process.env.NODE_ENV = 'production'
 
   pkg.rooseveltConfig = pkg.rooseveltConfig || {}
 
@@ -66,6 +59,7 @@ module.exports = function (app) {
     // behavior
     port: checkParams(process.env.HTTP_PORT, process.env.NODE_PORT, params.port, pkg.rooseveltConfig.port, defaultConfig.port),
     nodeEnv: checkParams(params.nodeEnv, pkg.rooseveltConfig.nodeEnv, process.env.NODE_ENV, defaultConfig.nodeEnv),
+    ignoreCLIFlags: checkParams(params.ignoreCLIFlags, pkg.rooseveltConfig.ignoreCLIFlags, defaultConfig.ignoreCLIFlags),
     generateFolderStructure: checkParams(params.generateFolderStructure, pkg.rooseveltConfig.generateFolderStructure, defaultConfig.generateFolderStructure),
     localhostOnly: checkParams(params.localhostOnly, pkg.rooseveltConfig.localhostOnly, defaultConfig.localhostOnly),
     suppressLogs: params.suppressLogs,
@@ -110,6 +104,15 @@ module.exports = function (app) {
     onReqStart: params.onReqStart || undefined,
     onReqBeforeRoute: params.onReqBeforeRoute || undefined,
     onReqAfterRoute: params.onReqAfterRoute || undefined
+  }
+
+  flags = require('./sourceFlags')(params.ignoreCLIFlags) // parse cli args
+
+  // override node env with command line setting
+  if (flags.productionMode) {
+    params.nodeEnv = 'production'
+  } else if (flags.developmentMode) {
+    params.nodeEnv = 'development'
   }
 
   // override NODE_ENV with nodeEnv param
@@ -167,6 +170,7 @@ module.exports = function (app) {
   appModulePath.addPath(path.join(appDir, params.controllersPath, '../'))
 
   app.set('params', params)
+  app.set('flags', flags)
 
   return app
 }

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -10,8 +10,6 @@ const fs = require('fs')
 const fsr = require('./lib/tools/fsr')()
 
 module.exports = function (params) {
-  const sourceName = path.basename(module.parent.filename) // name of file that required roosevelt
-  const flags = require('./lib/sourceFlags')(sourceName) // parse cli args
   params = params || {} // ensure params are an object
 
   // appDir is either specified by the user or sourced from the parent require
@@ -34,11 +32,11 @@ module.exports = function (params) {
   let connections = {}
   let initialized = false
   let faviconPath
+  let flags
 
   // expose initial vars
   app.set('express', express)
   app.set('params', params)
-  app.set('flags', flags)
 
   // source user supplied params
   app = require('./lib/sourceParams')(app)
@@ -46,6 +44,7 @@ module.exports = function (params) {
 
   appName = app.get('appName')
   appEnv = app.get('env')
+  flags = app.get('flags')
 
   logger.log('💭', `Starting ${appName} in ${appEnv} mode...`.bold)
 

--- a/test/unit/cliFlags.js
+++ b/test/unit/cliFlags.js
@@ -700,4 +700,37 @@ describe('Command Line Tests', function () {
       })
     })
   })
+
+  describe('CLI special cases', function () {
+    const appDir = path.join(__dirname, '../app/cliSpecial')
+    let options = { rooseveltPath: '../../../roosevelt' }
+
+    afterEach(function (done) {
+      cleanupTestApp(appDir, (err) => {
+        if (err) {
+          throw err
+        } else {
+          done()
+        }
+      })
+    })
+
+    it('should ignore parsing CLI flags when "ignoreCLIFlags" param is true', function (done) {
+      generateTestApp({
+        appDir: appDir,
+        ignoreCLIFlags: true
+      }, options)
+
+      const testApp = fork(path.join(appDir, 'app.js'), ['--development-mode'], {'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
+
+      testApp.on('message', params => {
+        assert.equal(params.nodeEnv, 'production')
+        testApp.kill('SIGINT')
+      })
+
+      testApp.on('exit', () => {
+        done()
+      })
+    })
+  })
 })

--- a/test/unit/constructorParams.js
+++ b/test/unit/constructorParams.js
@@ -22,6 +22,7 @@ describe('Constructor params', function () {
 
     app = require('../../roosevelt')({
       appDir: appDir,
+      ignoreCLIFlags: true,
       ...config
     })
   })

--- a/test/unit/defaultParams.js
+++ b/test/unit/defaultParams.js
@@ -11,6 +11,7 @@ describe('Default Params', function () {
   before(function () {
     app = require('../../roosevelt')({
       appDir: path.join(__dirname, '../app/defaultParams'),
+      ignoreCLIFlags: true,
       suppressLogs: {
         httpsLogs: true,
         rooseveltLogs: true,

--- a/test/unit/folderStructure.js
+++ b/test/unit/folderStructure.js
@@ -17,6 +17,7 @@ describe('Folder Tests', function () {
 
     app = require('../../roosevelt')({
       appDir: appDir,
+      ignoreCLIFlags: true,
       generateFolderStructure: true,
       suppressLogs: {
         rooseveltLogs: true,

--- a/test/unit/pkgParams.js
+++ b/test/unit/pkgParams.js
@@ -20,7 +20,8 @@ describe('package.json params', function () {
     fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(pkg))
 
     app = require('../../roosevelt')({
-      appDir: appDir
+      appDir: appDir,
+      ignoreCLIFlags: true
     })
   })
 


### PR DESCRIPTION
- This new param will allow the user to selectively disable the parsing of command line flags (`process.argv`). This is useful for testing environments like mocha.
  - As a result, Roosevelt will no longer selectively ignore cli flags under certain conditions. (Closes #340)
- Flags are now parsed after params.