### PR TITLE
Parse HTML validator results from JSON rather than text

### DIFF
--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -154,9 +154,6 @@ module.exports = function (app, callback) {
       let errorList
       let warnings
       let warningList
-      let errorArr
-      let errorArrLength
-      let errorLine
       let pageTitle
       let pageHeader
       let markup
@@ -164,6 +161,26 @@ module.exports = function (app, callback) {
       let markupLine
       let formattedHTML
       let model = {}
+
+      // utility function to parse html validation messages from JSON
+      function parseValidatorMessage (data) {
+        let validationMessage = ''
+
+        // print message on first line
+        validationMessage += `${data.message}\n`
+
+        // determine format of line/column numbers before adding them to message
+        if (data.firstLine) {
+          validationMessage += `From line ${data.firstLine}, column ${data.firstColumn}; to line ${data.lastLine}, column ${data.lastColumn}`
+        } else {
+          validationMessage += `At line ${data.lastLine}, column ${data.lastColumn}`
+        }
+
+        // add a line break after the message
+        validationMessage += '\n\n'
+
+        return validationMessage
+      }
 
       if (req.headers[headerException]) {
         res.set(headerException, true)
@@ -173,6 +190,7 @@ module.exports = function (app, callback) {
         return body =>
           new Promise((resolve) => {
             options.data = body
+            options.format = 'json'
 
             validator(options, (error, htmlErrorData) => {
               if (error) {
@@ -180,34 +198,22 @@ module.exports = function (app, callback) {
                 detectErrors = true
                 pageTitle = 'Cannot connect to validator'
                 pageHeader = 'Unable to connect to HTML validator'
-              } else if (htmlErrorData.indexOf('There were errors.') > -1) {
-                detectErrors = true
+              } else {
                 pageTitle = 'HTML did not pass validation'
                 pageHeader = 'HTML did not pass validator:'
-
-                // Add newline after errors and warnings
                 errorList = '<h2>Errors:</h2>\n<pre class="validatorErrors">'
                 warningList = '<h2>Warnings:</h2>\n<pre class="validatorWarnings">'
-                errorArr = htmlErrorData.split('\n')
-                errorArrLength = errorArr.length
 
-                for (i = 0; i < errorArrLength; i++) {
-                  errorLine = errorArr[i]
-                  if (errorLine.startsWith('Error')) {
-                    if (errorArr[i + 1].startsWith('From line') || errorArr[i + 1].startsWith('At line')) {
-                      errorList += errorLine + '\n' + errorArr[i + 1] + '\n\n'
-                    } else {
-                      errorList += errorLine + '\n\n'
-                    }
-                  } else if (errorLine.startsWith('Warning')) {
+                // parse html validation data
+                htmlErrorData.messages.forEach((item) => {
+                  if (item.type === 'error') {
+                    detectErrors = true
+                    errorList += parseValidatorMessage(item)
+                  } else if (item.subType === 'warning') {
                     warnings = true
-                    if (errorArr[i + 1].startsWith('From line') || errorArr[i + 1].startsWith('At line')) {
-                      warningList += errorLine + '\n' + errorArr[i + 1] + '\n\n'
-                    } else {
-                      warningList += errorLine + '\n\n'
-                    }
+                    warningList += parseValidatorMessage(item)
                   }
-                }
+                })
 
                 errorList += '</pre>'
                 warningList += '</pre>'


### PR DESCRIPTION
[vnu-jar supports JSON output](https://github.com/validator/validator/wiki/Output-%C2%BB-JSON) which in the long run is a much more sustainable way to process the error/warnings data that gets printed in the markup, as opposed to the manual string manipulation done in the past.