### PR TITLE
Added Environment Variable for Detaching Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,11 @@ npm run dev -- -attach-validator
 ```
 - `-a` can also be used.
 
-Roosevelt makes use of an ENV variable to set the validator to an attached or detached state by default. 
-- Set an environment variable `ROOSEVELT_IS_DETACHED` to true for a detached by default validator.
-- Set an environment variable `ROOSEVELT_IS_DETACHED` to false for an attached by default validator.
+Roosevelt makes use of an ENV variable to set the validator to an attached or detached state by default.
 
+(Note that when the ENV variable is set, it overrides the settings in package.json and params.) 
+- Set an environment variable `ROOSEVELT_VALIDATOR` to detached for a detached by default validator.
+- Set an environment variable `ROOSEVELT_VALIDATOR` to attached for an attached by default validator.
 
 Configure how many CPUs your app will run on:
 ```

--- a/README.md
+++ b/README.md
@@ -198,6 +198,33 @@ npm run audit
 
 See also the [the full list of default scripts](https://github.com/rooseveltframework/roosevelt/blob/master/lib/defaults/scripts.json).
 
+Setting Up Environment Variable
+===
+
+Roosevelt's HTML Validator can be set up to be ran in the detached or attached state by default through use of the environment variable, `IS_DETACHED`.
+There are a few different ways that you can go about setting up this environment variable, depending on what OS your machine is running:
+
+Windows
+---
+1. Open up your Control Panel and navigate to System and Security, and then System.
+2. Click on 'Advanced System Settings' in the side bar and then the 'Environment Variables' button.
+3. Press 'New'. In the 'Variable name' box, type `IS_DETACHED`.
+4. In the 'Variable value' box, type true if you want your validator detached by default, or false for attached by default.
+5. Click 'Ok' until you are back at the System Properties window, then press 'Apply' and 'Ok'
+6. Your environment variable for detaching/attaching the HTML validator is now set up and ready to be used.
+* If you would like to change the value associated with `IS_DETACHED`, in the command prompt, type `set IS_DETACHED=` immediately followed by the desired true/false value.
+* You can check your current value of `IS_DETACHED` at any time by typing `echo %IS_DETACHED%` in the command prompt.
+
+Linux
+---
+1. Open up a shell and make sure you are in your home directory.
+2. Type `vim ~/.bashrc`. This will open a file for editing in the shell.
+3. Press `i` on your keyboard to enter 'Insert mode' and add `export IS_DETACHED='true'` (or false) on a blank line.
+4. SAVE the file by: press the `Escape` key --> type a colon (SHIFT + ;) --> type an `x` next to the colon that appears --> hit enter.
+5. Current user must LOG OUT and log back in for changes to take place.
+6. Open up a shell again and type `echo $IS_DETACHED$` to confirm that the changes have been saved.
+* You can change the value associated with `IS_DETACHED` anytime by repeating steps over again with different value assigned in export statement.
+
 Default directory structure
 ===
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ npm run dev -- -attach-validator
 ```
 - `-a` can also be used.
 
+Roosevelt makes use of an ENV variable to set the validator to an attached or detached state by default. 
+- Set an environment variable `ROOSEVELT_IS_DETACHED` to true for a detached by default validator.
+- Set an environment variable `ROOSEVELT_IS_DETACHED` to false for an attached by default validator.
+
+
 Configure how many CPUs your app will run on:
 ```
 npm run dev -- --cores 2
@@ -197,33 +202,6 @@ npm run audit
 ```
 
 See also the [the full list of default scripts](https://github.com/rooseveltframework/roosevelt/blob/master/lib/defaults/scripts.json).
-
-Setting Up Environment Variable
-===
-
-Roosevelt's HTML Validator can be set up to be ran in the detached or attached state by default through use of the environment variable, `IS_DETACHED`.
-There are a few different ways that you can go about setting up this environment variable, depending on what OS your machine is running:
-
-Windows
----
-1. Open up your Control Panel and navigate to System and Security, and then System.
-2. Click on 'Advanced System Settings' in the side bar and then the 'Environment Variables' button.
-3. Press 'New'. In the 'Variable name' box, type `IS_DETACHED`.
-4. In the 'Variable value' box, type true if you want your validator detached by default, or false for attached by default.
-5. Click 'Ok' until you are back at the System Properties window, then press 'Apply' and 'Ok'
-6. Your environment variable for detaching/attaching the HTML validator is now set up and ready to be used.
-* If you would like to change the value associated with `IS_DETACHED`, in the command prompt, type `set IS_DETACHED=` immediately followed by the desired true/false value.
-* You can check your current value of `IS_DETACHED` at any time by typing `echo %IS_DETACHED%` in the command prompt.
-
-Linux
----
-1. Open up a shell and make sure you are in your home directory.
-2. Type `vim ~/.bashrc`. This will open a file for editing in the shell.
-3. Press `i` on your keyboard to enter 'Insert mode' and add `export IS_DETACHED='true'` (or false) on a blank line.
-4. SAVE the file by: press the `Escape` key --> type a colon (SHIFT + ;) --> type an `x` next to the colon that appears --> hit enter.
-5. Current user must LOG OUT and log back in for changes to take place.
-6. Open up a shell again and type `echo $IS_DETACHED$` to confirm that the changes have been saved.
-* You can change the value associated with `IS_DETACHED` anytime by repeating steps over again with different value assigned in export statement.
 
 Default directory structure
 ===

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -131,9 +131,9 @@ module.exports = function (app) {
   } else if (flags.attachValidator) {
     params.htmlValidator.separateProcess.enable = false
   }
-  if (process.env.IS_DETACHED === 'true') {
+  if (process.env.ROOSEVELT_IS_DETACHED === 'true') {
     params.htmlValidator.separateProcess.enable = true
-  } else if (process.env.IS_DETACHED === 'false') {
+  } else if (process.env.ROOSEVELT_IS_DETACHED === 'false') {
     params.htmlValidator.separateProcess.enable = false
   }
   if (flags.productionMode) {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -126,9 +126,9 @@ module.exports = function (app) {
   } else if (flags.disableValidator) {
     params.htmlValidator.enable = false
   }
-  if (process.env.ROOSEVELT_IS_DETACHED === 'true') {
+  if (process.env.ROOSEVELT_VALIDATOR === 'detached') {
     params.htmlValidator.separateProcess.enable = true
-  } else if (process.env.ROOSEVELT_IS_DETACHED === 'false') {
+  } else if (process.env.ROOSEVELT_VALIDATOR === 'attached') {
     params.htmlValidator.separateProcess.enable = false
   }
   if (flags.backgroundValidator) {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -127,14 +127,14 @@ module.exports = function (app) {
     params.htmlValidator.enable = false
   }
   if (flags.backgroundValidator) {
-    params.htmlValidator.separateProcess = true
+    params.htmlValidator.separateProcess.enable = true
   } else if (flags.attachValidator) {
-    params.htmlValidator.separateProcess = false
+    params.htmlValidator.separateProcess.enable = false
   }
   if (process.env.IS_DETACHED === 'true') {
-    params.htmlValidator.separateProcess = true
+    params.htmlValidator.separateProcess.enable = true
   } else if (process.env.IS_DETACHED === 'false') {
-    params.htmlValidator.separateProcess = false
+    params.htmlValidator.separateProcess.enable = false
   }
   if (flags.productionMode) {
     params.alwaysHostPublic = true

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -126,14 +126,14 @@ module.exports = function (app) {
   } else if (flags.disableValidator) {
     params.htmlValidator.enable = false
   }
-  if (flags.backgroundValidator) {
-    params.htmlValidator.separateProcess.enable = true
-  } else if (flags.attachValidator) {
-    params.htmlValidator.separateProcess.enable = false
-  }
   if (process.env.ROOSEVELT_IS_DETACHED === 'true') {
     params.htmlValidator.separateProcess.enable = true
   } else if (process.env.ROOSEVELT_IS_DETACHED === 'false') {
+    params.htmlValidator.separateProcess.enable = false
+  }
+  if (flags.backgroundValidator) {
+    params.htmlValidator.separateProcess.enable = true
+  } else if (flags.attachValidator) {
     params.htmlValidator.separateProcess.enable = false
   }
   if (flags.productionMode) {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -121,20 +121,20 @@ module.exports = function (app) {
   app.set('env', process.env.NODE_ENV)
 
   // give priority to params overridden by CLI/env
-  if (process.env.IS_DETACHED) {
-    params.htmlValidator.separateProcess.enable = true
-  } else if (!process.env.IS_DETACHED) {
-    params.htmlValidator.separateProcess.enable = false
-  }
   if (flags.enableValidator) {
     params.htmlValidator.enable = true
   } else if (flags.disableValidator) {
     params.htmlValidator.enable = false
   }
   if (flags.backgroundValidator) {
-    params.htmlValidator.separateProcess.enable = true
+    params.htmlValidator.separateProcess = true
   } else if (flags.attachValidator) {
-    params.htmlValidator.separateProcess.enable = false
+    params.htmlValidator.separateProcess = false
+  }
+  if (process.env.IS_DETACHED === 'true') {
+    params.htmlValidator.separateProcess = true
+  } else if (process.env.IS_DETACHED === 'false') {
+    params.htmlValidator.separateProcess = false
   }
   if (flags.productionMode) {
     params.alwaysHostPublic = true

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -121,6 +121,11 @@ module.exports = function (app) {
   app.set('env', process.env.NODE_ENV)
 
   // give priority to params overridden by CLI/env
+  if (process.env.IS_DETACHED) {
+    params.htmlValidator.separateProcess.enable = true
+  } else if (!process.env.IS_DETACHED) {
+    params.htmlValidator.separateProcess.enable = false
+  }
   if (flags.enableValidator) {
     params.htmlValidator.enable = true
   } else if (flags.disableValidator) {

--- a/test/unit/envParams.js
+++ b/test/unit/envParams.js
@@ -17,24 +17,24 @@ describe('ENV Params Test', function () {
   let app
 
   it('should change the enable param to true', function (done) {
-    const temp = process.env.ROOSEVELT_IS_DETACHED
-    process.env.ROOSEVELT_IS_DETACHED = true
+    const temp = process.env.ROOSEVELT_VALIDATOR
+    process.env.ROOSEVELT_VALIDATOR = 'detached'
     app = roosevelt({
       ...appConfig
     })
     assert.equal(app.expressApp.get('params').htmlValidator.separateProcess.enable, true)
-    process.env.ROOSEVELT_IS_DETACHED = temp
+    process.env.ROOSEVELT_VALIDATOR = temp
     done()
   })
 
   it('should change the enable param to false', function (done) {
-    const temp = process.env.ROOSEVELT_IS_DETACHED
-    process.env.ROOSEVELT_IS_DETACHED = false
+    const temp = process.env.ROOSEVELT_VALIDATOR
+    process.env.ROOSEVELT_VALIDATOR = 'attached'
     app = roosevelt({
       ...appConfig
     })
     assert.equal(app.expressApp.get('params').htmlValidator.separateProcess.enable, false)
-    process.env.ROOSEVELT_IS_DETACHED = temp
+    process.env.ROOSEVELT_VALIDATOR = temp
     done()
   })
 })

--- a/test/unit/envParams.js
+++ b/test/unit/envParams.js
@@ -1,0 +1,40 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const path = require('path')
+const roosevelt = require('../../roosevelt')
+
+describe('ENV Params Test', function () {
+  const appConfig = {
+    appDir: path.join(__dirname, '../app/envParams'),
+    ignoreCLIFlags: true,
+    suppressLogs: {
+      httpsLogs: true,
+      rooseveltLogs: true,
+      rooseveltWarnings: true
+    }
+  }
+  let app
+
+  it('should change the enable param to true', function (done) {
+    const temp = process.env.ROOSEVELT_IS_DETACHED
+    process.env.ROOSEVELT_IS_DETACHED = true
+    app = roosevelt({
+      ...appConfig
+    })
+    assert.equal(app.expressApp.get('params').htmlValidator.separateProcess.enable, true)
+    process.env.ROOSEVELT_IS_DETACHED = temp
+    done()
+  })
+
+  it('should change the enable param to false', function (done) {
+    const temp = process.env.ROOSEVELT_IS_DETACHED
+    process.env.ROOSEVELT_IS_DETACHED = false
+    app = roosevelt({
+      ...appConfig
+    })
+    assert.equal(app.expressApp.get('params').htmlValidator.separateProcess.enable, false)
+    process.env.ROOSEVELT_IS_DETACHED = temp
+    done()
+  })
+})


### PR DESCRIPTION
(closes #221)

This change will allow for the use of an environment variable for defaulting the HTML Validator to a detached or attached state. This change:

- [x] Added existence of "IS_DETACHED" environment variable with true or false value.
- [x] Mentioned ENV var in README section related to validator
- Allows for faster testing and general usage of apps. (i.e. Having the environment variable set to true allows your validator to run in a detached state with only typing `npm run dev` and no additional flags everytime across all shells)