### PR TITLE
killValidator Speed Up

### DIFF
--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -90,16 +90,14 @@ module.exports = function (app, callback) {
 
         validatorProcess.stderr.on('data', (data) => {
           if (`${data}`.includes('INFO:oejs.Server:main: Started')) {
-            setTimeout(() => {
-              clearTimeout(validatorTimeout)
-              if (params.htmlValidator.separateProcess.enable) {
-                logger.log('🎧', `HTML validator listening on port: ${params.htmlValidator.port} (as a detached, backgrounded process)`.bold)
-              } else {
-                logger.log('🎧', `HTML validator listening on port: ${params.htmlValidator.port}`.bold)
-              }
-              applyValidatorMiddleware()
-              resolve()
-            }, 5000)
+            clearTimeout(validatorTimeout)
+            if (params.htmlValidator.separateProcess.enable) {
+              logger.log('🎧', `HTML validator listening on port: ${params.htmlValidator.port} (as a detached, backgrounded process)`.bold)
+            } else {
+              logger.log('🎧', `HTML validator listening on port: ${params.htmlValidator.port}`.bold)
+            }
+            applyValidatorMiddleware()
+            resolve()
           }
         })
 

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -124,6 +124,10 @@ function getOpenPorts () {
     }
     scanPotentialPorts()
   })
+  // time out scanning for validator after 100000ms then scans results
+  timer = setTimeout(function () {
+    scanResults()
+  }, 100000)
 }
 
 /**

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -109,13 +109,16 @@ function getOpenPorts () {
       scanFoundPorts()
     })
   }
-  if (process.platform === 'darwin') {
+  if (process.platform === 'darwin' || process.platform === 'linux') {
     exec('netstat -ap tcp | grep -i "listen"', function (err, stdout, stderr) {
       if (err) {
         logger.error(`${err}`.red)
       }
       if (stderr) {
-        logger.error(`${stderr}`.red)
+        // ignore permissions error message on linux
+        if (!stderr.includes('(Not all processes')) {
+          logger.error(`${stderr}`.red)
+        }
       }
 
       portString = stdout.match(/\d{4,5}/gm) + ''

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -110,8 +110,30 @@ function getOpenPorts () {
       scanFoundPorts()
     })
   }
-  if (process.platform === 'darwin' || process.platform === 'linux') {
+  if (process.platform === 'darwin') {
     exec('netstat -ap tcp | grep -i "listen"', function (err, stdout, stderr) {
+      if (err) {
+        logger.error(`${err}`.red)
+      }
+      if (stderr) {
+        // ignore permissions error message on linux
+        if (!stderr.includes('(Not all processes')) {
+          logger.error(`${stderr}`.red)
+        }
+      }
+
+      portString = stdout.match(/\d{4,5}/gm) + ''
+
+      if (!portString) {
+        throw new TypeError('No open ports found.'.red)
+      } else {
+        portHolder = arrayify(portString)
+      }
+      scanFoundPorts()
+    })
+  }
+  if (process.platform === 'linux') {
+    exec('netstat -lnt', function (err, stdout, stderr) {
       if (err) {
         logger.error(`${err}`.red)
       }

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -1,300 +1,35 @@
 require('colors')
 
-const spawn = require('child_process').spawn
-const portscanner = require('portscanner')
-const path = require('path')
-const http = require('http')
+const ps = require('ps-node')
 const fkill = require('fkill')
 const logger = require('../tools/logger')()
-const appDir = process.cwd()
-let foundValidator = false
-let portHolder = []
-let finalPorts = []
-let args = []
-let portString
-let pkg
-let rooseveltConfig
-let commandString
-let cmdProcess
-let promises = []
-let finalPromises = []
-
-let validatorOptions = {
-  url: 'http://localhost',
-  method: 'GET',
-  headers: {
-    'User-Agent': 'request'
-  }
-}
-
-try {
-  pkg = require(path.join(appDir, 'package.json'))
-  rooseveltConfig = pkg.rooseveltConfig
-  validatorOptions.port = rooseveltConfig.htmlValidator.port || '8888'
-} catch (e) {
-  validatorOptions.port = '8888'
-}
 
 /**
- * gets validator, if not on specified port, calls to search function
- * @function getValidator
+ * looks for validator and kills it when found
+ * @function lookupValidator
  */
-function getValidator () {
-  http.get(validatorOptions, function (res) {
-    const { statusCode } = res
-
-    let error
-    let rawData = ''
-
-    if (statusCode !== 200) {
-      error = new Error(`Request Failed.\nStatus Code: ${statusCode}`)
+function lookupValidator () {
+  logger.log('Scanning for validator now...'.yellow)
+  ps.lookup({
+    command: 'java',
+    arguments: 'nu.validator.servlet.Main'
+  }, function (err, resultList) {
+    if (err) {
+      // throw new Error(err);
     }
-    if (error) {
-      // consume 404 response data
-      logger.error(error.message)
-      res.resume()
-      getOpenPorts()
+    if (resultList.length === 0) {
+      logger.error('Could not find the validator at this time, please make sure that the validator is running.'.red)
+      process.exit()
     }
-
-    res.setEncoding('utf8')
-
-    res.on('data', (chunk) => {
-      rawData += chunk
-    })
-
-    res.on('end', () => {
-      if (rawData.includes('Nu Html Checker')) {
-        logger.log('✔️', `Validator successfully found on port: ${validatorOptions.port}`.green)
-        foundValidator = true
-        killValidator(validatorOptions.port)
-      } else {
-        logger.warn(`Could not find validator on port: ${validatorOptions.port}. Scanning for validator now...`.yellow)
-        getOpenPorts()
+    resultList.forEach(function (process) {
+      if (process) {
+        logger.log('✔️', `Validator successfully found with PID: ${process.pid}`.green)
+        fkill(`${process.pid}`, {force: true}).then(() => {
+          logger.log('✔️', `Killed process with PID: ${process.pid}`.green)
+        })
       }
     })
-  }).on('error', (error) => {
-    if (error.message.includes('ECONNREFUSED')) {
-      logger.warn(`Could not find validator on port: ${validatorOptions.port}. Scanning for validator now...`.yellow)
-      getOpenPorts()
-    }
   })
+  // logger.log('Found and closed all validators at the moment, exiting killValidator'.green)
 }
-getValidator()
-
-/**
- * uses command line to get list of ports w/ potentially open connection
- * @function getOpenPorts
- */
-function getOpenPorts () {
-  if (process.platform === 'win32' || process.platform === 'darwin') {
-    commandString = 'netstat'
-    args = ['-an']
-  }
-  if (process.platform === 'linux') {
-    commandString = 'netstat'
-    args = ['-lnt']
-  }
-  cmdProcess = spawn(commandString, [args])
-
-  let output = ''
-
-  cmdProcess.stdout.on('data', data => {
-    output += data.toString()
-  })
-  cmdProcess.on('close', code => {
-    portString = output.match(/\d{4,5}/gm) + ''
-
-    portHolder = arrayify(portString)
-
-    scanPotentialPorts(portHolder)
-  })
-}
-
-/**
- * takes string from stdout and turns it into array of ports, ignoring duplicates
- * @function arrayify
- */
-function arrayify (portString) {
-  let i
-  let ar = portString.trim().split(',')
-  let final = []
-  for (i = 0; i < ar.length; i++) {
-    if (!final.includes(ar[i], 0) && ar[i] < 65536 && ar[i] >= 1000) {
-      final.push(ar[i])
-    }
-  }
-  return final
-}
-
-/**
- * sends potential ports to portscanner module for confirmation, then calls to scan through confirmed ports
- * @function scanPotentialPorts
- */
-function scanPotentialPorts (portHolder) {
-  portHolder.forEach((port) => {
-    promises.push(
-      new Promise((resolve, reject) => {
-        portscanner.checkPortStatus(port, '0.0.0.0', function (error, status) {
-          if (status === 'open') {
-            finalPorts.push(port)
-          }
-          if (error) {
-            // continue
-          }
-          resolve()
-        })
-      })
-    )
-  })
-
-  Promise.all(promises)
-    .then(() => {
-      rScanFinalPorts(finalPorts)
-    })
-    .catch((err) => {
-      logger.error(err)
-    })
-}
-
-function rScanFinalPorts (finalPorts) {
-  console.log(finalPorts)
-  finalPorts.forEach((cPort) => {
-    finalPromises.push(
-      new Promise((resolve, reject) => {
-        let options = {
-          url: 'http://localhost:',
-          port: cPort,
-          method: 'GET',
-          headers: {
-            'User-Agent': 'request'
-          }
-        }
-
-        console.log('Port being promised: ' + cPort)
-
-        http.get(options, function (res) {
-          const { statusCode } = res
-          console.log('Status code: ' + statusCode + ' on port: ' + cPort)
-
-          if (statusCode === 503) {
-            res.resume()
-            resolve()
-          }
-
-          res.setEncoding('utf8')
-          console.log(cPort + 'Hello')
-          let rawData = ''
-
-          res.on('data', chunk => {
-            rawData += chunk
-            console.log(cPort + '\'s data: ' + rawData)
-          })
-
-          res.on('end', () => {
-            if (rawData.includes('Nu Html Checker')) {
-              logger.log('✔️', `Validator successfully found on port: ${cPort}`.green)
-              foundValidator = true
-              killValidator(cPort)
-            }
-            resolve()
-          })
-        }).on('error', error => {
-          if (!error.message.includes('socket hang up')) {
-            if (!error.message.includes('ECONNRESET')) {
-              logger.error(`${error}`.red)
-            }
-          }
-          resolve()
-        })
-      })
-    )
-  })
-
-  Promise.all(finalPromises)
-    .then(() => {
-      console.log('Hello world')
-      scanResults()
-    })
-    .catch((err) => {
-      logger.error(err)
-    })
-}
-
-// function scanFinalPorts (finalPorts) {
-//   let index = 0
-//   while (index < finalPorts.length) {
-//     cPort = finalPorts[index]
-//     checkForValidator(cPort)
-//     index++
-//   }
-//   // wait for while loop to finish, if all ports in array were exhausted we scan results
-//   setTimeout(function () {
-//     if (index === finalPorts.length) {
-//       scanResults()
-//     }
-//   }, 5000)
-// }
-// /**
-//  * makes request to port, checking for validator
-//  * @function checkForValidator
-//  * @param {number} cPort - current final port being checked
-//  */
-// function checkForValidator (cPort) {
-//   let options = {
-//     url: 'http://localhost:',
-//     port: cPort,
-//     method: 'GET',
-//     headers: {
-//       'User-Agent': 'request'
-//     }
-//   }
-//   http.get(options, function (res) {
-//     res.setEncoding('utf8')
-
-//     let rawData = ''
-
-//     res.on('data', (chunk) => {
-//       rawData += chunk
-//     })
-
-//     res.on('end', () => {
-//       if (rawData.includes('Nu Html Checker')) {
-//         logger.log('✔️', `Validator successfully found on port: ${cPort}`.green)
-//         foundValidator = true
-//         killValidator(cPort)
-//       }
-//     })
-//   }).on('error', (error) => {
-//     if (!error.message.includes('socket hang up')) {
-//       if (!error.message.includes('ECONNRESET')) {
-//         logger.error(`${error}`.red)
-//       }
-//     }
-//     // possibly revisit here if errors show up
-//   })
-// }
-
-/**
- * checks to see if a validator was found at the end of script runtime
- * @function scanResults
- */
-function scanResults () {
-  if (foundValidator === false) {
-    logger.error('Could not find the validator at this time, please make sure that the validator is running.'.red)
-    process.exit()
-  } else {
-    logger.log('Found and closed all validators at the moment, exiting killValidator'.green)
-    process.exit()
-  }
-}
-
-/**
- * makes call to fkill module sending port confirmed to have validator on it
- * @function killValidator
- * @param {number} currentPort
- */
-function killValidator (currentPort) {
-  fkill(`:${currentPort}`, {force: true}).then(() => {
-    logger.log('✔️', `Killed process on port: ${currentPort}`.green)
-  })
-}
+lookupValidator()

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -179,6 +179,12 @@ function tryValidatorNewPorts () {
     scanThisPort(cPort)
     index++
   }
+  setTimeout(function () {
+    if (index === finalPorts.length) {
+      clearTimeout(timer)
+      scanResults()
+    }
+  }, 5000)
 }
 
 function scanThisPort (cPort) {
@@ -219,7 +225,9 @@ function scanThisPort (cPort) {
       })
     }).on('error', (error) => {
       if (!error.message.includes('socket hang up')) {
-        logger.error(`${error}`.red)
+        if (!error.message.includes('ECONNRESET')) {
+          logger.error(`${error}`.red)
+        }
       }
       // possibly revisit here if errors show up
     })

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -90,26 +90,44 @@ getValidator()
 
 function getOpenPorts () {
   // grabs potentially open connections
-  exec('netstat -an', function (err, stdout, stderr) {
-    if (err) {
-      logger.error(`${err}`.red)
-    }
-    if (stderr) {
-      logger.error(`${stderr}`.red)
-    }
+  if (process.platform === 'win32') {
+    exec('netstat -an', function (err, stdout, stderr) {
+      if (err) {
+        logger.error(`${err}`.red)
+      }
+      if (stderr) {
+        logger.error(`${stderr}`.red)
+      }
 
-    portString = stdout.match(/\d{4,5}/gm) + ''
+      portString = stdout.match(/\d{4,5}/gm) + ''
 
-    if (!portString) {
-      throw new TypeError('No open ports found.'.red)
-    } else {
-      portHolder = arrayify(portString)
-    }
-    scanFoundPorts()
-    setTimeout(function () {
-      process.exit()
-    }, 8000)
-  })
+      if (!portString) {
+        throw new TypeError('No open ports found.'.red)
+      } else {
+        portHolder = arrayify(portString)
+      }
+      scanFoundPorts()
+    })
+  }
+  if (process.platform === 'darwin') {
+    exec('lsof -nP -i4', function (err, stdout, stderr) {
+      if (err) {
+        logger.error(`${err}`.red)
+      }
+      if (stderr) {
+        logger.error(`${stderr}`.red)
+      }
+
+      portString = stdout.match(/\d{4,5}/gm) + ''
+
+      if (!portString) {
+        throw new TypeError('No open ports found.'.red)
+      } else {
+        portHolder = arrayify(portString)
+      }
+      scanFoundPorts()
+    })
+  }
 }
 
 // takes string from stdout and turns it into array of ports

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -9,7 +9,7 @@ const logger = require('../tools/logger')();
  * @function lookupFunction
  */
 (function lookupFunction () {
-  logger.log('Scanning for validator now...'.yellow)
+  logger.log('🔎', 'Scanning for validator now...'.yellow)
   ps.lookup({
     command: 'java',
     arguments: 'nu.validator.servlet.Main'

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -4,11 +4,9 @@ const spawn = require('child_process').spawn
 const portscanner = require('portscanner')
 const path = require('path')
 const http = require('http')
-const net = require('net')
 const fkill = require('fkill')
 const logger = require('../tools/logger')()
 const appDir = process.cwd()
-let host = 'localhost'
 let foundValidator = false
 let portHolder = []
 let finalPorts = []
@@ -17,7 +15,6 @@ let cPort
 let portString
 let pkg
 let rooseveltConfig
-let timeout = 2000
 let commandString
 let cmdProcess
 
@@ -77,16 +74,13 @@ function getValidator () {
   }).on('error', (error) => {
     if (error.message.includes('ECONNREFUSED')) {
       logger.warn(`Could not find validator on port: ${validatorOptions.port}. Scanning for validator now...`.yellow)
+      req.abort()
       getOpenPorts()
     } else {
       logger.error(`Error Occurred: ${error.message}. Scanning for validator now`.red)
+      req.abort()
       getOpenPorts()
     }
-  }).on('socket', (socket) => {
-    socket.setTimeout(timeout)
-    socket.on('timeout', () => {
-      req.abort()
-    })
   })
 }
 getValidator()
@@ -194,45 +188,38 @@ function scanFinalPorts () {
  * @param {number} cPort - current final port being checked
  */
 function checkForValidator (cPort) {
-  let s = new net.Socket()
+  let options = {
+    url: 'http://localhost:',
+    port: cPort,
+    method: 'GET',
+    headers: {
+      'User-Agent': 'request'
+    }
+  }
+  let req = http.get(options, function (res) {
+    res.setEncoding('utf8')
 
-  s.setTimeout(2000, function () {
-    s.destroy()
-  })
+    let rawData = ''
 
-  s.connect(cPort, host, function () {
-    let options = {
-      url: 'http://localhost:',
-      port: cPort,
-      method: 'GET',
-      headers: {
-        'User-Agent': 'request'
+    res.on('data', (chunk) => {
+      rawData += chunk
+    })
+
+    res.on('end', () => {
+      if (rawData.includes('Nu Html Checker')) {
+        logger.log('✔️', `Validator successfully found on port: ${cPort}`.green)
+        foundValidator = true
+        killValidator(cPort)
+      }
+    })
+  }).on('error', (error) => {
+    if (!error.message.includes('socket hang up')) {
+      if (!error.message.includes('ECONNRESET')) {
+        logger.error(`${error}`.red)
+        req.abort()
       }
     }
-    http.get(options, function (res) {
-      res.setEncoding('utf8')
-
-      let rawData = ''
-
-      res.on('data', (chunk) => {
-        rawData += chunk
-      })
-
-      res.on('end', () => {
-        if (rawData.includes('Nu Html Checker')) {
-          logger.log('✔️', `Validator successfully found on port: ${cPort}`.green)
-          foundValidator = true
-          killValidator(cPort)
-        }
-      })
-    }).on('error', (error) => {
-      if (!error.message.includes('socket hang up')) {
-        if (!error.message.includes('ECONNRESET')) {
-          logger.error(`${error}`.red)
-        }
-      }
-      // possibly revisit here if errors show up
-    })
+    // possibly revisit here if errors show up
   })
 }
 

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -11,13 +11,13 @@ let foundValidator = false
 let portHolder = []
 let finalPorts = []
 let args = []
-let cPort
 let portString
 let pkg
 let rooseveltConfig
 let commandString
 let cmdProcess
 let promises = []
+let finalPromises = []
 
 let validatorOptions = {
   url: 'http://localhost',
@@ -149,66 +149,130 @@ function scanPotentialPorts (portHolder) {
 
   Promise.all(promises)
     .then(() => {
-      scanFinalPorts(finalPorts)
+      rScanFinalPorts(finalPorts)
     })
     .catch((err) => {
       logger.error(err)
     })
 }
 
-function scanFinalPorts (finalPorts) {
-  let index = 0
-  while (index < finalPorts.length) {
-    cPort = finalPorts[index]
-    checkForValidator(cPort)
-    index++
-  }
-  // wait for while loop to finish, if all ports in array were exhausted we scan results
-  setTimeout(function () {
-    if (index === finalPorts.length) {
-      scanResults()
-    }
-  }, 5000)
-}
-/**
- * makes request to port, checking for validator
- * @function checkForValidator
- * @param {number} cPort - current final port being checked
- */
-function checkForValidator (cPort) {
-  let options = {
-    url: 'http://localhost:',
-    port: cPort,
-    method: 'GET',
-    headers: {
-      'User-Agent': 'request'
-    }
-  }
-  http.get(options, function (res) {
-    res.setEncoding('utf8')
+function rScanFinalPorts (finalPorts) {
+  console.log(finalPorts)
+  finalPorts.forEach((cPort) => {
+    finalPromises.push(
+      new Promise((resolve, reject) => {
+        let options = {
+          url: 'http://localhost:',
+          port: cPort,
+          method: 'GET',
+          headers: {
+            'User-Agent': 'request'
+          }
+        }
 
-    let rawData = ''
+        console.log('Port being promised: ' + cPort)
 
-    res.on('data', (chunk) => {
-      rawData += chunk
-    })
+        http.get(options, function (res) {
+          const { statusCode } = res
+          console.log('Status code: ' + statusCode + ' on port: ' + cPort)
 
-    res.on('end', () => {
-      if (rawData.includes('Nu Html Checker')) {
-        logger.log('✔️', `Validator successfully found on port: ${cPort}`.green)
-        foundValidator = true
-        killValidator(cPort)
-      }
-    })
-  }).on('error', (error) => {
-    if (!error.message.includes('socket hang up')) {
-      if (!error.message.includes('ECONNRESET')) {
-        logger.error(`${error}`.red)
-      }
-    }
-    // possibly revisit here if errors show up
+          if (statusCode === 503) {
+            res.resume()
+            resolve()
+          }
+
+          res.setEncoding('utf8')
+          console.log(cPort + 'Hello')
+          let rawData = ''
+
+          res.on('data', chunk => {
+            rawData += chunk
+            console.log(cPort + '\'s data: ' + rawData)
+          })
+
+          res.on('end', () => {
+            if (rawData.includes('Nu Html Checker')) {
+              logger.log('✔️', `Validator successfully found on port: ${cPort}`.green)
+              foundValidator = true
+              killValidator(cPort)
+            }
+            resolve()
+          })
+        }).on('error', error => {
+          if (!error.message.includes('socket hang up')) {
+            if (!error.message.includes('ECONNRESET')) {
+              logger.error(`${error}`.red)
+            }
+          }
+          resolve()
+        })
+      })
+    )
   })
+
+  Promise.all(finalPromises)
+    .then(() => {
+      console.log('Hello world')
+      scanResults()
+    })
+    .catch((err) => {
+      logger.error(err)
+    })
 }
+
+// function scanFinalPorts (finalPorts) {
+//   let index = 0
+//   while (index < finalPorts.length) {
+//     cPort = finalPorts[index]
+//     checkForValidator(cPort)
+//     index++
+//   }
+//   // wait for while loop to finish, if all ports in array were exhausted we scan results
+//   setTimeout(function () {
+//     if (index === finalPorts.length) {
+//       scanResults()
+//     }
+//   }, 5000)
+// }
+// /**
+//  * makes request to port, checking for validator
+//  * @function checkForValidator
+//  * @param {number} cPort - current final port being checked
+//  */
+// function checkForValidator (cPort) {
+//   let options = {
+//     url: 'http://localhost:',
+//     port: cPort,
+//     method: 'GET',
+//     headers: {
+//       'User-Agent': 'request'
+//     }
+//   }
+//   http.get(options, function (res) {
+//     res.setEncoding('utf8')
+
+//     let rawData = ''
+
+//     res.on('data', (chunk) => {
+//       rawData += chunk
+//     })
+
+//     res.on('end', () => {
+//       if (rawData.includes('Nu Html Checker')) {
+//         logger.log('✔️', `Validator successfully found on port: ${cPort}`.green)
+//         foundValidator = true
+//         killValidator(cPort)
+//       }
+//     })
+//   }).on('error', (error) => {
+//     if (!error.message.includes('socket hang up')) {
+//       if (!error.message.includes('ECONNRESET')) {
+//         logger.error(`${error}`.red)
+//       }
+//     }
+//     // possibly revisit here if errors show up
+//   })
+// }
 
 /**
  * checks to see if a validator was found at the end of script runtime

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -18,6 +18,7 @@ let pkg
 let timer
 let rooseveltConfig
 let timeout = 2000
+let commandString
 
 let validatorOptions = {
   url: 'http://localhost',
@@ -95,65 +96,34 @@ getValidator()
  */
 function getOpenPorts () {
   if (process.platform === 'win32') {
-    exec('netstat -an', function (err, stdout, stderr) {
-      if (err) {
-        logger.error(`${err}`.red)
-      }
-      if (stderr) {
-        logger.error(`${stderr}`.red)
-      }
-
-      portString = stdout.match(/\d{4,5}/gm) + ''
-
-      if (!portString) {
-        throw new TypeError('No open ports found.'.red)
-      } else {
-        portHolder = arrayify(portString)
-      }
-      scanPotentialPorts()
-    })
+    commandString = 'netstat -an'
   }
   if (process.platform === 'darwin') {
-    exec('netstat -ap tcp | grep -i "listen"', function (err, stdout, stderr) {
-      if (err) {
-        logger.error(`${err}`.red)
-      }
-      if (stderr) {
-        logger.error(`${stderr}`.red)
-      }
-
-      portString = stdout.match(/\d{4,5}/gm) + ''
-
-      if (!portString) {
-        throw new TypeError('No open ports found.'.red)
-      } else {
-        portHolder = arrayify(portString)
-      }
-      scanPotentialPorts()
-    })
+    commandString = 'netstat -ap tcp | grep -i "listen"'
   }
   if (process.platform === 'linux') {
-    exec('netstat -lnt', function (err, stdout, stderr) {
-      if (err) {
-        logger.error(`${err}`.red)
-      }
-      if (stderr) {
-        // ignore permissions error message on linux
-        if (!stderr.includes('(Not all processes')) {
-          logger.error(`${stderr}`.red)
-        }
-      }
-
-      portString = stdout.match(/\d{4,5}/gm) + ''
-
-      if (!portString) {
-        throw new TypeError('No open ports found.'.red)
-      } else {
-        portHolder = arrayify(portString)
-      }
-      scanPotentialPorts()
-    })
+    commandString = 'netstat -lnt'
   }
+  exec(commandString, function (err, stdout, stderr) {
+    if (err) {
+      logger.error(`${err}`.red)
+    }
+    if (stderr) {
+      // ignore permissions error message on linux
+      if (!stderr.includes('(Not all processes')) {
+        logger.error(`${stderr}`.red)
+      }
+    }
+
+    portString = stdout.match(/\d{4,5}/gm) + ''
+
+    if (!portString) {
+      throw new TypeError('No open ports found.'.red)
+    } else {
+      portHolder = arrayify(portString)
+    }
+    scanPotentialPorts()
+  })
   // time out scanning for validator after 100000ms then scans results
   timer = setTimeout(function () {
     scanResults()

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -15,7 +15,6 @@ let finalPorts = []
 let cPort
 let portString
 let pkg
-let timer
 let rooseveltConfig
 let timeout = 2000
 let commandString
@@ -118,10 +117,6 @@ function getOpenPorts () {
 
     scanPotentialPorts()
   })
-  // time out scanning for validator after 100000ms then scans results
-  timer = setTimeout(function () {
-    scanResults()
-  }, 100000)
 }
 
 /**
@@ -187,7 +182,6 @@ function scanFinalPorts () {
   // wait for while loop to finish, if all ports in array were exhausted we scan results
   setTimeout(function () {
     if (index === finalPorts.length) {
-      clearTimeout(timer)
       scanResults()
     }
   }, 5000)
@@ -263,7 +257,5 @@ function scanResults () {
 function killValidator (currentPort) {
   fkill(`:${currentPort}`, {force: true}).then(() => {
     logger.log('✔️', `Killed process on port: ${currentPort}`.green)
-    clearTimeout(timer)
-    scanResults()
   })
 }

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -4,11 +4,9 @@ const spawn = require('child_process').spawn
 const portscanner = require('portscanner')
 const path = require('path')
 const http = require('http')
-// const net = require('net')
 const fkill = require('fkill')
 const logger = require('../tools/logger')()
 const appDir = process.cwd()
-// let host = 'localhost'
 let foundValidator = false
 let portHolder = []
 let finalPorts = []
@@ -17,7 +15,6 @@ let cPort
 let portString
 let pkg
 let rooseveltConfig
-// let timeout = 2000
 let commandString
 let cmdProcess
 
@@ -78,15 +75,7 @@ function getValidator () {
     if (error.message.includes('ECONNREFUSED')) {
       logger.warn(`Could not find validator on port: ${validatorOptions.port}. Scanning for validator now...`.yellow)
       getOpenPorts()
-    // } else {
-      // logger.error(`Error Occurred: ${error.message}. Scanning for validator now`.red)
-      // getOpenPorts()
     }
-  // }).on('socket', (socket) => {
-  //   socket.setTimeout(timeout)
-  //   socket.on('timeout', () => {
-  //     req.abort()
-  //   })
   })
 }
 getValidator()
@@ -194,13 +183,6 @@ function scanFinalPorts () {
  * @param {number} cPort - current final port being checked
  */
 function checkForValidator (cPort) {
-  // let s = new net.Socket()
-
-  // s.setTimeout(2000, function () {
-  //   s.destroy()
-  // })
-
-  // s.connect(cPort, host, function () {
   let options = {
     url: 'http://localhost:',
     port: cPort,
@@ -229,7 +211,6 @@ function checkForValidator (cPort) {
     if (!error.message.includes('socket hang up')) {
       if (!error.message.includes('ECONNRESET')) {
         logger.error(`${error}`.red)
-        // req.abort()
       }
     }
     // possibly revisit here if errors show up

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -1,5 +1,7 @@
 require('colors')
 
+const exec = require('child_process').exec
+const portscanner = require('portscanner')
 const path = require('path')
 const http = require('http')
 const net = require('net')
@@ -7,15 +9,15 @@ const fkill = require('fkill')
 const logger = require('../tools/logger')()
 const appDir = process.cwd()
 let host = 'localhost'
-let foundValidator = false
-let timer
-let socketHolder = []
-let endingPortHitBool = false
+// let foundValidator = false
+let portHolder = []
+let finalPorts = []
+let cPort
+let portString
 let pkg
 let rooseveltConfig
-let startPort = 1000
-let endPort = 65535
 let timeout = 2000
+
 let validatorOptions = {
   url: 'http://localhost',
   method: 'GET',
@@ -50,7 +52,7 @@ function getValidator () {
       // consume 404 response data
       logger.error(error.message)
       res.resume()
-      scanForValidator()
+      getOpenPorts()
     }
 
     res.setEncoding('utf8')
@@ -62,20 +64,20 @@ function getValidator () {
     res.on('end', () => {
       if (rawData.includes('Nu Html Checker')) {
         logger.log('✔️', `Validator successfully found on port: ${validatorOptions.port}`.green)
-        foundValidator = true
+        // foundValidator = true
         killValidator(validatorOptions.port)
       } else {
         logger.warn(`Could not find validator on port: ${validatorOptions.port}. Scanning for validator now...`.yellow)
-        scanForValidator()
+        getOpenPorts()
       }
     })
   }).on('error', (error) => {
     if (error.message.includes('ECONNREFUSED')) {
       logger.warn(`Could not find validator on port: ${validatorOptions.port}. Scanning for validator now...`.yellow)
-      scanForValidator()
+      getOpenPorts()
     } else {
       logger.error(`Error Occurred: ${error.message}. Scanning for validator now`.red)
-      scanForValidator()
+      getOpenPorts()
     }
   }).on('socket', (socket) => {
     socket.setTimeout(timeout)
@@ -86,102 +88,123 @@ function getValidator () {
 }
 getValidator()
 
-/**
- * scans available ports for html validator
- * @function scanForValidator
- */
-function scanForValidator () {
-  let scanPorts = (start, end) => {
-    while (start <= end) {
-      let port = start;
+function getOpenPorts () {
+  // grabs potentially open connections
+  exec('netstat -an', function (err, stdout, stderr) {
+    if (err) {
+      logger.error(`${err}`.red)
+    }
+    if (stderr) {
+      logger.error(`${stderr}`.red)
+    }
 
-      (function (port) {
-        var s = new net.Socket()
-        socketHolder.push(port)
-        s.setTimeout(timeout, function () { s.destroy() })
-        s.connect(port, host, function () {
-          let options = {
-            method: 'GET',
-            port: port,
-            headers: {
-              'User-Agent': 'request'
-            }
-          }
-          http.get(options, function (res) {
-            res.setEncoding('utf8')
+    portString = stdout.match(/\d{4,5}/gm) + ''
 
-            let rawData = ''
+    if (!portString) {
+      throw new TypeError('No open ports found.'.red)
+    } else {
+      portHolder = arrayify(portString)
+    }
+    scanFoundPorts()
+    setTimeout(function () {
+      process.exit()
+    }, 8000)
+  })
+}
 
-            res.on('data', (chunk) => {
-              rawData += chunk
-            })
-
-            res.on('end', () => {
-              if (rawData.includes('Nu Html Checker')) {
-                logger.log('✔️', `Validator successfully found on port: ${port}`.green)
-                foundValidator = true
-                killValidator(port)
-              }
-            })
-          }).on('error', (err) => {
-            s.destroy(err)
-          })
-        })
-
-        s.on('error', function (e) {
-          s.destroy()
-        })
-
-        s.on('close', () => {
-          let index = socketHolder.indexOf(port)
-          socketHolder.splice(index, 1)
-          if (endingPortHitBool === true) {
-            if (socketHolder.length === 0) {
-              clearTimeout(timer)
-              scanResults()
-            }
-          }
-          if (port === end) {
-            if (end === endPort) {
-              endingPortHitBool = true
-            } else {
-              let newEndPort = end + 2000
-              if (newEndPort < endPort) {
-                scanPorts(end, newEndPort)
-              } else {
-                newEndPort = endPort
-                scanPorts(end, newEndPort)
-              }
-            }
-          }
-        })
-      })(port)
-      start++
+// takes string from stdout and turns it into array of ports
+function arrayify (portString) {
+  let i
+  let ar = portString.trim().split(',')
+  let final = []
+  for (i = 0; i < ar.length; i++) {
+    if (!final.includes(ar[i], 0)) {
+      final.push(ar[i])
     }
   }
-
-  scanPorts(startPort, 2000)
-
-  timer = setTimeout(function () {
-    scanResults()
-  }, 100000)
+  return final
 }
 
-function scanResults () {
-  if (foundValidator === false) {
-    logger.error('Could not find the validator at this time, please make sure that the validator is running.'.red)
-    process.exit()
-  } else {
-    logger.log('Found and closed all validators at the moment, exiting killValidator'.green)
-    process.exit()
+function scanFoundPorts () {
+  let index = 0
+  while (index < portHolder.length) {
+    let port = portHolder[index]
+    callScanner(port)
+    index++
+  }
+  setTimeout(function () {
+    tryValidatorNewPorts()
+  }, 2000)
+}
+
+function callScanner (port) {
+  portscanner.checkPortStatus(port, '0.0.0.0', function (error, status) {
+    if (status === 'open') {
+      finalPorts.push(port)
+    } else if (error) {
+      logger.error(error)
+    }
+  })
+}
+
+function tryValidatorNewPorts () {
+  let index = 0
+  while (index < finalPorts.length) {
+    cPort = finalPorts[index]
+    scanThisPort(cPort)
+    index++
   }
 }
 
-/**
- * kills the html validator
- * @function killValidator
- * @param {number} currentPort - current port that the validator is listening on
- */
+function scanThisPort (cPort) {
+  let s = new net.Socket()
+
+  s.setTimeout(2000, function () {
+    s.destroy()
+  })
+
+  s.connect(cPort, host, function () {
+    let options = {
+      url: 'http://localhost:',
+      port: cPort,
+      method: 'GET',
+      headers: {
+        'User-Agent': 'request'
+      }
+    }
+    http.get(options, function (res) {
+      res.setEncoding('utf8')
+
+      let rawData = ''
+
+      res.on('data', (chunk) => {
+        rawData += chunk
+      })
+
+      res.on('end', () => {
+        try {
+          if (rawData.includes('Nu Html Checker')) {
+            logger.log('✔️', `Validator succesfully found on port: ${cPort}`.green)
+            // foundValidator = true
+            killValidator(cPort)
+          }
+        } catch (err) {
+          logger.error(`${err}`.red)
+        }
+      })
+    }).on('error', (error) => {
+      logger.error(`${error}`.red)
+      // possibly revisit here if errors show up
+    })
+  })
+
+  s.on('error', function (error) {
+    if (error.message.includes('ECONNRESFUSED')) {
+      // handling for this error, continue as normal
+    }
+  })
+}
+
 function killValidator (currentPort) {
   fkill(`:${currentPort}`, {force: true}).then(() => {
     logger.log('✔️', `Killed process on port: ${currentPort}`.green)

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -21,7 +21,7 @@ const logger = require('../tools/logger')();
       } else {
         resultList.forEach(function (process) {
           logger.log('✔️', `Validator successfully found with PID: ${process.pid}`.green)
-          fkill(`${process.pid}`, {force: true}).then(() => {
+          fkill(Number(process.pid), {force: true}).then(() => {
             logger.log('✔️', `Killed process with PID: ${process.pid}`.green)
           })
         })

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -224,14 +224,10 @@ function checkForValidator (cPort) {
       })
 
       res.on('end', () => {
-        try {
-          if (rawData.includes('Nu Html Checker')) {
-            logger.log('✔️', `Validator successfully found on port: ${cPort}`.green)
-            foundValidator = true
-            killValidator(cPort)
-          }
-        } catch (err) {
-          logger.error(`${err}`.red)
+        if (rawData.includes('Nu Html Checker')) {
+          logger.log('✔️', `Validator successfully found on port: ${cPort}`.green)
+          foundValidator = true
+          killValidator(cPort)
         }
       })
     }).on('error', (error) => {

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -4,9 +4,11 @@ const spawn = require('child_process').spawn
 const portscanner = require('portscanner')
 const path = require('path')
 const http = require('http')
+// const net = require('net')
 const fkill = require('fkill')
 const logger = require('../tools/logger')()
 const appDir = process.cwd()
+// let host = 'localhost'
 let foundValidator = false
 let portHolder = []
 let finalPorts = []
@@ -15,6 +17,7 @@ let cPort
 let portString
 let pkg
 let rooseveltConfig
+// let timeout = 2000
 let commandString
 let cmdProcess
 
@@ -39,7 +42,7 @@ try {
  * @function getValidator
  */
 function getValidator () {
-  let req = http.get(validatorOptions, function (res) {
+  http.get(validatorOptions, function (res) {
     const { statusCode } = res
 
     let error
@@ -74,13 +77,16 @@ function getValidator () {
   }).on('error', (error) => {
     if (error.message.includes('ECONNREFUSED')) {
       logger.warn(`Could not find validator on port: ${validatorOptions.port}. Scanning for validator now...`.yellow)
-      req.abort()
       getOpenPorts()
     } else {
       logger.error(`Error Occurred: ${error.message}. Scanning for validator now`.red)
-      req.abort()
       getOpenPorts()
     }
+  // }).on('socket', (socket) => {
+  //   socket.setTimeout(timeout)
+  //   socket.on('timeout', () => {
+  //     req.abort()
+  //   })
   })
 }
 getValidator()
@@ -188,6 +194,13 @@ function scanFinalPorts () {
  * @param {number} cPort - current final port being checked
  */
 function checkForValidator (cPort) {
+  // let s = new net.Socket()
+
+  // s.setTimeout(2000, function () {
+  //   s.destroy()
+  // })
+
+  // s.connect(cPort, host, function () {
   let options = {
     url: 'http://localhost:',
     port: cPort,
@@ -196,7 +209,7 @@ function checkForValidator (cPort) {
       'User-Agent': 'request'
     }
   }
-  let req = http.get(options, function (res) {
+  http.get(options, function (res) {
     res.setEncoding('utf8')
 
     let rawData = ''
@@ -216,7 +229,7 @@ function checkForValidator (cPort) {
     if (!error.message.includes('socket hang up')) {
       if (!error.message.includes('ECONNRESET')) {
         logger.error(`${error}`.red)
-        req.abort()
+        // req.abort()
       }
     }
     // possibly revisit here if errors show up

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -15,7 +15,6 @@ let finalPorts = []
 let cPort
 let portString
 let pkg
-let timer
 let rooseveltConfig
 let timeout = 2000
 
@@ -132,7 +131,7 @@ function getOpenPorts () {
       scanFoundPorts()
     })
   }
-  timer = setTimeout(function () {
+  setTimeout(function () {
     scanResults()
   }, 100000)
 }
@@ -179,8 +178,6 @@ function tryValidatorNewPorts () {
     scanThisPort(cPort)
     index++
   }
-  clearTimeout(timer)
-  scanResults()
 }
 
 function scanThisPort (cPort) {

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -15,6 +15,7 @@ let finalPorts = []
 let cPort
 let portString
 let pkg
+let timer
 let rooseveltConfig
 let timeout = 2000
 
@@ -131,7 +132,7 @@ function getOpenPorts () {
       scanFoundPorts()
     })
   }
-  setTimeout(function () {
+  timer = setTimeout(function () {
     scanResults()
   }, 100000)
 }
@@ -208,7 +209,7 @@ function scanThisPort (cPort) {
       res.on('end', () => {
         try {
           if (rawData.includes('Nu Html Checker')) {
-            logger.log('✔️', `Validator succesfully found on port: ${cPort}`.green)
+            logger.log('✔️', `Validator successfully found on port: ${cPort}`.green)
             foundValidator = true
             killValidator(cPort)
           }
@@ -217,7 +218,9 @@ function scanThisPort (cPort) {
         }
       })
     }).on('error', (error) => {
-      logger.error(`${error}`.red)
+      if (!error.message.includes('socket hang up')) {
+        logger.error(`${error}`.red)
+      }
       // possibly revisit here if errors show up
     })
   })
@@ -242,5 +245,7 @@ function scanResults () {
 function killValidator (currentPort) {
   fkill(`:${currentPort}`, {force: true}).then(() => {
     logger.log('✔️', `Killed process on port: ${currentPort}`.green)
+    clearTimeout(timer)
+    scanResults()
   })
 }

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -9,12 +9,13 @@ const fkill = require('fkill')
 const logger = require('../tools/logger')()
 const appDir = process.cwd()
 let host = 'localhost'
-// let foundValidator = false
+let foundValidator = false
 let portHolder = []
 let finalPorts = []
 let cPort
 let portString
 let pkg
+let timer
 let rooseveltConfig
 let timeout = 2000
 
@@ -64,7 +65,7 @@ function getValidator () {
     res.on('end', () => {
       if (rawData.includes('Nu Html Checker')) {
         logger.log('✔️', `Validator successfully found on port: ${validatorOptions.port}`.green)
-        // foundValidator = true
+        foundValidator = true
         killValidator(validatorOptions.port)
       } else {
         logger.warn(`Could not find validator on port: ${validatorOptions.port}. Scanning for validator now...`.yellow)
@@ -131,6 +132,9 @@ function getOpenPorts () {
       scanFoundPorts()
     })
   }
+  timer = setTimeout(function () {
+    scanResults()
+  }, 100000)
 }
 
 // takes string from stdout and turns it into array of ports
@@ -175,6 +179,8 @@ function tryValidatorNewPorts () {
     scanThisPort(cPort)
     index++
   }
+  clearTimeout(timer)
+  scanResults()
 }
 
 function scanThisPort (cPort) {
@@ -206,7 +212,7 @@ function scanThisPort (cPort) {
         try {
           if (rawData.includes('Nu Html Checker')) {
             logger.log('✔️', `Validator succesfully found on port: ${cPort}`.green)
-            // foundValidator = true
+            foundValidator = true
             killValidator(cPort)
           }
         } catch (err) {
@@ -224,6 +230,16 @@ function scanThisPort (cPort) {
       // handling for this error, continue as normal
     }
   })
+}
+
+function scanResults () {
+  if (foundValidator === false) {
+    logger.error('Could not find the validator at this time, please make sure that the validator is running.'.red)
+    process.exit()
+  } else {
+    logger.log('Found and closed all validators at the moment, exiting killValidator'.green)
+    process.exit()
+  }
 }
 
 function killValidator (currentPort) {

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -14,22 +14,19 @@ function lookupValidator () {
     command: 'java',
     arguments: 'nu.validator.servlet.Main'
   }, function (err, resultList) {
-    if (err) {
-      // throw new Error(err);
-    }
-    if (resultList.length === 0) {
-      logger.error('Could not find the validator at this time, please make sure that the validator is running.'.red)
-      process.exit()
-    }
-    resultList.forEach(function (process) {
-      if (process) {
-        logger.log('✔️', `Validator successfully found with PID: ${process.pid}`.green)
-        fkill(`${process.pid}`, {force: true}).then(() => {
-          logger.log('✔️', `Killed process with PID: ${process.pid}`.green)
+    if (!err) {
+      if (resultList.length === 0) {
+        logger.error('Could not find the validator at this time, please make sure that the validator is running.'.red)
+        process.exit()
+      } else {
+        resultList.forEach(function (process) {
+          logger.log('✔️', `Validator successfully found with PID: ${process.pid}`.green)
+          fkill(`${process.pid}`, {force: true}).then(() => {
+            logger.log('✔️', `Killed process with PID: ${process.pid}`.green)
+          })
         })
       }
-    })
+    }
   })
-  // logger.log('Found and closed all validators at the moment, exiting killValidator'.green)
 }
 lookupValidator()

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -13,7 +13,7 @@ let socketHolder = []
 let endingPortHitBool = false
 let pkg
 let rooseveltConfig
-let startPort = 0
+let startPort = 1000
 let endPort = 65535
 let timeout = 2000
 let validatorOptions = {

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -17,6 +17,7 @@ let pkg
 let rooseveltConfig
 let commandString
 let cmdProcess
+let promises = []
 
 let validatorOptions = {
   url: 'http://localhost',
@@ -105,7 +106,7 @@ function getOpenPorts () {
 
     portHolder = arrayify(portString)
 
-    scanPotentialPorts()
+    scanPotentialPorts(portHolder)
   })
 }
 
@@ -129,40 +130,33 @@ function arrayify (portString) {
  * sends potential ports to portscanner module for confirmation, then calls to scan through confirmed ports
  * @function scanPotentialPorts
  */
-function scanPotentialPorts () {
-  let index = 0
-  while (index < portHolder.length) {
-    let port = portHolder[index]
-    confirmPort(port)
-    index++
-  }
-  setTimeout(function () {
-    scanFinalPorts()
-  }, 2000)
-}
-
-/**
- * takes ports from portHolder array and confirms if they are open or not then pushes
- * confirmed ports to a finalPorts array
- * @function confirmPort
- * @param {number} port - port to check status of
- */
-function confirmPort (port) {
-  portscanner.checkPortStatus(port, '0.0.0.0', function (error, status) {
-    if (status === 'open') {
-      finalPorts.push(port)
-    }
-    if (error) {
-      // continue
-    }
+function scanPotentialPorts (portHolder) {
+  portHolder.forEach((port) => {
+    promises.push(
+      new Promise((resolve, reject) => {
+        portscanner.checkPortStatus(port, '0.0.0.0', function (error, status) {
+          if (status === 'open') {
+            finalPorts.push(port)
+          }
+          if (error) {
+            // continue
+          }
+          resolve()
+        })
+      })
+    )
   })
+
+  Promise.all(promises)
+    .then(() => {
+      scanFinalPorts(finalPorts)
+    })
+    .catch((err) => {
+      logger.error(err)
+    })
 }
 
-/**
- * sends each port to final method making http.get requests to each final port
- * @function scanFinalPorts
- */
-function scanFinalPorts () {
+function scanFinalPorts (finalPorts) {
   let index = 0
   while (index < finalPorts.length) {
     cPort = finalPorts[index]
@@ -176,7 +170,6 @@ function scanFinalPorts () {
     }
   }, 5000)
 }
-
 /**
  * makes request to port, checking for validator
  * @function checkForValidator

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -110,7 +110,7 @@ function getOpenPorts () {
     })
   }
   if (process.platform === 'darwin') {
-    exec('lsof -nP -i4', function (err, stdout, stderr) {
+    exec('netstat -ap tcp | grep -i "listen"', function (err, stdout, stderr) {
       if (err) {
         logger.error(`${err}`.red)
       }

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -89,8 +89,11 @@ function getValidator () {
 }
 getValidator()
 
+/**
+ * uses command line to get list of ports w/ potentially open connection
+ * @function getOpenPorts
+ */
 function getOpenPorts () {
-  // grabs potentially open connections
   if (process.platform === 'win32') {
     exec('netstat -an', function (err, stdout, stderr) {
       if (err) {
@@ -107,7 +110,7 @@ function getOpenPorts () {
       } else {
         portHolder = arrayify(portString)
       }
-      scanFoundPorts()
+      scanPotentialPorts()
     })
   }
   if (process.platform === 'darwin') {
@@ -116,10 +119,7 @@ function getOpenPorts () {
         logger.error(`${err}`.red)
       }
       if (stderr) {
-        // ignore permissions error message on linux
-        if (!stderr.includes('(Not all processes')) {
-          logger.error(`${stderr}`.red)
-        }
+        logger.error(`${stderr}`.red)
       }
 
       portString = stdout.match(/\d{4,5}/gm) + ''
@@ -129,7 +129,7 @@ function getOpenPorts () {
       } else {
         portHolder = arrayify(portString)
       }
-      scanFoundPorts()
+      scanPotentialPorts()
     })
   }
   if (process.platform === 'linux') {
@@ -151,15 +151,19 @@ function getOpenPorts () {
       } else {
         portHolder = arrayify(portString)
       }
-      scanFoundPorts()
+      scanPotentialPorts()
     })
   }
+  // time out scanning for validator after 100000ms then scans results
   timer = setTimeout(function () {
     scanResults()
   }, 100000)
 }
 
-// takes string from stdout and turns it into array of ports
+/**
+ * takes string from stdout and turns it into array of ports, ignoring duplicates
+ * @function arrayify
+ */
 function arrayify (portString) {
   let i
   let ar = portString.trim().split(',')
@@ -172,19 +176,29 @@ function arrayify (portString) {
   return final
 }
 
-function scanFoundPorts () {
+/**
+ * sends potential ports to portscanner module for confirmation, then calls to scan through confirmed ports
+ * @function scanPotentialPorts
+ */
+function scanPotentialPorts () {
   let index = 0
   while (index < portHolder.length) {
     let port = portHolder[index]
-    callScanner(port)
+    confirmPort(port)
     index++
   }
   setTimeout(function () {
-    tryValidatorNewPorts()
+    scanFinalPorts()
   }, 2000)
 }
 
-function callScanner (port) {
+/**
+ * takes ports from portHolder array and confirms if they are open or not then pushes
+ * confirmed ports to a finalPorts array
+ * @function confirmPort
+ * @param {number} port - port to check status of
+ */
+function confirmPort (port) {
   portscanner.checkPortStatus(port, '0.0.0.0', function (error, status) {
     if (status === 'open') {
       finalPorts.push(port)
@@ -194,13 +208,18 @@ function callScanner (port) {
   })
 }
 
-function tryValidatorNewPorts () {
+/**
+ * sends each port to final method making http.get requests to each final port
+ * @function scanFinalPorts
+ */
+function scanFinalPorts () {
   let index = 0
   while (index < finalPorts.length) {
     cPort = finalPorts[index]
-    scanThisPort(cPort)
+    checkForValidator(cPort)
     index++
   }
+  // wait for while loop to finish, if all ports in array were exhausted we scan results
   setTimeout(function () {
     if (index === finalPorts.length) {
       clearTimeout(timer)
@@ -209,7 +228,12 @@ function tryValidatorNewPorts () {
   }, 5000)
 }
 
-function scanThisPort (cPort) {
+/**
+ * makes request to port, checking for validator
+ * @function checkForValidator
+ * @param {number} cPort - current final port being checked
+ */
+function checkForValidator (cPort) {
   let s = new net.Socket()
 
   s.setTimeout(2000, function () {
@@ -262,6 +286,10 @@ function scanThisPort (cPort) {
   })
 }
 
+/**
+ * checks to see if a validator was found at the end of script runtime
+ * @function scanResults
+ */
 function scanResults () {
   if (foundValidator === false) {
     logger.error('Could not find the validator at this time, please make sure that the validator is running.'.red)
@@ -272,6 +300,11 @@ function scanResults () {
   }
 }
 
+/**
+ * makes call to fkill module sending port confirmed to have validator on it
+ * @function killValidator
+ * @param {number} currentPort
+ */
 function killValidator (currentPort) {
   fkill(`:${currentPort}`, {force: true}).then(() => {
     logger.log('✔️', `Killed process on port: ${currentPort}`.green)

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -2,13 +2,13 @@ require('colors')
 
 const ps = require('ps-node')
 const fkill = require('fkill')
-const logger = require('../tools/logger')()
+const logger = require('../tools/logger')();
 
 /**
  * looks for validator and kills it when found
- * @function lookupValidator
+ * @function lookupFunction
  */
-function lookupValidator () {
+(function lookupFunction () {
   logger.log('Scanning for validator now...'.yellow)
   ps.lookup({
     command: 'java',
@@ -28,5 +28,4 @@ function lookupValidator () {
       }
     }
   })
-}
-lookupValidator()
+})()

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -124,10 +124,6 @@ function getOpenPorts () {
     }
     scanPotentialPorts()
   })
-  // time out scanning for validator after 100000ms then scans results
-  timer = setTimeout(function () {
-    scanResults()
-  }, 100000)
 }
 
 /**

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -106,7 +106,7 @@ function getOpenPorts () {
   }
   exec(commandString, function (err, stdout, stderr) {
     if (err) {
-      // throw this error
+      logger.error(`${err}`.red)
     }
     if (stderr) {
       logger.error(`${stderr}`.red)
@@ -114,11 +114,8 @@ function getOpenPorts () {
 
     portString = stdout.match(/\d{4,5}/gm) + ''
 
-    if (!portString) {
-      throw new TypeError('No open ports found.'.red)
-    } else {
-      portHolder = arrayify(portString)
-    }
+    portHolder = arrayify(portString)
+
     scanPotentialPorts()
   })
   // time out scanning for validator after 100000ms then scans results

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -234,7 +234,7 @@ function checkForValidator (cPort) {
             killValidator(cPort)
           }
         } catch (err) {
-          // continue
+          logger.error(`${err}`.red)
         }
       })
     }).on('error', (error) => {

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -106,13 +106,10 @@ function getOpenPorts () {
   }
   exec(commandString, function (err, stdout, stderr) {
     if (err) {
-      logger.error(`${err}`.red)
+      // throw this error
     }
     if (stderr) {
-      // ignore permissions error message on linux
-      if (!stderr.includes('(Not all processes')) {
-        logger.error(`${stderr}`.red)
-      }
+      logger.error(`${stderr}`.red)
     }
 
     portString = stdout.match(/\d{4,5}/gm) + ''
@@ -172,8 +169,9 @@ function confirmPort (port) {
   portscanner.checkPortStatus(port, '0.0.0.0', function (error, status) {
     if (status === 'open') {
       finalPorts.push(port)
-    } else if (error) {
-      logger.error(error)
+    }
+    if (error) {
+      // continue
     }
   })
 }
@@ -236,7 +234,7 @@ function checkForValidator (cPort) {
             killValidator(cPort)
           }
         } catch (err) {
-          logger.error(`${err}`.red)
+          // continue
         }
       })
     }).on('error', (error) => {
@@ -247,12 +245,6 @@ function checkForValidator (cPort) {
       }
       // possibly revisit here if errors show up
     })
-  })
-
-  s.on('error', function (error) {
-    if (error.message.includes('ECONNRESFUSED')) {
-      // handling for this error, continue as normal
-    }
   })
 }
 

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -78,9 +78,9 @@ function getValidator () {
     if (error.message.includes('ECONNREFUSED')) {
       logger.warn(`Could not find validator on port: ${validatorOptions.port}. Scanning for validator now...`.yellow)
       getOpenPorts()
-    } else {
-      logger.error(`Error Occurred: ${error.message}. Scanning for validator now`.red)
-      getOpenPorts()
+    // } else {
+      // logger.error(`Error Occurred: ${error.message}. Scanning for validator now`.red)
+      // getOpenPorts()
     }
   // }).on('socket', (socket) => {
   //   socket.setTimeout(timeout)

--- a/lib/scripts/killValidator.js
+++ b/lib/scripts/killValidator.js
@@ -1,6 +1,6 @@
 require('colors')
 
-const exec = require('child_process').exec
+const spawn = require('child_process').spawn
 const portscanner = require('portscanner')
 const path = require('path')
 const http = require('http')
@@ -12,12 +12,14 @@ let host = 'localhost'
 let foundValidator = false
 let portHolder = []
 let finalPorts = []
+let args = []
 let cPort
 let portString
 let pkg
 let rooseveltConfig
 let timeout = 2000
 let commandString
+let cmdProcess
 
 let validatorOptions = {
   url: 'http://localhost',
@@ -94,24 +96,23 @@ getValidator()
  * @function getOpenPorts
  */
 function getOpenPorts () {
-  if (process.platform === 'win32') {
-    commandString = 'netstat -an'
-  }
-  if (process.platform === 'darwin') {
-    commandString = 'netstat -ap tcp | grep -i "listen"'
+  if (process.platform === 'win32' || process.platform === 'darwin') {
+    commandString = 'netstat'
+    args = ['-an']
   }
   if (process.platform === 'linux') {
-    commandString = 'netstat -lnt'
+    commandString = 'netstat'
+    args = ['-lnt']
   }
-  exec(commandString, function (err, stdout, stderr) {
-    if (err) {
-      logger.error(`${err}`.red)
-    }
-    if (stderr) {
-      logger.error(`${stderr}`.red)
-    }
+  cmdProcess = spawn(commandString, [args])
 
-    portString = stdout.match(/\d{4,5}/gm) + ''
+  let output = ''
+
+  cmdProcess.stdout.on('data', data => {
+    output += data.toString()
+  })
+  cmdProcess.on('close', code => {
+    portString = output.match(/\d{4,5}/gm) + ''
 
     portHolder = arrayify(portString)
 
@@ -128,7 +129,7 @@ function arrayify (portString) {
   let ar = portString.trim().split(',')
   let final = []
   for (i = 0; i < ar.length; i++) {
-    if (!final.includes(ar[i], 0)) {
+    if (!final.includes(ar[i], 0) && ar[i] < 65536 && ar[i] >= 1000) {
       final.push(ar[i])
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -331,6 +331,14 @@
         "acorn": "^4.0.3"
       }
     },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
@@ -3273,6 +3281,14 @@
         }
       }
     },
+    "is-number-like": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+      "requires": {
+        "lodash.isfinite": "^3.3.2"
+      }
+    },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
@@ -4363,8 +4379,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -4376,6 +4391,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
+    },
+    "lodash.isfinite": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
     },
     "lodash.memoize": {
       "version": "3.0.4",
@@ -4947,9 +4967,9 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -4958,22 +4978,26 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
             "default-require-extensions": "^1.0.0"
@@ -4981,52 +5005,62 @@
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arr-diff": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
           "dev": true
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
           "dev": true
         },
         "arr-union": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
           "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "atob": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -5036,7 +5070,8 @@
         },
         "babel-generator": {
           "version": "6.26.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "dev": true,
           "requires": {
             "babel-messages": "^6.23.0",
@@ -5051,7 +5086,8 @@
         },
         "babel-messages": {
           "version": "6.23.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
             "babel-runtime": "^6.22.0"
@@ -5059,7 +5095,8 @@
         },
         "babel-runtime": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
             "core-js": "^2.4.0",
@@ -5068,7 +5105,8 @@
         },
         "babel-template": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
@@ -5080,7 +5118,8 @@
         },
         "babel-traverse": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
             "babel-code-frame": "^6.26.0",
@@ -5096,7 +5135,8 @@
         },
         "babel-types": {
           "version": "6.26.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
             "babel-runtime": "^6.26.0",
@@ -5107,17 +5147,20 @@
         },
         "babylon": {
           "version": "6.18.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "base": {
           "version": "0.11.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
           "dev": true,
           "requires": {
             "cache-base": "^1.0.1",
@@ -5131,7 +5174,8 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -5139,7 +5183,8 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -5147,7 +5192,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -5155,7 +5201,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -5165,19 +5212,22 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -5186,7 +5236,8 @@
         },
         "braces": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -5203,7 +5254,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -5213,12 +5265,14 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "cache-base": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
           "dev": true,
           "requires": {
             "collection-visit": "^1.0.0",
@@ -5234,14 +5288,16 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "caching-transform": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
             "md5-hex": "^1.2.0",
@@ -5251,13 +5307,15 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5267,7 +5325,8 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -5279,7 +5338,8 @@
         },
         "class-utils": {
           "version": "0.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -5290,7 +5350,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -5298,14 +5359,16 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "cliui": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5316,7 +5379,8 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "dev": true,
               "optional": true
             }
@@ -5324,12 +5388,14 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "collection-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "dev": true,
           "requires": {
             "map-visit": "^1.0.0",
@@ -5338,37 +5404,44 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "component-emitter": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
           "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
           "dev": true
         },
         "core-js": {
           "version": "2.5.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -5377,7 +5450,8 @@
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -5385,22 +5459,26 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
             "strip-bom": "^2.0.0"
@@ -5408,7 +5486,8 @@
         },
         "define-property": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
             "is-descriptor": "^1.0.2",
@@ -5417,7 +5496,8 @@
           "dependencies": {
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -5425,7 +5505,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -5433,7 +5514,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -5443,19 +5525,22 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "detect-indent": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
             "repeating": "^2.0.0"
@@ -5463,7 +5548,8 @@
         },
         "error-ex": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
@@ -5471,17 +5557,20 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -5495,7 +5584,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "dev": true,
               "requires": {
                 "lru-cache": "^4.0.1",
@@ -5507,7 +5597,8 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
             "debug": "^2.3.3",
@@ -5521,7 +5612,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -5529,7 +5621,8 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -5539,7 +5632,8 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
             "assign-symbols": "^1.0.0",
@@ -5548,7 +5642,8 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
@@ -5558,7 +5653,8 @@
         },
         "extglob": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
@@ -5573,7 +5669,8 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -5581,7 +5678,8 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -5589,7 +5687,8 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -5597,7 +5696,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -5605,7 +5705,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -5615,14 +5716,16 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "fill-range": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -5633,7 +5736,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -5643,7 +5747,8 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
@@ -5653,7 +5758,8 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -5661,12 +5767,14 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         },
         "foreground-child": {
           "version": "1.5.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
             "cross-spawn": "^4",
@@ -5675,7 +5783,8 @@
         },
         "fragment-cache": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "dev": true,
           "requires": {
             "map-cache": "^0.2.2"
@@ -5683,27 +5792,32 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "get-value": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -5716,17 +5830,20 @@
         },
         "globals": {
           "version": "9.18.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "handlebars": {
           "version": "4.0.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
           "dev": true,
           "requires": {
             "async": "^1.4.0",
@@ -5737,7 +5854,8 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
                 "amdefine": ">=0.0.4"
@@ -5747,7 +5865,8 @@
         },
         "has-ansi": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5755,12 +5874,14 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "has-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "dev": true,
           "requires": {
             "get-value": "^2.0.6",
@@ -5770,14 +5891,16 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "has-values": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -5786,7 +5909,8 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
@@ -5794,7 +5918,8 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
@@ -5804,7 +5929,8 @@
             },
             "kind-of": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -5814,17 +5940,20 @@
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -5833,12 +5962,14 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invariant": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "dev": true,
           "requires": {
             "loose-envify": "^1.0.0"
@@ -5846,12 +5977,14 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -5859,17 +5992,20 @@
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
             "builtin-modules": "^1.0.0"
@@ -5877,7 +6013,8 @@
         },
         "is-data-descriptor": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -5885,7 +6022,8 @@
         },
         "is-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
@@ -5895,19 +6033,22 @@
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
               "dev": true
             }
           }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -5915,12 +6056,14 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -5928,7 +6071,8 @@
         },
         "is-odd": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
           "dev": true,
           "requires": {
             "is-number": "^4.0.0"
@@ -5936,14 +6080,16 @@
           "dependencies": {
             "is-number": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
               "dev": true
             }
           }
         },
         "is-plain-object": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "dev": true,
           "requires": {
             "isobject": "^3.0.1"
@@ -5951,49 +6097,58 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
           "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isobject": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
           "dev": true,
           "requires": {
             "append-transform": "^0.4.0"
@@ -6001,7 +6156,8 @@
         },
         "istanbul-lib-instrument": {
           "version": "1.10.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
           "dev": true,
           "requires": {
             "babel-generator": "^6.18.0",
@@ -6015,7 +6171,8 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "^1.1.2",
@@ -6026,7 +6183,8 @@
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
                 "has-flag": "^1.0.0"
@@ -6036,7 +6194,8 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
           "dev": true,
           "requires": {
             "debug": "^3.1.0",
@@ -6048,7 +6207,8 @@
           "dependencies": {
             "debug": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
               "dev": true,
               "requires": {
                 "ms": "2.0.0"
@@ -6058,7 +6218,8 @@
         },
         "istanbul-reports": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OPzVo1fPZ2H+owr8q/LYKLD+vquv9Pj4F+dj808MdHbuQLD7S4ACRjcX+0Tne5Vxt2lxXvdZaL7v+FOOAV281w==",
           "dev": true,
           "requires": {
             "handlebars": "^4.0.3"
@@ -6066,17 +6227,20 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -6084,13 +6248,15 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
@@ -6098,7 +6264,8 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -6110,7 +6277,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -6119,25 +6287,28 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "resolved": false,
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
             "js-tokens": "^3.0.0"
@@ -6145,7 +6316,8 @@
         },
         "lru-cache": {
           "version": "4.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -6154,12 +6326,14 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
           "dev": true
         },
         "map-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "dev": true,
           "requires": {
             "object-visit": "^1.0.0"
@@ -6167,7 +6341,8 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
             "md5-o-matic": "^0.1.1"
@@ -6175,12 +6350,14 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -6188,7 +6365,8 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
           "dev": true,
           "requires": {
             "source-map": "^0.6.1"
@@ -6196,14 +6374,16 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
           }
         },
         "micromatch": {
           "version": "3.1.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -6223,19 +6403,22 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -6243,12 +6426,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mixin-deep": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
           "dev": true,
           "requires": {
             "for-in": "^1.0.2",
@@ -6257,7 +6442,8 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
                 "is-plain-object": "^2.0.4"
@@ -6267,7 +6453,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6275,12 +6462,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "nanomatch": {
           "version": "1.2.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
           "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
@@ -6299,24 +6488,28 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
               "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -6327,7 +6520,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -6335,17 +6529,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object-copy": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "dev": true,
           "requires": {
             "copy-descriptor": "^0.1.0",
@@ -6355,7 +6552,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -6365,7 +6563,8 @@
         },
         "object-visit": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "dev": true,
           "requires": {
             "isobject": "^3.0.0"
@@ -6373,14 +6572,16 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "object.pick": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "dev": true,
           "requires": {
             "isobject": "^3.0.1"
@@ -6388,14 +6589,16 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -6403,7 +6606,8 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
             "minimist": "~0.0.1",
@@ -6412,12 +6616,14 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -6427,12 +6633,14 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -6440,7 +6648,8 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -6448,12 +6657,14 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
@@ -6461,12 +6672,14 @@
         },
         "pascalcase": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
           "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -6474,22 +6687,26 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -6499,17 +6716,20 @@
         },
         "pify": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
             "pinkie": "^2.0.0"
@@ -6517,7 +6737,8 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
             "find-up": "^1.0.0"
@@ -6525,7 +6746,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -6536,17 +6758,20 @@
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
             "load-json-file": "^1.0.0",
@@ -6556,7 +6781,8 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
             "find-up": "^1.0.0",
@@ -6565,7 +6791,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "^2.0.0",
@@ -6576,12 +6803,14 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
         },
         "regex-not": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.2",
@@ -6590,17 +6819,20 @@
         },
         "repeat-element": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
             "is-finite": "^1.0.0"
@@ -6608,32 +6840,38 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "resolve-url": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
           "dev": true
         },
         "ret": {
           "version": "0.1.15",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6642,7 +6880,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
             "glob": "^7.0.5"
@@ -6650,7 +6889,8 @@
         },
         "safe-regex": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "dev": true,
           "requires": {
             "ret": "~0.1.10"
@@ -6658,17 +6898,20 @@
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "set-value": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -6679,7 +6922,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -6689,7 +6933,8 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -6697,22 +6942,26 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "snapdragon": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
           "dev": true,
           "requires": {
             "base": "^0.11.1",
@@ -6727,7 +6976,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -6735,7 +6985,8 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -6745,7 +6996,8 @@
         },
         "snapdragon-node": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
           "dev": true,
           "requires": {
             "define-property": "^1.0.0",
@@ -6755,7 +7007,8 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -6763,7 +7016,8 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -6771,7 +7025,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -6779,7 +7034,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -6789,19 +7045,22 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "snapdragon-util": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
           "dev": true,
           "requires": {
             "kind-of": "^3.2.0"
@@ -6809,12 +7068,14 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "source-map-resolve": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
           "dev": true,
           "requires": {
             "atob": "^2.0.0",
@@ -6826,12 +7087,14 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "dev": true,
           "requires": {
             "foreground-child": "^1.5.6",
@@ -6844,7 +7107,8 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -6853,12 +7117,14 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -6867,12 +7133,14 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
           "dev": true
         },
         "split-string": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
           "dev": true,
           "requires": {
             "extend-shallow": "^3.0.0"
@@ -6880,7 +7148,8 @@
         },
         "static-extend": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "dev": true,
           "requires": {
             "define-property": "^0.2.5",
@@ -6889,7 +7158,8 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -6899,7 +7169,8 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -6908,12 +7179,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -6923,7 +7196,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6931,7 +7205,8 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
             "is-utf8": "^0.2.0"
@@ -6939,17 +7214,20 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "test-exclude": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
           "dev": true,
           "requires": {
             "arrify": "^1.0.1",
@@ -6961,17 +7239,20 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
               "dev": true
             },
             "array-unique": {
               "version": "0.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
               "dev": true
             },
             "braces": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "dev": true,
               "requires": {
                 "arr-flatten": "^1.1.0",
@@ -6988,7 +7269,8 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -6998,7 +7280,8 @@
             },
             "expand-brackets": {
               "version": "2.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
               "dev": true,
               "requires": {
                 "debug": "^2.3.3",
@@ -7012,7 +7295,8 @@
               "dependencies": {
                 "define-property": {
                   "version": "0.2.5",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                   "dev": true,
                   "requires": {
                     "is-descriptor": "^0.1.0"
@@ -7020,7 +7304,8 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -7028,7 +7313,8 @@
                 },
                 "is-accessor-descriptor": {
                   "version": "0.1.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                   "dev": true,
                   "requires": {
                     "kind-of": "^3.0.2"
@@ -7036,7 +7322,8 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
                         "is-buffer": "^1.1.5"
@@ -7046,7 +7333,8 @@
                 },
                 "is-data-descriptor": {
                   "version": "0.1.4",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                   "dev": true,
                   "requires": {
                     "kind-of": "^3.0.2"
@@ -7054,7 +7342,8 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "bundled": true,
+                      "resolved": false,
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
                         "is-buffer": "^1.1.5"
@@ -7064,7 +7353,8 @@
                 },
                 "is-descriptor": {
                   "version": "0.1.6",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                   "dev": true,
                   "requires": {
                     "is-accessor-descriptor": "^0.1.6",
@@ -7074,14 +7364,16 @@
                 },
                 "kind-of": {
                   "version": "5.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
                   "dev": true
                 }
               }
             },
             "extglob": {
               "version": "2.0.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
               "dev": true,
               "requires": {
                 "array-unique": "^0.3.2",
@@ -7096,7 +7388,8 @@
               "dependencies": {
                 "define-property": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                   "dev": true,
                   "requires": {
                     "is-descriptor": "^1.0.0"
@@ -7104,7 +7397,8 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -7114,7 +7408,8 @@
             },
             "fill-range": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
               "dev": true,
               "requires": {
                 "extend-shallow": "^2.0.1",
@@ -7125,7 +7420,8 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -7135,7 +7431,8 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -7143,7 +7440,8 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
                 "kind-of": "^6.0.0"
@@ -7151,7 +7449,8 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -7161,7 +7460,8 @@
             },
             "is-number": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
@@ -7169,7 +7469,8 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
@@ -7179,17 +7480,20 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             },
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             },
             "micromatch": {
               "version": "3.1.10",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
               "dev": true,
               "requires": {
                 "arr-diff": "^4.0.0",
@@ -7211,12 +7515,14 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         },
         "to-object-path": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
@@ -7224,7 +7530,8 @@
         },
         "to-regex": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "dev": true,
           "requires": {
             "define-property": "^2.0.2",
@@ -7235,7 +7542,8 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
             "is-number": "^3.0.0",
@@ -7244,7 +7552,8 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
@@ -7254,12 +7563,14 @@
         },
         "trim-right": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7270,7 +7581,8 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -7284,13 +7596,15 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
         "union-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -7301,7 +7615,8 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -7309,7 +7624,8 @@
             },
             "set-value": {
               "version": "0.4.3",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
               "dev": true,
               "requires": {
                 "extend-shallow": "^2.0.1",
@@ -7322,7 +7638,8 @@
         },
         "unset-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "dev": true,
           "requires": {
             "has-value": "^0.3.1",
@@ -7331,7 +7648,8 @@
           "dependencies": {
             "has-value": {
               "version": "0.3.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "dev": true,
               "requires": {
                 "get-value": "^2.0.3",
@@ -7341,7 +7659,8 @@
               "dependencies": {
                 "isobject": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": false,
+                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
                   "dev": true,
                   "requires": {
                     "isarray": "1.0.0"
@@ -7351,24 +7670,28 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
               "dev": true
             },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
               "dev": true
             }
           }
         },
         "urix": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
           "dev": true
         },
         "use": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
           "dev": true,
           "requires": {
             "kind-of": "^6.0.2"
@@ -7376,14 +7699,16 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
               "dev": true
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -7392,7 +7717,8 @@
         },
         "which": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -7400,23 +7726,27 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -7425,7 +7755,8 @@
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -7433,7 +7764,8 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -7445,12 +7777,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -7460,17 +7794,20 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "11.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
@@ -7489,17 +7826,20 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             },
             "cliui": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "dev": true,
               "requires": {
                 "string-width": "^2.1.1",
@@ -7509,7 +7849,8 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -7517,7 +7858,8 @@
             },
             "yargs-parser": {
               "version": "9.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
               "dev": true,
               "requires": {
                 "camelcase": "^4.1.0"
@@ -7527,7 +7869,8 @@
         },
         "yargs-parser": {
           "version": "8.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -7535,7 +7878,8 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1184,6 +1184,11 @@
         "typedarray": "^0.0.6"
       }
     },
+    "connected-domain": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/connected-domain/-/connected-domain-1.0.0.tgz",
+      "integrity": "sha1-v+dyOMdL5FOnnwy2BY3utPI1jpM="
+    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -7166,6 +7171,14 @@
         "tasklist": "^3.1.0"
       }
     },
+    "ps-node": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ps-node/-/ps-node-0.1.6.tgz",
+      "integrity": "sha1-mvZ6mdex0BMuUaUDCZ04qNKs4sM=",
+      "requires": {
+        "table-parser": "^0.1.3"
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -8246,6 +8259,14 @@
         "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
+      }
+    },
+    "table-parser": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/table-parser/-/table-parser-0.1.3.tgz",
+      "integrity": "sha1-BEHPzhallIFoTCfRtaZ/8VpDx7A=",
+      "requires": {
+        "connected-domain": "^1.0.0"
       }
     },
     "tamper": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8117,6 +8117,15 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
+    "portscanner": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
+      "integrity": "sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==",
+      "requires": {
+        "async": "^2.6.0",
+        "is-number-like": "^1.0.3"
+      }
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "morgan": "~1.9.0",
     "node-emoji": "~1.8.1",
     "parent-require": "~1.0.0",
+    "portscanner": "^2.2.0",
     "serve-favicon": "~2.5.0",
     "tamper": "~1.0.0",
     "tmp": "~0.0.33",
     "toobusy-js": "~0.5.0",
-    "vnu-jar": "~18.3.0"
+    "vnu-jar": "^18.3.0"
   },
   "devDependencies": {
     "codecov": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "tamper": "~1.0.0",
     "tmp": "~0.0.33",
     "toobusy-js": "~0.5.0",
-    "vnu-jar": "^18.3.0"
+    "vnu-jar": "~18.3.0"
   },
   "devDependencies": {
     "codecov": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "morgan": "~1.9.0",
     "node-emoji": "~1.8.1",
     "parent-require": "~1.0.0",
-    "ps-node": "^0.1.6",
+    "ps-node": "~0.1.6",
     "serve-favicon": "~2.5.0",
     "tamper": "~1.0.0",
     "tmp": "~0.0.33",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "node-emoji": "~1.8.1",
     "parent-require": "~1.0.0",
     "portscanner": "^2.2.0",
+    "ps-node": "^0.1.6",
     "serve-favicon": "~2.5.0",
     "tamper": "~1.0.0",
     "tmp": "~0.0.33",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "morgan": "~1.9.0",
     "node-emoji": "~1.8.1",
     "parent-require": "~1.0.0",
-    "portscanner": "^2.2.0",
     "ps-node": "^0.1.6",
     "serve-favicon": "~2.5.0",
     "tamper": "~1.0.0",

--- a/test/unit/autoKillTest.js
+++ b/test/unit/autoKillTest.js
@@ -56,7 +56,7 @@ describe('Roosevelt autokill Test', function () {
 
     // on logs, check if specific logs were outputted
     testApp.stdout.on('data', (data) => {
-      if (data.includes('Killed process on port')) {
+      if (data.includes('Killed process with PID')) {
         htmlValidatorPortClosedBool = true
         exit()
       } else if (data.includes('There was no autoKiller running, creating a new one')) {
@@ -118,7 +118,7 @@ describe('Roosevelt autokill Test', function () {
         testApp.kill('SIGINT')
       } else if (data.includes('cannot connect to app, killing the validator now')) {
         cannotConnectBool = true
-      } else if (data.includes('Killed process on port')) {
+      } else if (data.includes('Killed process with PID')) {
         htmlValidatorPortClosedBool = true
         exit()
       }
@@ -165,7 +165,7 @@ describe('Roosevelt autokill Test', function () {
     testApp.stdout.on('data', (data) => {
       if (data.includes('Restarting autoKiller')) {
         restartAutoKillerLogBool = true
-      } else if (data.includes('Killed process')) {
+      } else if (data.includes('Killed process with PID')) {
         // wait for autoKiller to be finished before exiting test
         exit()
       }
@@ -286,7 +286,7 @@ describe('Roosevelt autokill Test', function () {
         timerResetBool = true
       } else if (data.includes('cannot connect to app, killing the validator now')) {
         cannotConnectBool = true
-      } else if (data.includes('Killed process on port: 8888')) {
+      } else if (data.includes('Killed process with PID')) {
         htmlValidatorPortClosedBool = true
       }
     })

--- a/test/unit/htmlValidatorTest.js
+++ b/test/unit/htmlValidatorTest.js
@@ -134,7 +134,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
       })
     })
 
-    it('should allow warnigns to show up if "suppressWarnings" is false', function (done) {
+    it('should allow warnings to show up if "suppressWarnings" is false', function (done) {
       // generate the app
       generateTestApp({
         generateFolderStructure: true,
@@ -182,7 +182,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
       })
     })
 
-    it('should not allow warnigns to show up if "suppressWarnings" is true', function (done) {
+    it('should not allow warnings to show up if "suppressWarnings" is true', function (done) {
       // generate the app
       generateTestApp({
         generateFolderStructure: true,
@@ -441,7 +441,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
       })
     })
 
-    it('should still validate the HTML page if the model in the response does not holds a value that is set in the exception param', function (done) {
+    it('should still validate the HTML page if the model in the response does not hold a value that is set in the exception param', function (done) {
       // generate the app
       generateTestApp({
         generateFolderStructure: true,
@@ -496,7 +496,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
       })
     })
 
-    it('should try to validate the HTML page because the model in the response does not holds a value that is set in the exception param', function (done) {
+    it('should try to validate the HTML page because the model in the response does not hold a value that is set in the exception param', function (done) {
       // generate the app
       generateTestApp({
         generateFolderStructure: true,
@@ -549,7 +549,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
       })
     })
 
-    it('should be able to run the validator even if we change the port number of the validator', function (done) {
+    it('should be able to run the validator even if we change the validator\'s port number', function (done) {
       // generate the app
       generateTestApp({
         generateFolderStructure: true,
@@ -673,7 +673,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
       })
     })
 
-    it('should not be starting another htmlValidator if one is alreadly running on the same port', function (done) {
+    it('should not start another htmlValidator if one is already running on the same port', function (done) {
       // bool vars to hold whether or not specific logs have been outputted
       let startingHTMLValidator2Bool = false
       let detachedValidatorFound2Bool = false
@@ -985,7 +985,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
     // make options msgEnabled back to false so that new app don't have a sinon timer
     options.msgEnabled = false
 
-    it('should output an error messages if the kill Validator script is used when the validator is not being used', function (done) {
+    it('should output an error message if the kill Validator script is used when the validator is not being used', function (done) {
       // bool var to hold whether or not the request failed status has been given
       let requestFailedLogBool = false
       let finalWarnBool = false
@@ -1074,7 +1074,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
 
         // when killValidator exits, check if all errors logs that we want are outputted
         killLine.on('exit', () => {
-          assert.equal(validatorClosedBool, true, 'Roosevelt was not able to closed the HTML Validator on its seperate port')
+          assert.equal(validatorClosedBool, true, 'Roosevelt was not able to close the HTML Validator on its seperate port')
           assert.equal(validatorFoundBool, true, 'Roosevelt was not able to find the HTML Validator on its seperate port')
           assert.equal(foundAndKilledAllBool, true, 'killValidator did not give the message that it has found and killed all the validators it can at the moment')
           done()
@@ -1235,7 +1235,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
         killLine.on('exit', () => {
           assert.equal(validatorFoundBool, true, 'killValidator was not able to find the port that the Validator is on')
           assert.equal(validatorClosedBool, true, 'killValidator did not close the Validator')
-          assert.equal(foundAndKilledAllBool, true, 'killValidator did not give a message saying that it found and killed al the validators it can at the moment')
+          assert.equal(foundAndKilledAllBool, true, 'killValidator did not give a message saying that it found and killed all the validators it can at the moment')
           done()
         })
       })
@@ -1339,7 +1339,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
       })
     })
 
-    it('should be able to catch the 404 error that is given back if the path requested from the server does not exists', function (done) {
+    it('should be able to catch the 404 error that is given back if the path requested from the server does not exist', function (done) {
       // bool vars to hold whether or not a log was outputted
       let requestFailedBool = false
 
@@ -1549,7 +1549,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
       })
     })
 
-    it('should report a error if the problem occurs within the port that we give it or the default 8888 and then scan for the validator', function (done) {
+    it('should report an error if the problem occurs within the port that we give it or the default 8888 and then scan for the validator', function (done) {
       // bool var to hold whether or not a specific error logs were outputted
       let timeoutErrorLogBool = false
       let scanContinuedLogBool = false
@@ -1589,7 +1589,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
         })
         // when the roosevelt app exits, check that all the logs we wanted were outputted
         testApp.on('exit', () => {
-          assert.equal(timeoutErrorLogBool, true, 'killValidator did not report that the initial scan was stopped because of timeout')
+          assert.equal(timeoutErrorLogBool, true, 'killValidator did not report that the initial scan was stopped because of a timeout')
           assert.equal(scanContinuedLogBool, true, 'killValidator did not continue scanning the ports for the Validator after the initial scan failed')
           done()
         })

--- a/test/unit/htmlValidatorTest.js
+++ b/test/unit/htmlValidatorTest.js
@@ -1551,7 +1551,6 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
 
     it('should report an error if the problem occurs within the port that we give it or the default 8888 and then scan for the validator', function (done) {
       // bool var to hold whether or not a specific error logs were outputted
-      // let timeoutErrorLogBool = false
       let scanContinuedLogBool = false
 
       let data = `
@@ -1576,9 +1575,6 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
         const killLine = fork('lib/scripts/killValidator.js', {'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
         // on error logs, see if specific logs are outputted
         killLine.stderr.on('data', (data) => {
-          // if (data.includes('Error Occurred:')) {
-          //   timeoutErrorLogBool = true
-          // }
           if (data.includes('Could not find the validator at this time, please make sure that the validator is running.')) {
             scanContinuedLogBool = true
           }
@@ -1589,7 +1585,6 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
         })
         // when the roosevelt app exits, check that all the logs we wanted were outputted
         testApp.on('exit', () => {
-          // assert.equal(timeoutErrorLogBool, true, 'killValidator did not report that the initial scan was stopped because of a timeout')
           assert.equal(scanContinuedLogBool, true, 'killValidator did not continue scanning the ports for the Validator after the initial scan failed')
           done()
         })

--- a/test/unit/htmlValidatorTest.js
+++ b/test/unit/htmlValidatorTest.js
@@ -1068,11 +1068,15 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
           })
 
           killLine.on('exit', () => {
-            assert.equal(foundValidatorBool, true, 'killValidator was not able to find the validator')
-            assert.equal(killedValidatorBool, true, 'killValidator was unable to kill the validator')
-            done()
+            testApp.kill('SIGINT')
           })
         }
+      })
+
+      testApp.on('exit', () => {
+        assert.equal(foundValidatorBool, true, 'killValidator was not able to find the validator')
+        assert.equal(killedValidatorBool, true, 'killValidator was unable to kill the validator')
+        done()
       })
     })
   })

--- a/test/unit/htmlValidatorTest.js
+++ b/test/unit/htmlValidatorTest.js
@@ -1040,7 +1040,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
       let killedValidatorBool = false
 
       generateTestApp({
-        generateFolderStructure: false,
+        generateFolderStructure: true,
         appDir: appDir,
         htmlValidator: {
           enable: true,

--- a/test/unit/htmlValidatorTest.js
+++ b/test/unit/htmlValidatorTest.js
@@ -981,7 +981,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
     })
   })
 
-  describe('Roosevelt killValidator test', function () {
+  describe.only('Roosevelt killValidator test', function () {
     // make options msgEnabled back to false so that new app don't have a sinon timer
     options.msgEnabled = false
 
@@ -1551,7 +1551,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
 
     it('should report an error if the problem occurs within the port that we give it or the default 8888 and then scan for the validator', function (done) {
       // bool var to hold whether or not a specific error logs were outputted
-      let timeoutErrorLogBool = false
+      // let timeoutErrorLogBool = false
       let scanContinuedLogBool = false
 
       let data = `
@@ -1576,9 +1576,9 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
         const killLine = fork('lib/scripts/killValidator.js', {'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
         // on error logs, see if specific logs are outputted
         killLine.stderr.on('data', (data) => {
-          if (data.includes('Error Occurred:')) {
-            timeoutErrorLogBool = true
-          }
+          // if (data.includes('Error Occurred:')) {
+          //   timeoutErrorLogBool = true
+          // }
           if (data.includes('Could not find the validator at this time, please make sure that the validator is running.')) {
             scanContinuedLogBool = true
           }
@@ -1589,7 +1589,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
         })
         // when the roosevelt app exits, check that all the logs we wanted were outputted
         testApp.on('exit', () => {
-          assert.equal(timeoutErrorLogBool, true, 'killValidator did not report that the initial scan was stopped because of a timeout')
+          // assert.equal(timeoutErrorLogBool, true, 'killValidator did not report that the initial scan was stopped because of a timeout')
           assert.equal(scanContinuedLogBool, true, 'killValidator did not continue scanning the ports for the Validator after the initial scan failed')
           done()
         })

--- a/test/unit/htmlValidatorTest.js
+++ b/test/unit/htmlValidatorTest.js
@@ -981,7 +981,7 @@ describe('Roosevelt HTML Validator/Kill Validator Test', function () {
     })
   })
 
-  describe.only('Roosevelt killValidator test', function () {
+  describe('Roosevelt killValidator test', function () {
     // make options msgEnabled back to false so that new app don't have a sinon timer
     options.msgEnabled = false
 

--- a/test/unit/paramFunctionTest.js
+++ b/test/unit/paramFunctionTest.js
@@ -65,6 +65,7 @@ describe('parameter Function Test Section', function () {
       done()
     })
   })
+
   it('should execute what is in onReqStart', function (done) {
     // bool var to hold whether or not the app had used its body parser middleware yet
     let bodyParserNotUsedBool = false


### PR DESCRIPTION
(closes #449)

The goal of this change is to make the killValidator script run quicker. 
In turn, this change also greatly improves the speed of the unit tests/travis build.

This change:
- Added 'ps-node' module that does all of the searching for us
- Removed many, now obsolete, unit tests