### PR TITLE
Update supressLogs to logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ npm run dev -- -attach-validator
 
 Roosevelt makes use of an ENV variable to set the validator to an attached or detached state by default.
 
-(Note that when the ENV variable is set, it overrides the settings in package.json and params.) 
+(Note that when the ENV variable is set, it overrides the settings in package.json and params.)
 - Set an environment variable `ROOSEVELT_VALIDATOR` to detached for a detached by default validator.
 - Set an environment variable `ROOSEVELT_VALIDATOR` to attached for an attached by default validator.
 
@@ -284,19 +284,19 @@ App behavior parameters
 
 - `localhostOnly`: Listen only to requests coming from localhost in production mode. This is useful in environments where it is expected that HTTP requests to your app will be proxied through a more traditional web server like Apache or nginx. This setting is ignored in development mode.
   - Default: *[Boolean]* `true`.
-- `suppressLogs`: Accepts an object containing four related parameters:
-  - `httpLogs`: *[Boolean]* When set to true, Roosevelt will not log HTTP requests to the console.
-  - `rooseveltLogs`: *[Boolean]* When set to true, Roosevelt will not log app status to the console.
-  - `rooseveltWarnings`: *[Boolean]* When set to true, Roosevelt will not log app warnings to the console.
-  - `verboseLogs`: *[Boolean]* When set to true, Roosevelt will not output logs made by some of its other processes
+- `logging`: Accepts an object containing four related parameters:
+  - `http`: *[Boolean]* When set to false, Roosevelt will not log HTTP requests to the console.
+  - `appStatus`: *[Boolean]* When set to false, Roosevelt will not log app status to the console.
+  - `warnings`: *[Boolean]* When set to false, Roosevelt will not log app warnings to the console.
+  - `verbose`: *[Boolean]* When set to false, Roosevelt will not output logs made by some of its other processes
   - Default: *[Object]*
 
       ```json
       {
-        "httpLogs": false,
-        "rooseveltLogs": false,
-        "rooseveltWarnings": false,
-        "verboseLogs": true
+        "http": true,
+        "appStatus": true,
+        "warnings": true,
+        "verbose": false
       }
       ```
 

--- a/lib/500ErrorPage.js
+++ b/lib/500ErrorPage.js
@@ -2,7 +2,7 @@
 
 module.exports = function (app) {
   const params = app.get('params')
-  const logger = require('./tools/logger')(app.get('params').suppressLogs)
+  const logger = require('./tools/logger')(app.get('params').logging)
 
   // 500 internal server error page
   app.use((err, req, res, next) => {

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -2,11 +2,11 @@
   "port": 43711,
   "generateFolderStructure": true,
   "localhostOnly": true,
-  "suppressLogs": {
-    "httpLogs": false,
-    "rooseveltLogs": false,
-    "verboseLogs": true,
-    "rooseveltWarnings": false
+  "logging": {
+    "http": true,
+    "appStatus": true,
+    "warnings": true,
+    "verbose": false
   },
   "noMinify": false,
   "htmlValidator": {

--- a/lib/enableMultipart.js
+++ b/lib/enableMultipart.js
@@ -7,7 +7,7 @@ const formidable = require('formidable')
 
 module.exports = function (app) {
   const appName = app.get('appName')
-  const logger = require('./tools/logger')(app.get('params').suppressLogs)
+  const logger = require('./tools/logger')(app.get('params').logging)
 
   app.set('formidable', formidable)
 

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -264,7 +264,6 @@ module.exports = function (app, callback) {
           // if it finds a process and kills it, state that we are restarting autoKiller and fire autoKillValidator as a child process, also deletes the temp file
           logger.log('Restarting autoKiller')
           fs.unlinkSync(PIDPath)
-          // TODO
           let autokiller = spawn('node', [`${path.join(__dirname, 'scripts', 'autoKillValidator.js')}`, `${params.port}`, `${params.htmlValidator.separateProcess.autoKillerTimeout}`, params.logging.verbose], {detached: true, stdio: 'inherit', shell: false, windowsHide: true})
           autokiller.unref()
           cb()

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -15,7 +15,7 @@ const os = require('os')
 const fkill = require('fkill')
 
 module.exports = function (app, callback) {
-  const logger = require('./tools/logger')(app.get('params').suppressLogs)
+  const logger = require('./tools/logger')(app.get('params').logging)
   let params = app.get('params')
   let validatorProcess
   let javaDetectProcess
@@ -264,21 +264,22 @@ module.exports = function (app, callback) {
           // if it finds a process and kills it, state that we are restarting autoKiller and fire autoKillValidator as a child process, also deletes the temp file
           logger.log('Restarting autoKiller')
           fs.unlinkSync(PIDPath)
-          let autokiller = spawn('node', [`${path.join(__dirname, 'scripts', 'autoKillValidator.js')}`, `${params.port}`, `${params.htmlValidator.separateProcess.autoKillerTimeout}`, params.suppressLogs.verboseLogs], {detached: true, stdio: 'inherit', shell: false, windowsHide: true})
+          // TODO
+          let autokiller = spawn('node', [`${path.join(__dirname, 'scripts', 'autoKillValidator.js')}`, `${params.port}`, `${params.htmlValidator.separateProcess.autoKillerTimeout}`, params.logging.verbose], {detached: true, stdio: 'inherit', shell: false, windowsHide: true})
           autokiller.unref()
           cb()
         }, () => {
           // if the process was closed alreadly, state that there was no process found and that roosevelt is creating a new autoKiller and fire autoKillValidator as a child process, also deletes the temp file
           logger.log('There was no autoKiller running with the PID given, creating a new one')
           fs.unlinkSync(PIDPath)
-          let autokiller = spawn('node', [`${path.join(__dirname, 'scripts', 'autoKillValidator.js')}`, `${params.port}`, `${params.htmlValidator.separateProcess.autoKillerTimeout}`, params.suppressLogs.verboseLogs], {detached: true, stdio: 'inherit', shell: false, windowsHide: true})
+          let autokiller = spawn('node', [`${path.join(__dirname, 'scripts', 'autoKillValidator.js')}`, `${params.port}`, `${params.htmlValidator.separateProcess.autoKillerTimeout}`, params.logging.verbose], {detached: true, stdio: 'inherit', shell: false, windowsHide: true})
           autokiller.unref()
           cb()
         })
       } else {
         // if a PID text file doesn't exist, state that there was no autoKiller running, that the app is creating a new autoKiller, and then fire autoKillValidator as a child process
         logger.log('There was no autoKiller running, creating a new one')
-        let autokiller = spawn('node', [`${path.join(__dirname, 'scripts', 'autoKillValidator.js')}`, `${params.port}`, `${params.htmlValidator.separateProcess.autoKillerTimeout}`, params.suppressLogs.verboseLogs], {detached: true, stdio: 'inherit', shell: false, windowsHide: true})
+        let autokiller = spawn('node', [`${path.join(__dirname, 'scripts', 'autoKillValidator.js')}`, `${params.port}`, `${params.htmlValidator.separateProcess.autoKillerTimeout}`, params.logging.verbose], {detached: true, stdio: 'inherit', shell: false, windowsHide: true})
         autokiller.unref()
         cb()
       }

--- a/lib/jsBundler.js
+++ b/lib/jsBundler.js
@@ -12,7 +12,7 @@ module.exports = function (app, callback) {
   const jsPath = app.get('jsPath')
   const jsBundledOutput = app.get('jsBundledOutput')
   const bundleBuildDir = path.join(app.get('jsCompiledOutput'), jsBundledOutput.replace(app.get('jsPath'), ''))
-  const logger = require('./tools/logger')(app.get('params').suppressLogs)
+  const logger = require('./tools/logger')(app.get('params').logging)
   const fsr = require('./tools/fsr')(app)
   let bundleEnv
   let promises = []

--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -15,7 +15,7 @@ module.exports = function (app, callback) {
   const jsCompiledOutput = app.get('jsCompiledOutput')
   const usingWhitelist = !!params.js.whitelist
   const blacklist = params.js.blacklist || []
-  const logger = require('./tools/logger')(app.get('params').suppressLogs)
+  const logger = require('./tools/logger')(app.get('params').logging)
   const fsr = require('./tools/fsr')(app)
   let preprocessor
   let jsFiles

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -11,7 +11,7 @@ module.exports = function (app) {
   const express = app.get('express')
   const appDir = app.get('appDir')
   const appName = app.get('appName')
-  const logger = require('./tools/logger')(app.get('params').suppressLogs)
+  const logger = require('./tools/logger')(app.get('params').logging)
   const fsr = require('./tools/fsr')(app)
   let params = app.get('params')
   let basicCSSPath

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -14,7 +14,7 @@ module.exports = function (app, callback) {
   const cssPath = app.get('cssPath')
   const cssCompiledOutput = app.get('cssCompiledOutput')
   const usingWhitelist = !!params.css.whitelist
-  const logger = require('./tools/logger')(app.get('params').suppressLogs)
+  const logger = require('./tools/logger')(app.get('params').logging)
   const fsr = require('./tools/fsr')(app)
   let preprocessor
   let cssFiles

--- a/lib/scripts/autoKillValidator.js
+++ b/lib/scripts/autoKillValidator.js
@@ -7,7 +7,7 @@ const os = require('os')
 
 let appPort = process.argv[2]
 let timeout = process.argv[3]
-let verbose = {verboseLogs: process.argv[4] === 'true'}
+let verbose = {verbose: process.argv[4] === 'false'}
 let timeoutHolder
 
 const logger = require('./../tools/logger')(verbose)

--- a/lib/scripts/autoKillValidator.js
+++ b/lib/scripts/autoKillValidator.js
@@ -7,7 +7,7 @@ const os = require('os')
 
 let appPort = process.argv[2]
 let timeout = process.argv[3]
-let verbose = {verbose: process.argv[4] === 'false'}
+let verbose = {verbose: process.argv[4] === 'true'}
 let timeoutHolder
 
 const logger = require('./../tools/logger')(verbose)

--- a/lib/setExpressConfigs.js
+++ b/lib/setExpressConfigs.js
@@ -7,7 +7,7 @@ const bodyParser = require('body-parser') // express body parser
 const prequire = require('parent-require')
 
 module.exports = function (app) {
-  const logger = require('./tools/logger')(app.get('params').suppressLogs)
+  const logger = require('./tools/logger')(app.get('params').logging)
   let params = app.get('params')
   let viewEngineParam = params.viewEngine
   let defaultEngine
@@ -61,7 +61,7 @@ module.exports = function (app) {
   })
 
   // dumps http requests to the console
-  if (!params.suppressLogs.httpLogs) {
+  if (params.logging.http) {
     app.use(morgan('combined'))
   }
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -10,7 +10,7 @@ const fsr = require('./tools/fsr')()
 let pkg
 
 module.exports = function (app) {
-  const logger = require('./tools/logger')(app.get('params').suppressLogs)
+  const logger = require('./tools/logger')(app.get('params').logging)
   let params = app.get('params')
   let flags
   let appDir = params.appDir
@@ -43,13 +43,13 @@ module.exports = function (app) {
   app.set('appName', pkg.name || 'Roosevelt Express')
   app.set('appVersion', pkg.version)
 
-  params.suppressLogs = checkParams(params.suppressLogs, pkg.rooseveltConfig.suppressLogs, defaultConfig.suppressLogs)
+  params.logging = checkParams(params.logging, pkg.rooseveltConfig.logging, defaultConfig.logging)
 
   params.publicFolder = checkParams(params.publicFolder, pkg.rooseveltConfig.publicFolder, defaultConfig.publicFolder)
   app.set('publicFolder', path.join(appDir, params.publicFolder))
 
   // use existence of public folder to determine first run
-  if (!fsr.fileExists(path.join(appDir, params.publicFolder)) && !params.suppressLogs.rooseveltLogs) {
+  if (!fsr.fileExists(path.join(appDir, params.publicFolder)) && params.logging.appStatus) {
     // run the param audit
     require('./scripts/configAuditor').audit(app.get('appDir'))
   }
@@ -62,7 +62,7 @@ module.exports = function (app) {
     ignoreCLIFlags: checkParams(params.ignoreCLIFlags, pkg.rooseveltConfig.ignoreCLIFlags, defaultConfig.ignoreCLIFlags),
     generateFolderStructure: checkParams(params.generateFolderStructure, pkg.rooseveltConfig.generateFolderStructure, defaultConfig.generateFolderStructure),
     localhostOnly: checkParams(params.localhostOnly, pkg.rooseveltConfig.localhostOnly, defaultConfig.localhostOnly),
-    suppressLogs: params.suppressLogs,
+    logging: params.logging,
     noMinify: checkParams(params.noMinify, pkg.rooseveltConfig.noMinify, defaultConfig.noMinify),
     htmlValidator: checkParams(params.htmlValidator, pkg.rooseveltConfig.htmlValidator, defaultConfig.htmlValidator),
     multipart: checkParams(params.multipart, pkg.rooseveltConfig.multipart, defaultConfig.multipart),

--- a/lib/tools/logger.js
+++ b/lib/tools/logger.js
@@ -34,21 +34,21 @@ class Logger {
   }
 
   log () {
-    if (this.enableLogging) {
+    if (this.enableLogging !== 'false' && this.enableLogging !== false) {
       let logs = parseLogs(arguments)
       console.log(...logs)
     }
   }
 
   warn () {
-    if (this.enableWarnings) {
+    if (this.enableWarnings !== 'false' && this.enableWarnings !== false) {
       let logs = parseLogs(arguments, 'warn')
       console.warn(...logs)
     }
   }
 
   verbose () {
-    if (this.enableVerbose) {
+    if (this.enableVerbose !== 'false' && this.enableVerbose !== false) {
       let logs = parseLogs(arguments)
       console.log(...logs)
     }

--- a/lib/tools/logger.js
+++ b/lib/tools/logger.js
@@ -27,28 +27,28 @@ function parseLogs (input, type) {
 class Logger {
   constructor (params) {
     if (params) {
-      this.suppressLogs = params.rooseveltLogs
-      this.suppressWarnings = params.rooseveltWarnings
-      this.suppressVerbose = params.verboseLogs
+      this.logging = params.appStatus
+      this.warnings = params.warnings
+      this.verbose = params.verbose
     }
   }
 
   log () {
-    if (!this.suppressLogs) {
+    if (this.logging) {
       let logs = parseLogs(arguments)
       console.log(...logs)
     }
   }
 
   warn () {
-    if (!this.suppressWarnings) {
+    if (this.warnings) {
       let logs = parseLogs(arguments, 'warn')
       console.warn(...logs)
     }
   }
 
   verbose () {
-    if (!this.suppressVerbose) {
+    if (this.verbose) {
       let logs = parseLogs(arguments)
       console.log(...logs)
     }

--- a/lib/tools/logger.js
+++ b/lib/tools/logger.js
@@ -27,28 +27,28 @@ function parseLogs (input, type) {
 class Logger {
   constructor (params) {
     if (params) {
-      this.logging = params.appStatus
-      this.warnings = params.warnings
-      this.verbose = params.verbose
+      this.enableLogging = params.appStatus
+      this.enableWarnings = params.warnings
+      this.enableVerbose = params.verbose
     }
   }
 
   log () {
-    if (this.logging) {
+    if (this.enableLogging) {
       let logs = parseLogs(arguments)
       console.log(...logs)
     }
   }
 
   warn () {
-    if (this.warnings) {
+    if (this.enableWarnings) {
       let logs = parseLogs(arguments, 'warn')
       console.warn(...logs)
     }
   }
 
   verbose () {
-    if (this.verbose) {
+    if (this.enableVerbose) {
       let logs = parseLogs(arguments)
       console.log(...logs)
     }

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -42,7 +42,7 @@ module.exports = function (params) {
 
   // source user supplied params
   app = require('./lib/sourceParams')(app)
-  logger = require('./lib/tools/logger')(app.get('params').suppressLogs)
+  logger = require('./lib/tools/logger')(app.get('params').logging)
 
   // warn the user if there are any dependencies that are missing or out of date for the user, or to make a package.json file if they don't have one
   if (app.get('params').checkDependencies) {

--- a/test/unit/autoKillTest.js
+++ b/test/unit/autoKillTest.js
@@ -36,8 +36,8 @@ describe('Roosevelt autokill Test', function () {
     // create the app.js file
     generateTestApp({
       appDir: appDir,
-      suppressLogs: {
-        verboseLogs: false
+      logging: {
+        verbose: true
       },
       generateFolderStructure: true,
       htmlValidator: {
@@ -90,8 +90,8 @@ describe('Roosevelt autokill Test', function () {
     generateTestApp({
       appDir: appDir,
       generateFolderStructure: true,
-      suppressLogs: {
-        verboseLogs: false
+      logging: {
+        verbose: true
       },
       htmlValidator: {
         enable: true,
@@ -141,8 +141,8 @@ describe('Roosevelt autokill Test', function () {
     generateTestApp({
       appDir: appDir,
       generateFolderStructure: true,
-      suppressLogs: {
-        verboseLogs: false
+      logging: {
+        verbose: true
       },
       htmlValidator: {
         enable: true,
@@ -190,8 +190,8 @@ describe('Roosevelt autokill Test', function () {
     generateTestApp({
       appDir: appDir,
       generateFolderStructure: true,
-      suppressLogs: {
-        verboseLogs: false
+      logging: {
+        verbose: true
       },
       htmlValidator: {
         enable: true,
@@ -247,7 +247,7 @@ describe('Roosevelt autokill Test', function () {
     }
   })
 
-  it('should restart the timer if the app is still active when autoKiller goes to check if the app was closed and try to kill the Validator when the app is closed, but does not report anything if verboseLogs is true', function (done) {
+  it('should restart the timer if the app is still active when autoKiller goes to check if the app was closed and try to kill the Validator when the app is closed, but does not report anything if verbose is false', function (done) {
     // vars to hold whether or not a specific log was outputted
     let timerResetBool = false
     let htmlValidatorPortClosedBool = false

--- a/test/unit/constructorParams.js
+++ b/test/unit/constructorParams.js
@@ -38,7 +38,7 @@ describe('Constructor params', function () {
   })
 
   params.forEach((param) => {
-    if (param !== 'suppressLogs' && param !== 'generateFolderStructure') {
+    if (param !== 'logging' && param !== 'generateFolderStructure') {
       it(`should set param "${param}" from constructor`, function () {
         assert.deepEqual(app.expressApp.get('params')[param], config[param])
       })

--- a/test/unit/defaultParams.js
+++ b/test/unit/defaultParams.js
@@ -12,16 +12,16 @@ describe('Default Params', function () {
     app = require('../../roosevelt')({
       appDir: path.join(__dirname, '../app/defaultParams'),
       ignoreCLIFlags: true,
-      suppressLogs: {
-        httpsLogs: true,
-        rooseveltLogs: true,
-        rooseveltWarnings: true
+      logging: {
+        http: false,
+        appStatus: false,
+        warnings: false
       }
     })
   })
 
   params.forEach((param) => {
-    if (param !== 'suppressLogs' && param !== 'generateFolderStructure') {
+    if (param !== 'logging' && param !== 'generateFolderStructure') {
       it(`should set correct default for param "${param}"`, function () {
         assert.deepEqual(app.expressApp.get('params')[param], defaults[param])
       })

--- a/test/unit/envParams.js
+++ b/test/unit/envParams.js
@@ -8,10 +8,10 @@ describe('ENV Params Test', function () {
   const appConfig = {
     appDir: path.join(__dirname, '../app/envParams'),
     ignoreCLIFlags: true,
-    suppressLogs: {
-      httpsLogs: true,
-      rooseveltLogs: true,
-      rooseveltWarnings: true
+    logging: {
+      http: false,
+      appStatus: false,
+      warnings: false
     }
   }
   let app

--- a/test/unit/folderStructure.js
+++ b/test/unit/folderStructure.js
@@ -19,9 +19,9 @@ describe('Folder Tests', function () {
       appDir: appDir,
       ignoreCLIFlags: true,
       generateFolderStructure: true,
-      suppressLogs: {
-        rooseveltLogs: true,
-        rooseveltWarnings: true
+      logging: {
+        appStatus: false,
+        warnings: false
       },
       viewsPath: 'mvc/viewsTest',
       modelsPath: 'mvc/modelsTest',

--- a/test/unit/htmlMinify.js
+++ b/test/unit/htmlMinify.js
@@ -12,11 +12,11 @@ describe('htmlMinify', function () {
   const appDir = path.join(__dirname, '../app/htmlMinify')
   const appConfig = {
     appDir: appDir,
-    suppressLogs: {
-      httpLogs: true,
-      rooseveltLogs: true,
-      rooseveltWarnings: true,
-      verboseLogs: true
+    logging: {
+      http: false,
+      appStatus: false,
+      warnings: false,
+      verbose: false
     },
     generateFolderStructure: true,
     viewEngine: 'html:teddy',

--- a/test/unit/pkgParams.js
+++ b/test/unit/pkgParams.js
@@ -36,7 +36,7 @@ describe('package.json params', function () {
   })
 
   params.forEach((param) => {
-    if (param !== 'suppressLogs' && param !== 'generateFolderStructure') {
+    if (param !== 'logging' && param !== 'generateFolderStructure') {
       it(`should set param "${param}" from package.json`, function () {
         assert.deepEqual(app.expressApp.get('params')[param], pkgConfig[param])
       })

--- a/test/util/testConstructorConfig.json
+++ b/test/util/testConstructorConfig.json
@@ -2,10 +2,10 @@
   "port": "constructor",
   "generateFolderStructure": false,
   "localhostOnly": "constructor",
-  "suppressLogs": {
-    "httpLogs": true,
-    "rooseveltLogs": true,
-    "rooseveltWarnings": true
+  "logging": {
+    "http": false,
+    "appStatus": false,
+    "warnings": false
   },
   "noMinify": "constructor",
   "htmlValidator": {

--- a/test/util/testHttpsConfig.json
+++ b/test/util/testHttpsConfig.json
@@ -1,10 +1,10 @@
 {
   "port": 1234,
   "generateFolderStructure": false,
-  "suppressLogs": {
-    "httpLogs": true,
-    "rooseveltLogs": true,
-    "rooseveltWarnings": true
+  "logging": {
+    "http": false,
+    "appStatus": true,
+    "warnings": false
   },
   "https": {
     "enable": true,

--- a/test/util/testHttpsConfig.json
+++ b/test/util/testHttpsConfig.json
@@ -3,7 +3,7 @@
   "generateFolderStructure": false,
   "logging": {
     "http": false,
-    "appStatus": true,
+    "appStatus": false,
     "warnings": false
   },
   "https": {

--- a/test/util/testPkgConfig.json
+++ b/test/util/testPkgConfig.json
@@ -2,10 +2,10 @@
   "port": "package",
   "generateFolderStructure": false,
   "localhostOnly": "package",
-  "suppressLogs": {
-    "httpLogs": true,
-    "rooseveltLogs": true,
-    "rooseveltWarnings": true
+  "logging": {
+    "http": false,
+    "appStatus": false,
+    "warnings": false
   },
   "noMinify": "package",
   "htmlValidator": {


### PR DESCRIPTION
This updates `supressLogs` object and replaces it with `logging`. This also fixes the double negatives of the logging parameters while renaming them to make them more lucid. (Closes: #443)

```
logging: {
  http: true
  appStatus: true
  warnings: true
  verbose: false
}
