### PR TITLE
Config Auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ npm run cleanup
 Scan current `rooseveltConfig` and `scripts` in `package.json` and warn about any params or npm scripts that don't match the current API:
 
 ```
-npm run audit
+npm run config-audit
 ```
 
 See also the [the full list of default scripts](https://github.com/rooseveltframework/roosevelt/blob/master/lib/defaults/scripts.json).

--- a/lib/defaults/scripts.json
+++ b/lib/defaults/scripts.json
@@ -45,7 +45,7 @@
     "value": "node ./node_modules/roosevelt/lib/scripts/appCleanup.js",
     "priority": "ignore"
   },
-  "audit": {
+  "config-audit": {
     "value": "node ./node_modules/roosevelt/lib/scripts/configAuditor.js",
     "priority": "error",
     "inspect": true

--- a/lib/defaults/scripts.json
+++ b/lib/defaults/scripts.json
@@ -1,11 +1,11 @@
 {
   "start": {
     "value": "npm run production",
-    "priority": "error"
+    "priority": "ignore"
   },
   "production": {
     "value": "nodemon app.js --production-mode",
-    "priority": "error"
+    "priority": "ignore"
   },
   "prod": {
     "value": "nodemon app.js --production-mode",
@@ -17,7 +17,7 @@
   },
   "development": {
     "value": "nodemon app.js --development-mode",
-    "priority": "error"
+    "priority": "ignore"
   },
   "dev": {
     "value": "nodemon app.js --development-mode",

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -76,16 +76,21 @@ function configAudit (appDir) {
   })
 
   // inspect for missing or outdated scripts
-  let startScripts = [
-    'npm run production',
-    'nodemon app.js --production-mode',
-    'nodemon app.js --development-mode'
-  ]
-  let hasStartScripts = false
+  let startScripts = {
+    'production': ['start', 'production', 'prod', 'p'],
+    'development': ['development', 'dev', 'd']
+  }
+  let hasProdScript = false
+  let hasDevScript = false
   defaultScriptKeys.forEach((defaultScript) => {
-    if (startScripts.includes(userScripts[defaultScript]) === true) {
-      hasStartScripts = true
-    }
+    Object.keys(userScripts).forEach((userScript) => {
+      if (startScripts.production.includes(userScript) === true) {
+        hasProdScript = true
+      }
+      if (startScripts.development.includes(userScript) === true) {
+        hasDevScript = true
+      }
+    })
     if (userScripts[defaultScript] === undefined) {
       if (defaultScripts[defaultScript].priority === 'error') {
         logger.error('⚠️', `Missing script "${defaultScript}"!`.red.bold)
@@ -103,8 +108,12 @@ function configAudit (appDir) {
   })
 
   // output warning for missing start script
-  if (hasStartScripts === false) {
-    logger.warn('Missing production and development run script(s).'.bold)
+  if (!hasProdScript) {
+    logger.warn('Missing production run script(s).'.bold)
+    errors = true
+  }
+  if (!hasDevScript) {
+    logger.warn('Missing development run script(s).'.bold)
     errors = true
   }
 

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -108,6 +108,14 @@ function configAudit (appDir) {
     errors = true
   }
 
+  // check dependencies
+  let checkDeps = require('check-dependencies').sync({packageDir: appDir})
+  if (checkDeps.depsWereOk === false) {
+    for (var i = 0; i < checkDeps.error.length; i++) {
+      logger.error('⚠️', `Missing Dependency: ${checkDeps.error[i]}`.bold)
+    }
+  }
+
   if (errors) {
     logger.error('Issues have been detected in roosevelt config, please consult https://github.com/rooseveltframework/roosevelt#configure-your-app-with-parameters for details on each param.'.red.bold)
     logger.error('Or see https://github.com/rooseveltframework/roosevelt/blob/master/lib/defaults/config.json for the latest sample rooseveltConfig.'.red.bold)

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -76,7 +76,16 @@ function configAudit (appDir) {
   })
 
   // inspect for missing or outdated scripts
+  let startScripts = [
+    'npm run production',
+    'nodemon app.js --production-mode',
+    'nodemon app.js --development-mode'
+  ]
+  let hasStartScripts = false
   defaultScriptKeys.forEach((defaultScript) => {
+    if (startScripts.includes(userScripts[defaultScript]) === true) {
+      hasStartScripts = true
+    }
     if (userScripts[defaultScript] === undefined) {
       if (defaultScripts[defaultScript].priority === 'error') {
         logger.error('⚠️', `Missing script "${defaultScript}"!`.red.bold)
@@ -92,6 +101,12 @@ function configAudit (appDir) {
       }
     }
   })
+
+  // output warning for missing start script
+  if (hasStartScripts === false) {
+    logger.warn('Missing production and development run script(s).'.bold)
+    errors = true
+  }
 
   if (errors) {
     logger.error('Issues have been detected in roosevelt config, please consult https://github.com/rooseveltframework/roosevelt#configure-your-app-with-parameters for details on each param.'.red.bold)

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -58,8 +58,12 @@ function configAudit (appDir) {
   defaultConfigKeys.forEach((key) => {
     defaultParam = defaultConfig[key]
     if (userConfig[key] === undefined) {
-      logger.error('⚠️', `Missing param "${key}"!`.red.bold)
-      errors = true
+      if (key === 'port') {
+        logger.warn('Missing port param'.bold)
+      } else {
+        logger.error('⚠️', `Missing param "${key}"!`.red.bold)
+        errors = true
+      }
     } else if (defaultParam instanceof Object && !(Array.isArray(defaultParam)) && Object.keys(defaultParam).length > 0 && defaultParam !== null) {
       if (checkParamObject(userConfig[key], defaultParam, key)) {
         errors = true

--- a/test/unit/configAuditorTest.js
+++ b/test/unit/configAuditorTest.js
@@ -5,8 +5,10 @@ const path = require('path')
 const generateTestApp = require('../util/generateTestApp')
 const cleanupTestApp = require('../util/cleanupTestApp')
 const fork = require('child_process').fork
+const spawn = require('child_process').spawnSync
 const fse = require('fs-extra')
 const configAuditor = require('../../lib/scripts/configAuditor')
+const os = require('os')
 
 describe('Roosevelt config Auditor Test', function () {
   // path to the Test App Directory
@@ -629,6 +631,56 @@ describe('Roosevelt config Auditor Test', function () {
     testApp.on('exit', () => {
       assert.equal(startingConfigAuditBool, true, 'Roosevelt did not start the config Auditor')
       assert.equal(noErrorsBool, true, 'config Auditor is reporting back that there is an error even though the package.json file does not have one')
+      done()
+    })
+  })
+
+  it('should report that the node_modules directory is missing some packages or that some are out of date', function (done) {
+    // bool var to hold that whether or not a specific warning was outputted
+    let missingOrOODPackageBool = false
+
+    // set env.INIT_CWD to the correct location
+    process.env.INIT_CWD = appDir
+
+    // command for npm
+    let npmName
+    if (os.platform() === 'win32') {
+      npmName = 'npm.cmd'
+    } else {
+      npmName = 'npm'
+    }
+
+    // set up the node_modules and the package.json file
+    fse.ensureDirSync(appDir)
+
+    // Add dependencies to the packageJSONSource
+    packageJSONSource.dependencies = {}
+    packageJSONSource.dependencies.express = '~4.16.2'
+    packageJSONSource.dependencies.colors = `~1.2.0`
+    packageJSONSource = JSON.stringify(packageJSONSource)
+
+    // Create the package.json file in the app test dir
+    fse.writeFileSync(path.join(appDir, 'package.json'), packageJSONSource)
+
+    // Install an old version of express
+    spawn(npmName, ['install', 'express@3.0.0'], {cwd: appDir})
+
+    // Rewrite the package.json file reflecting the newer version of express
+    fse.writeFileSync(path.join(appDir, 'package.json'), packageJSONSource)
+
+    // fork the auditor and run it as a child process
+    let testApp = fork(path.join(appDir, '../', '../', '../', '/lib', '/scripts', '/configAuditor.js'), [], {'cwd': appDir, 'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
+
+    // on error logs, check if any display the missing or out of date warning log
+    testApp.stderr.on('data', data => {
+      if (data.includes('Missing Dependency')) {
+        missingOrOODPackageBool = true
+      }
+    })
+
+    // when the app exit, check to see if the warning log was made
+    testApp.on('exit', () => {
+      assert.equal(missingOrOODPackageBool, true, 'Roosevelt did not report that there are some missing or out of date packages in the app Directory')
       done()
     })
   })

--- a/test/unit/configAuditorTest.js
+++ b/test/unit/configAuditorTest.js
@@ -32,9 +32,9 @@ describe('Roosevelt config Auditor Test', function () {
 
   beforeEach(function (done) {
     // grab the contents of the default config file
-    let defaultContent = JSON.parse(fse.readFileSync(path.join(__dirname, '../', '../', 'lib', 'defaults', 'config.json')).toString('utf8'))
+    let defaultContent = JSON.parse(fse.readFileSync(path.join(__dirname, '../../lib/defaults/config.json')).toString('utf8'))
     // grab the content of the script file
-    let scriptContent = JSON.parse(fse.readFileSync(path.join(__dirname, '../', '../', 'lib', 'defaults', 'scripts.json')).toString('utf8'))
+    let scriptContent = JSON.parse(fse.readFileSync(path.join(__dirname, '../../lib/defaults/scripts.json')).toString('utf8'))
     // add the defaultContent to packageJSONSource
     packageJSONSource.rooseveltConfig = defaultContent
     // seperate the commands from the rest of the data in the scripts file
@@ -172,7 +172,7 @@ describe('Roosevelt config Auditor Test', function () {
     fse.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
 
     // fork the configAuditor.js file and run it as a child process
-    let testApp = fork(path.join(appDir, '../', '../', '../', '/lib', '/scripts', '/configAuditor.js'), [], {cwd: appDir, 'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
+    let testApp = fork(path.join(appDir, '../../../lib/scripts/configAuditor.js'), [], {cwd: appDir, 'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
 
     testApp.stdout.on('data', (data) => {
       if (data.includes('Starting roosevelt user configuration audit...')) {
@@ -556,7 +556,7 @@ describe('Roosevelt config Auditor Test', function () {
     process.env.INIT_CWD = path.join(appDir, '../', 'util')
 
     // fork the configAuditor.js file and run it as a child process
-    let testApp = fork(path.join(appDir, '../', '../', '../', '/lib', '/scripts', '/configAuditor.js'), [], {'cwd': appDir, 'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
+    let testApp = fork(path.join(appDir, '../../../lib/scripts/configAuditor.js'), [], {'cwd': appDir, 'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
 
     testApp.stdout.on('data', (data) => {
       if (data.includes('Starting roosevelt user configuration audit...')) {
@@ -617,7 +617,7 @@ describe('Roosevelt config Auditor Test', function () {
     fse.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
 
     // fork the app.js file and run it as a child process
-    let testApp = fork(path.join(appDir, '../', '../', '../', '/lib', '/scripts', '/configAuditor.js'), [], {'cwd': appDir, 'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
+    let testApp = fork(path.join(appDir, '../../../lib/scripts/configAuditor.js'), [], {'cwd': appDir, 'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
 
     testApp.stdout.on('data', (data) => {
       if (data.includes('Starting roosevelt user configuration audit...')) {
@@ -669,7 +669,7 @@ describe('Roosevelt config Auditor Test', function () {
     fse.writeFileSync(path.join(appDir, 'package.json'), packageJSONSource)
 
     // fork the auditor and run it as a child process
-    let testApp = fork(path.join(appDir, '../', '../', '../', '/lib', '/scripts', '/configAuditor.js'), [], {'cwd': appDir, 'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
+    let testApp = fork(path.join(appDir, '../../../lib/scripts/configAuditor.js'), [], {'cwd': appDir, 'stdio': ['pipe', 'pipe', 'pipe', 'ipc']})
 
     // on error logs, check if any display the missing or out of date warning log
     testApp.stderr.on('data', data => {


### PR DESCRIPTION
This changes the `npm run audit` command to `npm run config-audit`. This is to avoid confusion with the `npm audit` command in npm 6. This will also make a few other subtle changes to the auditor listed below.

- [x] Rename `audit` to `config-audit`
- [x] Add check-dependencies to the auditor
- [x] Only have the auditor warn if there are no start scripts at all
- [x] Any other parameter set by the environment should be set to a warning

(Closes: #451)