### PR TITLE
Source files from .gitignore for our jsCompiler (closes #39)

### DIFF
--- a/lib/jsCompiler.js
+++ b/lib/jsCompiler.js
@@ -19,6 +19,7 @@ module.exports = function (app, callback) {
   const fsr = require('./tools/fsr')(app)
   let preprocessor
   let jsFiles
+  let gitignoreFiles = []
   let preprocessorModule
   let preprocessorArgs
   let promises = []
@@ -84,6 +85,21 @@ module.exports = function (app, callback) {
     jsFiles = klawSync(jsPath)
   }
 
+  // read files to ignore from .gitignore
+  fs.readFile('.gitignore', (err, data) => {
+    let split
+    if (err) {
+      logger.error(err)
+    }
+    split = data.toString().split('\n')
+    split.forEach((line) => {
+      // skip blank lines
+      if (line !== '') {
+        gitignoreFiles.push(line)
+      }
+    })
+  })
+
   jsFiles.forEach((file) => {
     file = file.path || file
     promises.push(
@@ -105,7 +121,7 @@ module.exports = function (app, callback) {
           }
         }
 
-        if (file === '.' || file === '..' || file === 'Thumbs.db' || fs.lstatSync(usingWhitelist ? path.join(jsPath, file) : file).isDirectory()) {
+        if (gitignoreFiles.includes(file) || fs.lstatSync(usingWhitelist ? path.join(jsPath, file) : file).isDirectory()) {
           resolve()
         }
 


### PR DESCRIPTION
Now reads from our `.gitignore` file for `jsCompiler.js` instead of just looking for a single dot, two dots, or the `Thumbs.db` file