### PR TITLE
Fix ECMA Deprecation Warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4633,7 +4633,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -5576,8 +5575,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -71,10 +71,7 @@
   "gitHead": "",
   "eslintConfig": {
     "parserOptions": {
-      "ecmaVersion": 2017,
-      "ecmaFeatures": {
-        "experimentalObjectRestSpread": true
-      }
+      "ecmaVersion": 2018
     },
     "plugins": [
       "mocha"


### PR DESCRIPTION
Currently when running lint there's a deprecation warning for `ecmaFeatures.experimentalObjectRestSpread`

![capture](https://user-images.githubusercontent.com/3014282/43004679-8aca6404-8bfe-11e8-87c8-149644379ec9.PNG)

This is because that syntax is now supported in ECMA 2018. A link to this documentation is here https://eslint.org/docs/user-guide/configuring#specifying-parser-options

This PR just updates to ECMA 2018 and removes ecmaFeatures from package.json.