### PR TITLE
Fix: Failing Windows Unit Tests

### DIFF
--- a/test/unit/folderStructure.js
+++ b/test/unit/folderStructure.js
@@ -222,7 +222,7 @@ describe('Folder Structure Tests', function () {
   it('should not generate extra directories or files into the appDir', function (done) {
     const dirs = []
     let item
-    klaw(appDir, { depthLimit: 1 })
+    klaw(appDir, { depthLimit: 1, preserveSymlinks: true })
       .on('readable', function () {
         while ((item = this.read())) {
           dirs.push(item)

--- a/test/unit/publicFolderTest.js
+++ b/test/unit/publicFolderTest.js
@@ -202,7 +202,7 @@ describe('Public Folder Tests', function () {
       let publicNameChange = false
       // get the what is in the app folder
       const dirs = []
-      klaw(path.join(appDir, 'public'), { nofile: true })
+      klaw(path.join(appDir, 'public'), { nofile: true, preserveSymlinks: true })
         .on('readable', function () {
           let item
           while ((item = this.read())) {


### PR DESCRIPTION
While working on the custom logger for roosevelt I came across a domino effect of failing tests on Windows. The issue was the update to Klaw 3.0.0 a few days ago. 

Oddly enough the tests don't fail on AppVeyor. But they do on a standard Windows machine.

Klaw added [this](https://github.com/jprichardson/node-klaw/pull/29) preserveSymlinks option which happens to be set to `false` by default. This PR just sets that option to true, allowing all of the tests to pass once again.