### PR TITLE
Modified logger to consistently concatenate arguments into a string

### DIFF
--- a/lib/tools/logger.js
+++ b/lib/tools/logger.js
@@ -27,17 +27,17 @@ const logger = winston.createLogger({
 
 // pass in input object and returns string with spaces
 function argumentsToString (input, type) {
-  let str = []
+  let str = ''
   // convert arguments object to array
   let args = Array.prototype.slice.call(input)
   // if the first arg is a string and the first arg isn't an emoji add the types emoji
   if (typeof args[0] === 'string' && !emoji.which(args[0])) {
     switch (type) {
       case 'warn':
-        str.push('⚠️  ')
+        str += '⚠️  '
         break
       case 'error':
-        str.push('❌  ')
+        str += '❌  '
         break
     }
   }

--- a/test/unit/loggerTest.js
+++ b/test/unit/loggerTest.js
@@ -150,6 +150,39 @@ describe('Logger Tests', function () {
     done()
   })
 
+  it('should handle empty logs and other data types', function (done) {
+    // require the logger for this test
+    const logger = require('../../lib/tools/logger')()
+
+    // variable to store the logs
+    let logs = []
+    // hook up standard output
+    let unhookStdout = hookStream(process.stdout, function (string, encoding, fd) {
+      logs.push(string)
+    })
+
+    // testing logs
+    logger.log()
+    logger.log('')
+    logger.log(123)
+    logger.log({ 'key': 'value' })
+    logger.log(['array'])
+
+    // unhook stdout
+    unhookStdout()
+
+    // log assertions
+    assert.strictEqual(logs[0].includes(''), true, 'The logger failed to output an empty log')
+    assert.strictEqual(logs[1].includes(''), true, 'The logger failed to output an emty string')
+    assert.strictEqual(logs[2].includes('123'), true, 'The logger did not output a number')
+    // use inspect for objects
+    assert.strictEqual(logs[3].includes(util.inspect({ key: 'value' }, false, null, true)), true, 'The logger did not output an object')
+    assert.strictEqual(logs[4].includes(util.inspect([ 'array' ], false, null, true)), true, 'The logger did not output an array')
+
+    // exit test
+    done()
+  })
+
   it('should not have console output in production if disable has an array item \'production\' in the logging parameters', function (done) {
     //
     let logBool = false


### PR DESCRIPTION
This fixes/closes #540  

If no arguments get passed into the logger it would never iterate through the `for loop` and convert the array into a string. Instead it would try to use `String.prototype.replace()` on the array which isn't a function. 

So this PR just changes that array into a string at declaration and concatenates by default. This also adds more unit tests for the logger which check for empty logs and other data types.