### PR TITLE
Bug Fix: Path to Prism in the htmlValidator

### DIFF
--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -15,7 +15,7 @@ const os = require('os')
 const fkill = require('fkill')
 const Prism = require('prismjs')
 const prismPath = require.resolve('prismjs')
-const prismStyleSheet = fs.readFileSync(prismPath.substring(0, prismPath.lastIndexOf('/')) + '/themes/prism.css')
+const prismStyleSheet = fs.readFileSync(path.join(prismPath.split('prism.js')[0], 'themes/prism.css'))
 
 module.exports = function (app, callback) {
   const logger = require('./tools/logger')(app.get('params').logging)

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -14,7 +14,8 @@ const validatorErrorPage = fs.readFileSync(path.join(__dirname, '../defaultError
 const os = require('os')
 const fkill = require('fkill')
 const Prism = require('prismjs')
-const prismStyleSheet = fs.readFileSync(path.join(__dirname, '../node_modules/prismjs/themes/prism.css'))
+const prismPath = require.resolve('prismjs')
+const prismStyleSheet = fs.readFileSync(prismPath.substring(0, prismPath.lastIndexOf('/')) + '/themes/prism.css')
 
 module.exports = function (app, callback) {
   const logger = require('./tools/logger')(app.get('params').logging)


### PR DESCRIPTION
This fixes the path for Prism style sheet in the htmlValidator by getting the path of the module itself by using `require.resolve()`, then stripping off `prism.js` from that path, and finally concatenating the correct path for the prism.css file. Closes #550