### PR TITLE
Created a few snippets for common Roosevelt Test suite codeblocks

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 .travis.yml
+.vscode

--- a/.vscode/roosevelt.code-snippets
+++ b/.vscode/roosevelt.code-snippets
@@ -1,0 +1,52 @@
+{
+	// Place your global snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
+	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+	// Placeholders with the same ids are connected.
+	// Example:
+	// "Print to console": {
+	// 	"scope": "javascript,typescript",
+	// 	"prefix": "log",
+	// 	"body": [
+	// 		"console.log('$1');",
+	// 		"$2"
+	// 	],
+	// 	"description": "Log output to console"
+	// }
+
+	"Roosevelt Test Scaffold": {
+		"scope": "javascript",
+		"prefix": "roosevelt-test-scaffold",
+		"body": [
+			"it('$1', function (done) {",
+				"\tgenerateTestApp({",
+					"\t\tgenerateFolderStructure: true,",
+					"\t\tappDir: appDir,",
+					"\t\t$3",
+				"\t}, options)",
+				"\tconst testApp = fork(path.join(appDir, 'app.js'), { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })",
+			"})"
+		],
+		"description": "Test Scaffold for Roosevelt app that needs a test app"
+	},
+	"Roosevelt TestApp on message": {
+		"scope": "javascript",
+		"prefix": "roosevelt-test-message",
+		"body": "testApp.on('message', (params) => {$1})",
+		"description": "on('message') scaffold for roosevelt test suite"
+	},
+	"Roosevelt TestApp stderr": {
+		"scope": "javascript",
+		"prefix": "roosevelt-test-stderr",
+		"body": "testApp.stderr.on('data', (results) => {$1})",
+		"description": "stderr event scaffold for roosevelt test suite"
+	},
+	"Roosevelt TestApp stdout": {
+		"scope": "javascript",
+		"prefix": "roosevelt-test-stdout",
+		"body": "testApp.stdout.on('data', (results) => {$1})",
+		"description": "stdout event scaffold for roosevelt test suite"
+	}
+}


### PR DESCRIPTION
Closes #554

We can discuss the naming / content of the snippets but I added the following snippets:

* a snippet for scaffolding for a test with a test app
* a snippet for the event handler for stdout on the testapp
* a snippet for the event handler for stderr on the testapp
* a snippet for the event handler for the message event on the test app

As well, I added the .vscode folder to .npmignore so this isn't bundled when deployed to NPM