### PR TITLE
EPERM Symlink issue fix

### DIFF
--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -106,7 +106,7 @@ module.exports = function (app) {
 
     // make symlink if it doesn't yet exist
     if (!fsr.fileExists(linkTarget)) {
-      if (fsr.symlinkSync(staticTarget, linkTarget, 'dir')) {
+      if (fsr.symlinkSync(staticTarget, linkTarget, 'junction')) {
         logger.log('📁', `${appName} making new symlink `.cyan + `${linkTarget}`.yellow + (' pointing to ').cyan + `${staticTarget}`.yellow)
       }
     }

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -106,7 +106,7 @@ module.exports = function (app) {
 
     // make symlink if it doesn't yet exist
     if (!fsr.fileExists(linkTarget)) {
-      if (fsr.symlinkSync(staticTarget, linkTarget)) {
+      if (fsr.symlinkSync(staticTarget, linkTarget, 'dir')) {
         logger.log('📁', `${appName} making new symlink `.cyan + `${linkTarget}`.yellow + (' pointing to ').cyan + `${staticTarget}`.yellow)
       }
     }

--- a/test/unit/paramFunctionTest.js
+++ b/test/unit/paramFunctionTest.js
@@ -507,9 +507,9 @@ describe('Parameter Function Tests', function () {
     // create the symlinks
     let publicPath = path.join(appDir, 'public')
     fse.mkdirSync(publicPath)
-    fse.symlinkSync(imagesPath, path.join(publicPath, 'images'))
-    fse.symlinkSync(cssPath, path.join(publicPath, 'css'))
-    fse.symlinkSync(jsPath, path.join(publicPath, 'js'))
+    fse.symlinkSync(imagesPath, path.join(publicPath, 'images'), 'junction')
+    fse.symlinkSync(cssPath, path.join(publicPath, 'css'), 'junction')
+    fse.symlinkSync(jsPath, path.join(publicPath, 'js'), 'junction')
 
     // create the app.js file
     generateTestApp({


### PR DESCRIPTION
Roosevelt has had issues with symlinks not working properly on Windows. I stumbled upon an optional argument while skimming the node documentation today.

[fs.symlinkSync](https://nodejs.org/api/fs.html#fs_fs_symlinksync_target_path_type) has an optional argument called `type`. According to the docs _the type argument can be set to 'dir', 'file', or 'junction' and is only available on Windows (ignored on other platforms)._ and it is defaulted to `file`

Standard would always throw an error before:
![capture](https://user-images.githubusercontent.com/3014282/47455356-a999c900-d79f-11e8-8601-86a3d1c0f8ba.PNG)

After changing the `type` to `junction` standard runs fine:
![capture2](https://user-images.githubusercontent.com/3014282/47455358-ac94b980-d79f-11e8-8f85-5d694b53c330.PNG)

Note: Changing the `type` to `dir` will allow for symlinks to be read properly when walking files and directories but still requires admin to create the symlinks. If we use `junction` instead, it will allow for non-admin creation and they will still be read properly. There is a chart below that describes the pros and cons of using symlinks vs junctions on Windows. It seems that for roosevelts use case, junctions would be fine.

![unr0s](https://user-images.githubusercontent.com/3014282/47505626-7d805580-d83c-11e8-9b45-00d9c12105d7.png)

