### PR TITLE
Revamped the params for https to be more clear and understandable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,30 +427,35 @@ App behavior parameters
 HTTPS parameters
 ---
 
-- `https`: *[Object]* Run an HTTPS server using Roosevelt.
+- `https`: *[Object]* Run a HTTPS server using Roosevelt.
   - Object members:
-  - `enable`: Enable an HTTPS server.
+  - `enable`: Enable a HTTPS server.
     - Default: *[Boolean]* `false`.
-  - `httpsOnly`: Disable the HTTP server when running an HTTPS server.
+  - `httpsOnly`: Disable the HTTP server when running a HTTPS server.
     - Default: *[Boolean]* `false`.
-  - `httpsPort`: The port your app will run an HTTPS server on. Can also be defined using the `HTTPS_PORT` environment variable.
+  - `httpsPort`: The port your app will run a HTTPS server on. Can also be defined using the `HTTPS_PORT` environment variable.
     - Default: *[Number]* `43733`.
-  - `authInfoPath`: Specify either the paths where the _server_ certificate files can be found or set the appropriate parameters to be a PKCS#12-formatted string or certificate or key strings.
-    - Default: *[Boolean]* `false`.
-    - `p12`: Parameter used when the _server_ certificate/key is in PKCS#12 format.
-      - `p12Path`: Either the path to a PKCS#12-formatted file (.p12/.pfx) _or_ a PKCS#12-formatted string or buffer (i.e. the result of fs.readFileSync(/path/to/file/example.p12))
-        - Default: `null`
+  - `authInfoPath`: *[Object]* Specify either the paths where the _server_ certificate files can be found or set the appropriate parameters to be a PKCS#12-formatted string or certificate or key strings.
+    - Default: `undefined`
+    - Object members:
+    - `p12`: *[Object]* Parameter used when the _server_ certificate/key is in PKCS#12 format.
+      - Object members:
+      - `p12Path`:  *[String]* Either the path to a PKCS#12-formatted file (.p12/.pfx) _or_ a PKCS#12-formatted string or buffer (i.e. the result of fs.readFileSync(/path/to/file/example.p12))
+        - Default: `undefined`
       - `passphrase`: *[String]* The password used to encrypt the PKCS#12-formatted file or string.
-        - Default: `null`.
-    `authCertAndKey`: Parameter used when the _server_ certificate and key are in separate PEM-encoded files.
-      - `cert`: Either the path to a PEM-encoded certificate file (.crt, .cer, etc.) or a PEM-encoded certificate string.
-      - `key`: Either the path to a PEM-encoded key file (.crt, .cer, etc.) or a PEM-encoded key string for the certificate given in `cert`.
+        - Default: `undefined`.
+    - `authCertAndKey`: *[Object]* Parameter used when the _server_ certificate and key are in separate PEM-encoded files.
+      - Object members:
+      - `cert`: *[String]* Either the path to a PEM-encoded certificate file (.crt, .cer, etc.) or a PEM-encoded certificate string.
+        - Default: `undefined`
+      - `key`: *[String]* Either the path to a PEM-encoded key file (.crt, .cer, etc.) or a PEM-encoded key string for the certificate given in `cert`.
+        - Default: `undefined`
   - `caCert`: *[String]* Either the path to a PEM-encoded Certificate Authority root certificate or certificate chain or a PEM-encoded Certificate Authority root certificate or certificate chain string. _This certificate (chain) will be used to verify **client** certificates presented to the server. It is only needed if `requestCert` and `rejectUnauthorized` are both set to `true` and the client certificates are **not** signed by a Certificate Authority in the default publicly trusted list of CAs [curated by Mozilla](https://hg.mozilla.org/mozilla-central/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt)_.
-    - Default: `null`.
-  - `requestCert`: Set whether to request a certificate from the client attempting to connect to the server to verify the client's identity.
-    - Default: *[Boolean]* `false`.
-  - `rejectUnauthorized`: Set whether to reject connections from clients that do no present a valid certificate to the server. (Ignored if `requestCert` is set to `false`.)
-    - Default: *[Boolean]* `false`.
+    - Default: `undefined`.
+  - `requestCert`: *[Boolean]* Set whether to request a certificate from the client attempting to connect to the server to verify the client's identity.
+    - Default: `undefined`.
+  - `rejectUnauthorized`: *[Boolean]* Set whether to reject connections from clients that do no present a valid certificate to the server. (Ignored if `requestCert` is set to `false`.)
+    - Default:  `undefined`.
   - Default: *[Object]* `{}`.
 
 

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ HTTPS parameters
     - Default: *[Boolean]* `false`.
   - `httpsOnly`: Disable the HTTP server when running a HTTPS server.
     - Default: *[Boolean]* `false`.
-  - `httpsPort`: The port your app will run a HTTPS server on. Can also be defined using the `HTTPS_PORT` environment variable.
+  - `port`: The port your app will run a HTTPS server on. Can also be defined using the `HTTPS_PORT` environment variable.
     - Default: *[Number]* `43733`.
   - `authInfoPath`: *[Object]* Specify either the paths where the _server_ certificate files can be found or set the appropriate parameters to be a PKCS#12-formatted string or certificate or key strings.
     - Default: `undefined`

--- a/README.md
+++ b/README.md
@@ -427,28 +427,29 @@ App behavior parameters
 HTTPS parameters
 ---
 
-- `https`: *[Object]* Run a HTTPS server using Roosevelt.
+- `https`: *[Object]* Run an HTTPS server using Roosevelt.
   - Object members:
-  - `enable`: Enable HTTPS server.
+  - `enable`: Enable an HTTPS server.
     - Default: *[Boolean]* `false`.
-  - `httpsOnly`: Disable HTTP server when running a HTTPS server.
+  - `httpsOnly`: Disable the HTTP server when running an HTTPS server.
     - Default: *[Boolean]* `false`.
-  - `httpsPort`: The port your app will run a HTTPS server on.
+  - `httpsPort`: The port your app will run an HTTPS server on. Can also be defined using the `HTTPS_PORT` environment variable.
     - Default: *[Number]* `43733`.
-  - `pfx`: Specify whether or not your app will use pfx or standard certification.
+  - `authInfoPath`: Specify either the paths where the _server_ certificate files can be found or set the appropriate parameters to be a PKCS#12-formatted string or certificate or key strings.
     - Default: *[Boolean]* `false`.
-  - `keyPath`: Stores the file paths of specific key/certificate to be used by the server.
+    - `p12`: Parameter used when the _server_ certificate/key is in PKCS#12 format.
+      - `p12Path`: Either the path to a PKCS#12-formatted file (.p12/.pfx) _or_ a PKCS#12-formatted string or buffer (i.e. the result of fs.readFileSync(/path/to/file/example.p12))
+        - Default: `null`
+      - `passphrase`: *[String]* The password used to encrypt the PKCS#12-formatted file or string.
+        - Default: `null`.
+    `authCertAndKey`: Parameter used when the _server_ certificate and key are in separate PEM-encoded files.
+      - `cert`: Either the path to a PEM-encoded certificate file (.crt, .cer, etc.) or a PEM-encoded certificate string.
+      - `key`: Either the path to a PEM-encoded key file (.crt, .cer, etc.) or a PEM-encoded key string for the certificate given in `cert`.
+  - `caCert`: *[String]* Either the path to a PEM-encoded Certificate Authority root certificate or certificate chain or a PEM-encoded Certificate Authority root certificate or certificate chain string. _This certificate (chain) will be used to verify **client** certificates presented to the server. It is only needed if `requestCert` and `rejectUnauthorized` are both set to `true` and the client certificates are **not** signed by a Certificate Authority in the default publicly trusted list of CAs [curated by Mozilla](https://hg.mozilla.org/mozilla-central/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt)_.
     - Default: `null`.
-    - When set: *[Object]*  `pfx`, `key`, `cert` -- use one of {`pfx`} or {`key`, `cert`}.
-  - `passphrase`: *[String]* Supply the HTTPS server with the password for the certificate being used, if necessary.
-    - Default: `null`.
-  - `ca`: *[String]* Certificate authority to match client certificates against, as a file path or array of file paths. Can also be a full certificate string, requiring `cafile` to be `false`.
-    - Default: `null`.
-  - `cafile`: Whether or not the entry supplied by `ca` is a file.
-    - Default: *[Boolean]* `true`.
-  - `requestCert`: Request a certificate from a client and attempt to verify it.
+  - `requestCert`: Set whether to request a certificate from the client attempting to connect to the server to verify the client's identity.
     - Default: *[Boolean]* `false`.
-  - `rejectUnauthorized`: Upon failing to authorize a user with supplied CA(s), reject their connection entirely.
+  - `rejectUnauthorized`: Set whether to reject connections from clients that do no present a valid certificate to the server. (Ignored if `requestCert` is set to `false`.)
     - Default: *[Boolean]* `false`.
   - Default: *[Object]* `{}`.
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -146,8 +146,8 @@ module.exports = function (app) {
   if (flags.cores) {
     params.cores = flags.cores
   }
-  if (process.env.HTTPS_PORT && params.https.httpsPort) {
-    params.https.httpsPort = process.env.HTTPS_PORT
+  if (process.env.HTTPS_PORT && params.https.port) {
+    params.https.port = process.env.HTTPS_PORT
   }
 
   // map mvc paths

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -20,13 +20,11 @@ module.exports = function (params) {
   let logger
   let appName
   let appEnv
+  let httpsParams
   let httpServer
   let httpsServer
   let httpsOptions
-  let keyPath
-  let ca
-  let cafile
-  let passphrase
+  let authInfoPath
   let numCPUs = 1
   let servers = []
   let i
@@ -69,50 +67,72 @@ module.exports = function (params) {
   flags = app.get('flags')
 
   logger.log('💭', `Starting ${appName} in ${appEnv} mode...`.bold)
+  httpsParams = app.get('params').https
 
   // let's try setting up the servers with user-supplied params
-  if (!app.get('params').https.httpsOnly) {
+  if (!httpsParams.httpsOnly) {
     httpServer = http.Server(app)
     httpServer.on('connection', mapConnections)
   }
 
-  if (app.get('params').https.enable) {
-    httpsOptions = {
-      requestCert: app.get('params').https.requestCert,
-      rejectUnauthorized: app.get('params').https.rejectUnauthorized
-    }
-    ca = app.get('params').https.ca
-    cafile = app.get('params').https.cafile !== false
-    passphrase = app.get('params').https.passphrase
-    keyPath = app.get('params').https.keyPath
+  if (httpsParams.enable) {
+    authInfoPath = httpsParams.authInfoPath
 
-    if (keyPath) {
-      if (app.get('params').https.pfx) {
-        httpsOptions.pfx = fs.readFileSync(keyPath.pfx)
-      } else {
-        httpsOptions.key = fs.readFileSync(keyPath.key)
-        httpsOptions.cert = fs.readFileSync(keyPath.cert)
-      }
-      if (passphrase) {
-        httpsOptions.passphrase = passphrase
-      }
-      if (ca) {
-        // Are we using a CA file, or are we sending the CA directly?
-        if (cafile) {
-          // String or array
-          if (typeof ca === 'string') {
-            httpsOptions.ca = fs.readFileSync(ca)
-          } else if (ca instanceof Array) {
-            httpsOptions.ca = []
-            ca.forEach(function (val, index, array) {
-              httpsOptions.ca.push(fs.readFileSync(val))
-            })
+    // options to configure to the https server
+    httpsOptions = {}
+
+    if (authInfoPath) {
+      if (authInfoPath.p12 && authInfoPath.p12.p12Path) {
+        // if the string ends with a dot and 3 alphanumeric characters (including _)
+        // then we assume it's a filepath.
+        if (typeof authInfoPath.p12.p12Path === 'string' && authInfoPath.p12.p12Path.match(/\.\w{3}$/)) {
+          httpsOptions.pfx = fs.readFileSync(authInfoPath.p12.p12Path)
+        } else { // if the string doesn't end that way, we assume it's an encrypted string
+          httpsOptions.pfx = authInfoPath.p12.p12Path
+        }
+        if (authInfoPath.p12.passphrase) {
+          httpsOptions.passphrase = authInfoPath.p12.passphrase
+        }
+      } else if (authInfoPath.authCertAndKey) {
+        if (authInfoPath.authCertAndKey.cert) {
+          if (isCertString(authInfoPath.authCertAndKey.cert)) {
+            httpsOptions.cert = authInfoPath.authCertAndKey.cert
+          } else {
+            httpsOptions.cert = fs.readFileSync(authInfoPath.authCertAndKey.cert)
           }
-        } else {
-          httpsOptions.ca = ca
+        }
+        if (authInfoPath.authCertAndKey.key) {
+          // key strings are formatted the same way as cert strings
+          if (isCertString(authInfoPath.authCertAndKey.key)) {
+            httpsOptions.key = authInfoPath.authCertAndKey.key
+          } else {
+            httpsOptions.key = fs.readFileSync(authInfoPath.authCertAndKey.key)
+          }
         }
       }
     }
+    if (httpsParams.caCert) {
+      if (typeof httpsParams.caCert === 'string') {
+        if (isCertString(httpsParams.caCert)) { // then it's the cert(s) as a string, not a file path
+          httpsOptions.ca = httpsParams.caCert
+        } else { // it's a file path to the file, so read file
+          httpsOptions.ca = fs.readFileSync(httpsParams.caCert)
+        }
+      } else if (httpsParams.caCert instanceof Array) {
+        httpsOptions.ca = []
+
+        httpsParams.caCert.forEach(function (certOrPath) {
+          let certStr = certOrPath
+          if (!isCertString(certOrPath)) {
+            certStr = fs.readFileSync(certOrPath)
+          }
+          httpsOptions.ca.push(certStr)
+        })
+      }
+    }
+    httpsOptions.requestCert = httpsParams.requestCert
+    httpsOptions.rejectUnauthorized = httpsParams.rejectUnauthorized
+
     httpsServer = https.Server(httpsOptions, app)
     httpsServer.on('connection', mapConnections)
   }
@@ -339,8 +359,8 @@ module.exports = function (params) {
       if (!app.get('params').https.httpsOnly) {
         serverPush(httpServer, app.get('params').port, 'HTTP')
       }
-      if (app.get('params').https.enable) {
-        serverPush(httpsServer, app.get('params').https.httpsPort, 'HTTPS')
+      if (httpsParams.enable) {
+        serverPush(httpsServer, httpsParams.httpsPort, 'HTTPS')
       }
 
       process.on('SIGTERM', gracefulShutdown)
@@ -353,6 +373,14 @@ module.exports = function (params) {
       return initServer(startHttpServer)
     }
     startHttpServer()
+  }
+
+  function isCertString (stringToTest) {
+    let testString = stringToTest
+    if (typeof testString !== 'string') {
+      testString = testString.toString()
+    }
+    return (testString.substring(testString.length - 6) === '-----\n')
   }
 
   return {

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -360,7 +360,7 @@ module.exports = function (params) {
         serverPush(httpServer, app.get('params').port, 'HTTP')
       }
       if (httpsParams.enable) {
-        serverPush(httpsServer, httpsParams.httpsPort, 'HTTPS')
+        serverPush(httpsServer, httpsParams.port, 'HTTPS')
       }
 
       process.on('SIGTERM', gracefulShutdown)

--- a/test/unit/envParams.js
+++ b/test/unit/envParams.js
@@ -14,7 +14,7 @@ describe('ENV Parameter Tests', function () {
       warnings: false
     },
     https: {
-      httpsPort: 12345
+      port: 12345
     }
   }
   let app
@@ -41,12 +41,12 @@ describe('ENV Parameter Tests', function () {
     done()
   })
 
-  it('should change the https.httpsPort param to 45678', function (done) {
+  it('should change the https.port param to 45678', function (done) {
     process.env.HTTPS_PORT = 45678
     app = roosevelt({
       ...appConfig
     })
-    assert.strictEqual(app.expressApp.get('params').https.httpsPort, '45678')
+    assert.strictEqual(app.expressApp.get('params').https.port, '45678')
     delete process.env.HTTPS_PORT
     done()
   })

--- a/test/unit/httpsOptions.js
+++ b/test/unit/httpsOptions.js
@@ -54,14 +54,14 @@ describe('HTTPS Server Options Tests', function () {
     })
   })
 
-  it('should create https.Server when enabled', function () {
+  it('should create an https.Server when https.enable is set to true', function () {
     app({ appDir: appDir, ...config })
 
     // test assertion
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should create http.Server when httpsOnly is false', function () {
+  it('should create an http.Server and an https.Server when https.httpsOnly is false', function () {
     // change config
     config.https.httpsOnly = false
 
@@ -69,9 +69,10 @@ describe('HTTPS Server Options Tests', function () {
 
     // test assertion
     assert(stubHttpServer.called, 'http.Server was not called')
+    assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should not create http.Server when httpsOnly is true', function () {
+  it('should not create an http.Server when https.httpsOnly is set to true', function () {
     // change config
     config.https.httpsOnly = true
 
@@ -81,67 +82,153 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpServer.notCalled, 'http.Server called despite httpsOnly flag')
   })
 
-  it('should use given pfx file if pfx option is true', function () {
-    let keytext = fs.readFileSync(path.join(__dirname, '../util/certs/test.p12'))
-
-    // change config
-    config.https.pfx = true
+  it('should start an HTTPS server using the given p12 file and passphrase if the p12Path property is set to a file path string and the passphrase is set', function () {
+    let p12text = fs.readFileSync(path.join(__dirname, '../util/certs/test.p12'), 'utf8')
 
     app({ appDir: appDir, ...config })
 
     // test assertions
-    assert(typeof stubHttpsServer.args[0][0].key === 'undefined', 'https.Server had key when using pft')
-    assert(typeof stubHttpsServer.args[0][0].cert === 'undefined', 'https.Server had cert when using pfx')
-    assert(stubHttpsServer.args[0][0].pfx.equals(keytext), 'https.Server pfx file did not match supplied')
+    assert(typeof stubHttpsServer.args[0][0].cert === 'undefined', 'https.Server had cert when using p12')
+    assert(typeof stubHttpsServer.args[0][0].key === 'undefined', 'https.Server had key when using p12')
+    assert(stubHttpsServer.args[0][0].pfx.toString() === p12text, 'https.Server p12 file did not match file at config p12 file path')
+    assert(stubHttpsServer.args[0][0].passphrase === config.https.authInfoPath.p12.passphrase, 'https.Server passphrase did not match config passphrase')
+    assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should use key/cert if pfx option is false', function () {
+  it('should start an HTTPS server using the given p12 buffer and passphrase if the p12.p12Path property is set to a PKCS#12 formatted buffer and p12.passphrase is set', function () {
+    let p12text = fs.readFileSync(path.join(__dirname, '../util/certs/test.p12'), 'utf8')
+    config.https.authInfoPath.p12.p12Path = p12text
+    app({ appDir: appDir, ...config })
+
+    // test assertions
+    assert(typeof stubHttpsServer.args[0][0].cert === 'undefined', 'https.Server had cert when using p12')
+    assert(typeof stubHttpsServer.args[0][0].key === 'undefined', 'https.Server had key when using p12')
+    assert(stubHttpsServer.args[0][0].pfx.toString() === p12text, 'https.Server p12 file did not match supplied')
+    assert(stubHttpsServer.args[0][0].passphrase === config.https.authInfoPath.p12.passphrase, 'https.Server passphrase did not match supplied')
+    assert(stubHttpsServer.called, 'https.Server was not called')
+  })
+
+  it('should start an HTTPS server using the given certAndKey.cert and certAndKey.key if they are set with file path strings', function () {
     let keytext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.key'))
     let certext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.crt'))
 
-    // change config
-    config.https.pfx = false
+    // change config - unset p12Path
+    config.https.authInfoPath.p12.p12Path = ''
 
     app({ appDir: appDir, ...config })
 
     // test assertions
     assert(stubHttpsServer.args[0][0].key.equals(keytext), 'https.Server key file did not match supplied')
     assert(stubHttpsServer.args[0][0].cert.equals(certext), 'https.Server cert file did not match supplied')
-    assert(typeof stubHttpsServer.args[0][0].pfx === 'undefined', 'https.Server had pfx when using key/cert')
+    assert(typeof stubHttpsServer.args[0][0].pfx === 'undefined', 'https.Server options had pfx set when p12Path was null')
+    assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should read certificate authority from file if cafile is true', function () {
+  it('should start an HTTPS server using the given certAndKey.cert and certAndKey.key if one is a certificate string and one is a file path', function () {
+    let certext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.crt'))
+    let keytext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.key'))
+
+    // change config - change key to a string
+    config.https.authInfoPath.authCertAndKey.key = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.key'))
+
+    app({ appDir: appDir, ...config })
+
+    // test assertions
+    assert(stubHttpsServer.args[0][0].key.equals(keytext), 'https.Server key file did not match supplied')
+    assert(stubHttpsServer.args[0][0].cert.equals(certext), 'https.Server cert file did not match supplied')
+    assert(typeof stubHttpsServer.args[0][0].pfx === 'undefined', 'https.Server options had pfx set when p12Path was null')
+    assert(stubHttpsServer.called, 'https.Server was not called')
+  })
+
+  it('should start an HTTPS server using the given certAndKey.cert and certAndKey.key if they are set with certificate strings', function () {
+    let certext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.crt'))
+    let keytext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.key'))
+
+    // change config - change cert to a  string
+    config.https.authInfoPath.authCertAndKey.cert = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.crt'))
+
+    app({ appDir: appDir, ...config })
+
+    // test assertions
+    assert(stubHttpsServer.args[0][0].key.equals(keytext), 'https.Server key file did not match supplied')
+    assert(stubHttpsServer.args[0][0].cert.equals(certext), 'https.Server cert file did not match supplied')
+    assert(typeof stubHttpsServer.args[0][0].pfx === 'undefined', 'https.Server options had pfx set when p12Path was null')
+    assert(stubHttpsServer.called, 'https.Server was not called')
+  })
+
+  it('should start an HTTPS server using the certificate authority certificate from a file if the caCert property is set with a file path', function () {
     let catext = fs.readFileSync(path.join(__dirname, '../util/certs/ca.crt'))
 
     app({ appDir: appDir, ...config })
 
     // test assertion
     assert(stubHttpsServer.args[0][0].ca.equals(catext), 'https.Server CA did not match supplied CA')
+    assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should be able to read array of certificates', function () {
+  it('should start an HTTPS using a certificate chain as an array of certificates when the caCert property is set with an array of file paths', function () {
     let ca1 = fs.readFileSync(path.join(__dirname, '../util/certs/ca.crt'))
     let ca2 = fs.readFileSync(path.join(__dirname, '../util/certs/ca-2.crt'))
 
     // change config
-    config.https.ca = ['test/util/certs/ca.crt', 'test/util/certs/ca-2.crt']
+    config.https.caCert = ['test/util/certs/ca.crt', 'test/util/certs/ca-2.crt']
 
     app({ appDir: appDir, ...config })
 
     // test assertions
     assert(stubHttpsServer.args[0][0].ca[0].equals(ca1), 'https.Server CA (1) did not match supplied CA')
     assert(stubHttpsServer.args[0][0].ca[1].equals(ca2), 'https.Server CA (2) did not match supplied CA')
+    assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should pass certificate authority directly to httpsServer if cafile is false', function () {
+  it('should start an HTTPS server using the caCert property directly if it is set as a certificate string', function () {
     // change config
-    config.https.ca = 'test/util/certs/ca.crt'
-    config.https.cafile = false
-    config.https.ca = fs.readFileSync(config.https.ca, 'UTF8')
+    config.https.caCert = fs.readFileSync('test/util/certs/ca.crt', 'UTF8')
 
     app({ appDir: appDir, ...config })
 
     // test assertion
-    assert.strictEqual(stubHttpsServer.args[0][0].ca, config.https.ca, 'https.Server CA did not match supplied CA')
+    assert.strictEqual(stubHttpsServer.args[0][0].ca, config.https.caCert, 'https.Server CA did not match supplied CA')
+    assert(stubHttpsServer.called, 'https.Server was not called')
+  })
+
+  it('should start an HTTPS server using the caCert certificate chain if it is set as an array of certificate strings', function () {
+    let ca1 = fs.readFileSync(path.join(__dirname, '../util/certs/ca.crt'))
+    let ca2 = fs.readFileSync(path.join(__dirname, '../util/certs/ca-2.crt'))
+
+    // change config
+    config.https.caCert = [ca1, ca2]
+
+    app({ appDir: appDir, ...config })
+
+    // test assertions
+    assert(stubHttpsServer.args[0][0].ca[0].equals(ca1), 'https.Server CA (1) did not match supplied CA')
+    assert(stubHttpsServer.args[0][0].ca[1].equals(ca2), 'https.Server CA (2) did not match supplied CA')
+    assert(stubHttpsServer.called, 'https.Server was not called')
+  })
+
+  it('should start an HTTPS server using the caCert certificate chain if it is set as an array of mixed file paths and certificate strings', function () {
+    let ca1 = fs.readFileSync(path.join(__dirname, '../util/certs/ca.crt'))
+    let ca2 = fs.readFileSync(path.join(__dirname, '../util/certs/ca-2.crt'))
+
+    // change config
+    config.https.caCert = [ca1, path.join(__dirname, '../util/certs/ca-2.crt')]
+
+    app({ appDir: appDir, ...config })
+
+    // test assertions
+    assert(stubHttpsServer.args[0][0].ca[0].equals(ca1), 'https.Server CA (1) did not match supplied CA')
+    assert(stubHttpsServer.args[0][0].ca[1].equals(ca2), 'https.Server CA (2) did not match supplied CA')
+    assert(stubHttpsServer.called, 'https.Server was not called')
+  })
+
+  it('should start an HTTPS server if the caCert property is not a string or an array', function () {
+    // change config
+    config.https.caCert = 42
+
+    app({ appDir: appDir, ...config })
+
+    // test assertions
+    assert(stubHttpsServer.called, 'https.Server was not called')
   })
 })

--- a/test/unit/httpsOptions.js
+++ b/test/unit/httpsOptions.js
@@ -54,14 +54,14 @@ describe('HTTPS Server Options Tests', function () {
     })
   })
 
-  it('should create an https.Server when https.enable is set to true', function () {
+  it('should create a https server when https.enable is set to true', function () {
     app({ appDir: appDir, ...config })
 
     // test assertion
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should create an http.Server and an https.Server when https.httpsOnly is false', function () {
+  it('should create a http server and a https server when the https.httpsOnly param is false', function () {
     // change config
     config.https.httpsOnly = false
 
@@ -72,7 +72,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should not create an http.Server when https.httpsOnly is set to true', function () {
+  it('should not create a http.Server when the https.httpsOnly param is set to true', function () {
     // change config
     config.https.httpsOnly = true
 
@@ -82,7 +82,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpServer.notCalled, 'http.Server called despite httpsOnly flag')
   })
 
-  it('should start an HTTPS server using the given p12 file and passphrase if the p12Path property is set to a file path string and the passphrase is set', function () {
+  it('should start a https server using the given p12 file and passphrase if the p12Path param is set to a file path string and the passphrase is set', function () {
     let p12text = fs.readFileSync(path.join(__dirname, '../util/certs/test.p12'), 'utf8')
 
     app({ appDir: appDir, ...config })
@@ -95,7 +95,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should start an HTTPS server using the given p12 buffer and passphrase if the p12.p12Path property is set to a PKCS#12 formatted buffer and p12.passphrase is set', function () {
+  it('should start a https server using the given p12 buffer and passphrase if the p12.p12Path param is set to a PKCS#12 formatted buffer and p12.passphrase is set', function () {
     let p12text = fs.readFileSync(path.join(__dirname, '../util/certs/test.p12'), 'utf8')
     config.https.authInfoPath.p12.p12Path = p12text
     app({ appDir: appDir, ...config })
@@ -108,7 +108,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should start an HTTPS server using the given certAndKey.cert and certAndKey.key if they are set with file path strings', function () {
+  it('should start a https server using the given certAndKey.cert and certAndKey.key params if they are set with file path strings', function () {
     let keytext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.key'))
     let certext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.crt'))
 
@@ -124,7 +124,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should start an HTTPS server using the given certAndKey.cert and certAndKey.key if one is a certificate string and one is a file path', function () {
+  it('should start a https server using the given certAndKey.cert and certAndKey.key params if one is a certificate string and one is a file path', function () {
     let certext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.crt'))
     let keytext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.key'))
 
@@ -140,7 +140,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should start an HTTPS server using the given certAndKey.cert and certAndKey.key if they are set with certificate strings', function () {
+  it('should start a https server using the given certAndKey.cert and certAndKey.key params if they are set with certificate strings', function () {
     let certext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.crt'))
     let keytext = fs.readFileSync(path.join(__dirname, '../util/certs/test.req.key'))
 
@@ -156,7 +156,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should start an HTTPS server using the certificate authority certificate from a file if the caCert property is set with a file path', function () {
+  it('should start a https server using the certificate authority certificate from a file if the caCert param is set with a file path', function () {
     let catext = fs.readFileSync(path.join(__dirname, '../util/certs/ca.crt'))
 
     app({ appDir: appDir, ...config })
@@ -166,7 +166,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should start an HTTPS using a certificate chain as an array of certificates when the caCert property is set with an array of file paths', function () {
+  it('should start a https using a certificate chain as an array of certificates when the caCert param is set with an array of file paths', function () {
     let ca1 = fs.readFileSync(path.join(__dirname, '../util/certs/ca.crt'))
     let ca2 = fs.readFileSync(path.join(__dirname, '../util/certs/ca-2.crt'))
 
@@ -181,7 +181,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should start an HTTPS server using the caCert property directly if it is set as a certificate string', function () {
+  it('should start a https server using the caCert param directly if it is set as a certificate string', function () {
     // change config
     config.https.caCert = fs.readFileSync('test/util/certs/ca.crt', 'UTF8')
 
@@ -192,7 +192,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should start an HTTPS server using the caCert certificate chain if it is set as an array of certificate strings', function () {
+  it('should start a https server using the caCert certificate chain if the caCert param is set as an array of certificate strings', function () {
     let ca1 = fs.readFileSync(path.join(__dirname, '../util/certs/ca.crt'))
     let ca2 = fs.readFileSync(path.join(__dirname, '../util/certs/ca-2.crt'))
 
@@ -207,7 +207,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should start an HTTPS server using the caCert certificate chain if it is set as an array of mixed file paths and certificate strings', function () {
+  it('should start a https server using the caCert certificate chain if it the caCert param set as an array of mixed file paths and certificate strings', function () {
     let ca1 = fs.readFileSync(path.join(__dirname, '../util/certs/ca.crt'))
     let ca2 = fs.readFileSync(path.join(__dirname, '../util/certs/ca-2.crt'))
 
@@ -222,7 +222,7 @@ describe('HTTPS Server Options Tests', function () {
     assert(stubHttpsServer.called, 'https.Server was not called')
   })
 
-  it('should start an HTTPS server if the caCert property is not a string or an array', function () {
+  it('should start a https server if the caCert param is not a string or an array', function () {
     // change config
     config.https.caCert = 42
 

--- a/test/unit/rooseveltTest.js
+++ b/test/unit/rooseveltTest.js
@@ -18,14 +18,6 @@ describe('Roosevelt.js Tests', function () {
   // options to pass into test app generator
   let sOptions = { rooseveltPath: '../../../roosevelt', method: 'startServer', stopServer: true }
 
-  // paths to key and cert & ca files
-  let certs = {
-    key: path.join(__dirname, '/../util/certs/test.req.key'),
-    cert: path.join(__dirname, '/../util/certs/test.req.crt'),
-    ca: path.join(__dirname, '/../util/certs/ca.crt'),
-    ca2: path.join(__dirname, '/../util/certs/ca-2.crt')
-  }
-
   // clean up the test app directory after each test
   afterEach(function (done) {
     cleanupTestApp(appDir, (err) => {
@@ -448,86 +440,6 @@ describe('Roosevelt.js Tests', function () {
     })
   })
 
-  it('should be able to start an HTTPS server if it is enabled', function (done) {
-    // bool var to see if a specific log was outputted
-    let httpsServerMadeBool = false
-
-    // generate the app.js file
-    generateTestApp({
-      appDir: appDir,
-      generateFolderStructure: true,
-      onServerStart: `(app) => {process.send(app.get("params"))}`,
-      https: {
-        enable: true,
-        httpsPort: 43203
-      }
-    }, sOptions)
-
-    // fork the app and run it as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), ['--dev'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // listen on the logs to see if the https server is initialized
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Roosevelt Express HTTPS server listening on port')) {
-        httpsServerMadeBool = true
-      }
-    })
-
-    // when the app starts, kill it
-    testApp.on('message', (params) => {
-      testApp.send('stop')
-    })
-
-    // on exit, check if roosevelt an https server started or not
-    testApp.on('exit', () => {
-      assert.strictEqual(httpsServerMadeBool, true, 'Roosevelt did not make the HTTPS server even though it was enabled')
-      done()
-    })
-  })
-
-  it('should start an HTTPS server if it is enabled and httpsOnly param is true', function (done) {
-    // bool var to see if specifics log was outputted
-    let httpsServerMadeBool = false
-    let httpServerMadeBool = false
-
-    // generate the app.js file
-    generateTestApp({
-      appDir: appDir,
-      generateFolderStructure: true,
-      onServerStart: `(app) => {process.send(app.get("params"))}`,
-      https: {
-        enable: true,
-        httpsPort: 43203,
-        httpsOnly: true
-      }
-    }, sOptions)
-
-    // fork the app and run it as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), ['--dev'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // Check the logs to see which type of server was made
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Roosevelt Express HTTPS server listening on port')) {
-        httpsServerMadeBool = true
-      }
-      if (data.includes('Roosevelt Express HTTP server listening on port')) {
-        httpServerMadeBool = true
-      }
-    })
-
-    // when the app starts, kill it
-    testApp.on('message', (params) => {
-      testApp.send('stop')
-    })
-
-    // on exit, see if the app started an https server and not an http server
-    testApp.on('exit', () => {
-      assert.strictEqual(httpsServerMadeBool, true, 'Roosevelt did not make the HTTPS server even though it was enabled')
-      assert.strictEqual(httpServerMadeBool, false, 'Roosevelt made a http Server even though the httpsOnly param is true')
-      done()
-    })
-  })
-
   it('should be able to run the app in production mode', function (done) {
     // bool var to hold whether a specific log was outputted
     let productionModeBool = false
@@ -598,6 +510,38 @@ describe('Roosevelt.js Tests', function () {
     })
   })
 
+  it('should not execute onServerStart if the value is not a function', function (done) {
+    // bool var that will hold whether or not a message is recieved based on if a function was passed to onServerStart
+    let serverStartFunctionBool = false
+
+    // generate the app.js file
+    generateTestApp({
+      appDir: appDir,
+      generateFolderStructure: true,
+      onServerStart: `something`
+    }, sOptions)
+
+    // fork the app and run it as a child process
+    const testApp = fork(path.join(appDir, 'app.js'), ['--prod'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
+
+    // if a message was recieved, then it probably means that the onServerStart param has excuted and sent something
+    testApp.on('message', () => {
+      serverStartFunctionBool = true
+      testApp.send('stop')
+    })
+
+    // since a message will not be recieved by the test suite, kill the app after a certain amount of time
+    setTimeout(function () {
+      testApp.send('stop')
+    }, 4000)
+
+    // on exit, test to see if a message was recieved by the test suite from the app
+    testApp.on('exit', () => {
+      assert.strictEqual(serverStartFunctionBool, false, 'Roosevelt still executed what was in onServerStart even though it is not a function')
+      done()
+    })
+  })
+
   it('should be able to run the app with localhostOnly set to true, in production mode, and run an HTTPS server', function (done) {
     // bool var to hold whether a specific log was outputted
     let productionModeBool = false
@@ -640,237 +584,6 @@ describe('Roosevelt.js Tests', function () {
     testApp.on('exit', () => {
       assert.strictEqual(productionModeBool, true, 'Roosevelt did not start in production mode even though the production flag was passed to it as a command line arg')
       assert.strictEqual(httpsServerMadeBool, true, 'Roosevelt did not make a HTTPS server even though it is enabled')
-      done()
-    })
-  })
-
-  it('should not execute onServerStart if the value is not a function', function (done) {
-    // bool var that will hold whether or not a message is recieved based on if a function was passed to onServerStart
-    let serverStartFunctionBool = false
-
-    // generate the app.js file
-    generateTestApp({
-      appDir: appDir,
-      generateFolderStructure: true,
-      onServerStart: `something`
-    }, sOptions)
-
-    // fork the app and run it as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), ['--prod'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // if a message was recieved, then it probably means that the onServerStart param has excuted and sent something
-    testApp.on('message', () => {
-      serverStartFunctionBool = true
-      testApp.send('stop')
-    })
-
-    // since a message will not be recieved by the test suite, kill the app after a certain amount of time
-    setTimeout(function () {
-      testApp.send('stop')
-    }, 4000)
-
-    // on exit, test to see if a message was recieved by the test suite from the app
-    testApp.on('exit', () => {
-      assert.strictEqual(serverStartFunctionBool, false, 'Roosevelt still executed what was in onServerStart even though it is not a function')
-      done()
-    })
-  })
-
-  it('should be able to start the app as an HTTPS server without the passphrase or ca', function (done) {
-    // bool var to hold that the HTTPS server is listening
-    let HTTPSServerListeningBool = false
-
-    // generate the app.js file
-    generateTestApp({
-      appDir: appDir,
-      generateFolderStructure: true,
-      onServerStart: `(app) => {process.send(app.get("params"))}`,
-      https: {
-        enable: true,
-        httpsPort: 43733,
-        passphrase: undefined,
-        ca: undefined,
-        keyPath: { key: certs.key, cert: certs.cert }
-      }
-    }, sOptions)
-
-    // fork the app and run it as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), ['--prod'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on logs, check to see if the specific log was outputted
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Roosevelt Express HTTPS server listening on port')) {
-        HTTPSServerListeningBool = true
-      }
-    })
-
-    // when the app finishes initialization and starts, kill it
-    testApp.on('message', (params) => {
-      testApp.send('stop')
-    })
-
-    // on the apps exit, see of the HTTPS server was listening
-    testApp.on('exit', () => {
-      assert.strictEqual(HTTPSServerListeningBool, true, 'Roosevelt did not make a HTTPS Server')
-      done()
-    })
-  })
-
-  it('should be able to start the app as an HTTPS server with a passphrase', function (done) {
-    // bool var to hold that the HTTPS server is listening
-    let HTTPSServerListeningBool = false
-
-    // generate the app.js file
-    generateTestApp({
-      appDir: appDir,
-      generateFolderStructure: true,
-      onServerStart: `(app) => {process.send(app.get("params"))}`,
-      https: {
-        enable: true,
-        httpsPort: 43733,
-        passphrase: 'something',
-        keyPath: { key: certs.key, cert: certs.cert }
-      }
-    }, sOptions)
-
-    // fork the app and run it as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), ['--prod'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on logs, check to see if the specific log was outputted
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Roosevelt Express HTTPS server listening on port')) {
-        HTTPSServerListeningBool = true
-      }
-    })
-
-    // when the app finishes initialization and starts, kill it
-    testApp.on('message', (params) => {
-      testApp.send('stop')
-    })
-
-    // on the apps exit, see of the HTTPS server was listening
-    testApp.on('exit', () => {
-      assert.strictEqual(HTTPSServerListeningBool, true, 'Roosevelt did not make a HTTPS Server')
-      done()
-    })
-  })
-
-  it('should be able to start an HTTPS server if a ca string is passed in', function (done) {
-    // bool var to hold that the HTTPS server is listening
-    let HTTPSServerListeningBool = false
-
-    // generate the app.js file
-    generateTestApp({
-      appDir: appDir,
-      generateFolderStructure: true,
-      onServerStart: `(app) => {process.send(app.get("params"))}`,
-      https: {
-        enable: true,
-        httpsPort: 43733,
-        keyPath: { key: certs.key, cert: certs.cert },
-        ca: certs.ca,
-        cafile: true
-      }
-    }, sOptions)
-
-    // fork the app and run it as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), ['--prod'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on logs, check to see if the specific log was outputted
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Roosevelt Express HTTPS server listening on port')) {
-        HTTPSServerListeningBool = true
-      }
-    })
-
-    // when the app finishes initialization and starts, kill it
-    testApp.on('message', () => {
-      testApp.send('stop')
-    })
-
-    // on the apps exit, see of the HTTPS server was listening
-    testApp.on('exit', () => {
-      assert.strictEqual(HTTPSServerListeningBool, true, 'Roosevelt did not make a HTTPS Server')
-      done()
-    })
-  })
-
-  it('should be able to start an HTTPS server if a ca array is passed in', function (done) {
-    // bool var to hold that the HTTPS server is listening
-    let HTTPSServerListeningBool = false
-
-    // generate the app.js file
-    generateTestApp({
-      appDir: appDir,
-      generateFolderStructure: true,
-      onServerStart: `(app) => {process.send(app.get("params"))}`,
-      https: {
-        enable: true,
-        httpsPort: 43733,
-        keyPath: { key: certs.key, cert: certs.cert },
-        ca: [certs.ca, certs.ca2],
-        cafile: true
-      }
-    }, sOptions)
-
-    // fork the app and run it as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), ['--prod'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on logs, check to see if the specific log was outputted
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Roosevelt Express HTTPS server listening on port')) {
-        HTTPSServerListeningBool = true
-      }
-    })
-
-    // when the app finishes initialization and starts, kill it
-    testApp.on('message', () => {
-      testApp.send('stop')
-    })
-
-    // on the apps exit, see of the HTTPS server was listening
-    testApp.on('exit', () => {
-      assert.strictEqual(HTTPSServerListeningBool, true, 'Roosevelt did not make a HTTPS Server')
-      done()
-    })
-  })
-
-  it('should be able to start an HTTPS server if a ca passed in is not a string or array and cafile is set to true', function (done) {
-    // bool var to hold that the HTTPS server is listening
-    let HTTPSServerListeningBool = false
-
-    // generate the app.js file
-    generateTestApp({
-      appDir: appDir,
-      generateFolderStructure: true,
-      onServerStart: `(app) => {process.send(app.get("params"))}`,
-      https: {
-        enable: true,
-        httpsPort: 43733,
-        keyPath: { key: certs.key, cert: certs.cert },
-        ca: 32,
-        cafile: true
-      }
-    }, sOptions)
-
-    // fork the app and run it as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), ['--prod'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on logs, check to see if the specific log was outputted
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Roosevelt Express HTTPS server listening on port')) {
-        HTTPSServerListeningBool = true
-      }
-    })
-
-    // when the app finishes initialization and starts, kill it
-    testApp.on('message', () => {
-      testApp.send('stop')
-    })
-
-    // on the apps exit, see of the HTTPS server was listening
-    testApp.on('exit', () => {
-      assert.strictEqual(HTTPSServerListeningBool, true, 'Roosevelt did not make a HTTPS Server')
       done()
     })
   })

--- a/test/unit/rooseveltTest.js
+++ b/test/unit/rooseveltTest.js
@@ -554,7 +554,7 @@ describe('Roosevelt.js Tests', function () {
       localhostOnly: true,
       https: {
         enable: true,
-        httpsPort: 43203
+        port: 43203
       },
       onServerStart: `(app) => {process.send(app.get("params"))}`
     }, sOptions)
@@ -836,7 +836,7 @@ describe('Roosevelt.js Tests', function () {
       generateFolderStructure: true,
       https: {
         enable: true,
-        httpsPort: 43203,
+        port: 43203,
         httpsOnly: true
       }
     }, sOptions)

--- a/test/unit/routesTest.js
+++ b/test/unit/routesTest.js
@@ -707,7 +707,7 @@ describe('Roosevelt Routes Tests', function () {
       generateFolderStructure: true,
       https: {
         enable: true,
-        httpsPort: 43203
+        port: 43203
       },
       onServerStart: `(app) => {process.send(app.get("params"))}`,
       shutdownTimeout: 7000

--- a/test/util/generateTestApp.js
+++ b/test/util/generateTestApp.js
@@ -94,7 +94,7 @@ module.exports = function (params, options) {
     contents += defaultMessages
   }
 
-  // generate test app drectory
+  // generate test app directory
   fse.ensureDirSync(path.join(appDir))
 
   // generate app.js in test directory

--- a/test/util/testHttpsConfig.json
+++ b/test/util/testHttpsConfig.json
@@ -9,7 +9,7 @@
   "https": {
     "enable": true,
     "httpsOnly": true,
-    "httpsPort": 2468,
+    "port": 2468,
     "authInfoPath": {
       "p12": {
         "p12Path": "test/util/certs/test.p12",

--- a/test/util/testHttpsConfig.json
+++ b/test/util/testHttpsConfig.json
@@ -9,16 +9,18 @@
   "https": {
     "enable": true,
     "httpsOnly": true,
-    "httpsPort": 1234,
-    "pfx": false,
-    "keyPath": {
-      "pfx": "test/util/certs/test.p12",
-      "key": "test/util/certs/test.req.key",
-      "cert": "test/util/certs/test.req.crt"
+    "httpsPort": 2468,
+    "authInfoPath": {
+      "p12": {
+        "p12Path": "test/util/certs/test.p12",
+        "passphrase": "testpass"
+      },
+      "authCertAndKey": {
+        "cert": "test/util/certs/test.req.crt",
+        "key": "test/util/certs/test.req.key"
+      }
     },
-    "passphrase": "testpass",
-    "cafile": true,
-    "ca": "test/util/certs/ca.crt",
+    "caCert": "test/util/certs/ca.crt",
     "requestCert": false,
     "rejectUnauthorized": false
   }


### PR DESCRIPTION
Removed the 'pfx' and 'cafile' params, as they were unnecessary, and changed the keyPath object to be an object named authInfoPath containing one object defining the information needed if the server certificate is a p12 (pfx) file and a second object containing the information needed if the server certificate and key are in separate files. The README was updated to more clearly define what each parameter does and how certain parameters affect certain other parameters. In addition, nearly all of the tests relating to the https parameters have been moved from the rooseveltTest.js test file into the httpsOptions.js test file to remove duplication and for clarity.