### PR TITLE
Changed end-of-line character in https code to be OS-agnostic.

### DIFF
--- a/roosevelt.js
+++ b/roosevelt.js
@@ -380,7 +380,8 @@ module.exports = function (params) {
     if (typeof testString !== 'string') {
       testString = testString.toString()
     }
-    return (testString.substring(testString.length - 6) === '-----\n')
+    let endOfLine = require('os').EOL
+    return (testString.substring(testString.length - (endOfLine.length + 5)) === ('-----' + endOfLine))
   }
 
   return {


### PR DESCRIPTION
The end-of-line character in part of the https code in roosevelt.js needed to be changed to be OS-agnostic so the code would properly differentiate between a file path and a PKCS#12, certificate, or key string when using the https.authInfoPath.p12.p12Path or https.authInfoPath.authCertAndKey.cert and/or https.authInfoPath.authCertAndKey.key params in different OSes.