### PR TITLE
Fix AppVeyor for not changing linefeed on clone for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
     - nodejs_version: "8"
     - nodejs_version: "10"
+init:
+  - git config --global core.autocrlf true
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install


### PR DESCRIPTION
By default AppVeyor does not change the linefeed characters from a unix system to a windows system: https://www.appveyor.com/docs/lang/nodejs-iojs/#line-endings

This PR fixes that and resolves the HTTPS Server Options tests breaking due to such