### PR TITLE
Config Auditor - Skip extra parameters

### DIFF
--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -7,7 +7,8 @@
     "http": true,
     "appStatus": true,
     "warnings": true,
-    "verbose": false
+    "verbose": false,
+    "_roosevelt-extra-exempt": true
   },
   "minify": true,
   "htmlValidator": {
@@ -25,7 +26,9 @@
     }
   },
   "multipart": {
-    "multiples": true
+    "multiples": true,
+    "_roosevelt-extra-exempt": true,
+    "_roosevelt-missing-exempt": true
   },
   "toobusy": {
     "maxLagPerRequest": 70,
@@ -35,7 +38,9 @@
     "urlEncoded": {
       "extended": true
     },
-    "json": {}
+    "json": {},
+    "_roosevelt-extra-exempt": true,
+    "_roosevelt-missing-exempt": true
   },
   "checkDependencies": true,
   "cores": 1,

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -36,11 +36,13 @@
   },
   "bodyParser": {
     "urlEncoded": {
-      "extended": true
+      "extended": true,
+      "_roosevelt-extra-exempt": true,
+      "_roosevelt-missing-exempt": true
     },
-    "json": {},
-    "_roosevelt-extra-exempt": true,
-    "_roosevelt-missing-exempt": true
+    "json": {
+      "_roosevelt-extra-exempt": true
+    }
   },
   "checkDependencies": true,
   "cores": 1,

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -66,7 +66,9 @@
       "collapseWhitespace": true,
       "collapseBooleanAttributes": true,
       "removeAttributeQuotes": true,
-      "removeEmptyAttributes": true
+      "removeEmptyAttributes": true,
+      "_roosevelt-extra-exempt": true,
+      "_roosevelt-missing-exempt": true
     }
   },
   "css": {

--- a/lib/tools/checkParamObject.js
+++ b/lib/tools/checkParamObject.js
@@ -7,31 +7,29 @@ module.exports = function (userParam, defaultParam, auditKey) {
   let defaultProp
   let extraOrMissingkeysBool = false
 
-  // params to skip
-  let skipExtra = ['logging', 'multipart', 'bodyParser']
-  let skipMissing = ['multipart', 'bodyParser']
-
-  if (auditKey) {
+  if (auditKey && defaultParam['_roosevelt-extra-exempt'] !== true) {
     userKeys.forEach((key) => {
-      if (defaultParam[key] === undefined && !skipExtra.includes(auditKey)) {
+      if (defaultParam[key] === undefined) {
         logger.error('⚠️', ` Extra param "${key}" found in "${auditKey}", this can be removed.`.red.bold)
         extraOrMissingkeysBool = true
       }
     })
   }
 
-  defaultKeys.forEach((key) => {
-    defaultProp = defaultParam[key]
-    if (userParam[key] === undefined) {
-      if (auditKey && !skipMissing.includes(auditKey)) {
-        logger.error('⚠️', ` Missing param "${key}" in "${auditKey}"!`.red.bold)
-        extraOrMissingkeysBool = true
-      } else {
-        userParam[key] = defaultProp
+  if (defaultParam['_roosevelt-missing-exempt'] !== true) {
+    defaultKeys.forEach((key) => {
+      defaultProp = defaultParam[key]
+      if (userParam[key] === undefined && key !== '_roosevelt-extra-exempt') {
+        if (auditKey) {
+          logger.error('⚠️', ` Missing param "${key}" in "${auditKey}"!`.red.bold)
+          extraOrMissingkeysBool = true
+        } else {
+          userParam[key] = defaultProp
+        }
+      } else if (defaultProp instanceof Object && !(Array.isArray(defaultProp)) && Object.keys(defaultProp).length > 0 && defaultProp !== null) {
+        module.exports(userParam[key], defaultProp, auditKey ? key : undefined)
       }
-    } else if (defaultProp instanceof Object && !(Array.isArray(defaultProp)) && Object.keys(defaultProp).length > 0 && defaultProp !== null) {
-      module.exports(userParam[key], defaultProp, auditKey ? key : undefined)
-    }
-  })
+    })
+  }
   return extraOrMissingkeysBool
 }

--- a/lib/tools/checkParamObject.js
+++ b/lib/tools/checkParamObject.js
@@ -8,11 +8,12 @@ module.exports = function (userParam, defaultParam, auditKey) {
   let extraOrMissingkeysBool = false
 
   // params to skip
-  let skipParams = ['logging', 'multipart', 'bodyParser']
+  let skipExtra = ['logging', 'multipart', 'bodyParser']
+  let skipMissing = ['multipart', 'bodyParser']
 
   if (auditKey) {
     userKeys.forEach((key) => {
-      if (defaultParam[key] === undefined && !skipParams.includes(auditKey)) {
+      if (defaultParam[key] === undefined && !skipExtra.includes(auditKey)) {
         logger.error('⚠️', ` Extra param "${key}" found in "${auditKey}", this can be removed.`.red.bold)
         extraOrMissingkeysBool = true
       }
@@ -22,7 +23,7 @@ module.exports = function (userParam, defaultParam, auditKey) {
   defaultKeys.forEach((key) => {
     defaultProp = defaultParam[key]
     if (userParam[key] === undefined) {
-      if (auditKey && !skipParams.includes(auditKey)) {
+      if (auditKey && !skipMissing.includes(auditKey)) {
         logger.error('⚠️', ` Missing param "${key}" in "${auditKey}"!`.red.bold)
         extraOrMissingkeysBool = true
       } else {

--- a/lib/tools/checkParamObject.js
+++ b/lib/tools/checkParamObject.js
@@ -7,9 +7,12 @@ module.exports = function (userParam, defaultParam, auditKey) {
   let defaultProp
   let extraOrMissingkeysBool = false
 
+  // params to skip
+  let skipParams = ['logging', 'multipart', 'bodyParser']
+
   if (auditKey) {
     userKeys.forEach((key) => {
-      if (defaultParam[key] === undefined && auditKey !== 'logging') {
+      if (defaultParam[key] === undefined && !skipParams.includes(auditKey)) {
         logger.error('⚠️', ` Extra param "${key}" found in "${auditKey}", this can be removed.`.red.bold)
         extraOrMissingkeysBool = true
       }
@@ -19,7 +22,7 @@ module.exports = function (userParam, defaultParam, auditKey) {
   defaultKeys.forEach((key) => {
     defaultProp = defaultParam[key]
     if (userParam[key] === undefined) {
-      if (auditKey) {
+      if (auditKey && !skipParams.includes(auditKey)) {
         logger.error('⚠️', ` Missing param "${key}" in "${auditKey}"!`.red.bold)
         extraOrMissingkeysBool = true
       } else {

--- a/test/unit/configAuditorTest.js
+++ b/test/unit/configAuditorTest.js
@@ -478,6 +478,106 @@ describe('Roosevelt Config Auditor Test', function () {
     })
   })
 
+  it('should not report that there are extra params if _roosevelt-extra-exempt is set to true', function (done) {
+    // bool var to hold whether or not the correct logs are being outputted
+    let extraParamBool = false
+    let errorBool = false
+    let startingConfigAuditBool = false
+
+    // generate the package.json file
+    fse.ensureDirSync(appDir)
+    packageJSONSource.rooseveltConfig.logging.extraParam = true
+    fse.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
+
+    // generate the test app
+    generateTestApp({
+      appDir: appDir,
+      onServerStart: `(app) => {process.send("something")}`
+    }, options)
+
+    // fork and run app.js as a child process
+    const testApp = fork(path.join(appDir, 'app.js'), { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
+
+    // on the output stream, check
+    testApp.stdout.on('data', (data) => {
+      if (data.includes('Starting roosevelt user configuration audit...')) {
+        startingConfigAuditBool = true
+      }
+    })
+
+    // on the error stream, check config auditor output
+    testApp.stderr.on('data', (data) => {
+      if (data.includes('Extra param "extraParam" found')) {
+        extraParamBool = true
+      }
+      if (data.includes('Issues have been detected in roosevelt config')) {
+        errorBool = true
+      }
+    })
+
+    testApp.on('message', () => {
+      testApp.send('stop')
+    })
+
+    // when the child process exits, check assertions and finish the test
+    testApp.on('exit', () => {
+      assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the config Auditor')
+      assert.strictEqual(extraParamBool, false, 'configAuditor should not have warned about the extra param in the roosevelt config')
+      assert.strictEqual(errorBool, false, 'configAuditor should not have reported issues with the roosevelt config')
+      done()
+    })
+  })
+
+  it('should not report that there are missing params if _roosevelt-missing-exempt is set to true', function (done) {
+    // bool var to hold whether or not the correct logs are being outputted
+    let extraParamBool = false
+    let errorBool = false
+    let startingConfigAuditBool = false
+
+    // generate the package.json file
+    fse.ensureDirSync(appDir)
+    delete packageJSONSource.rooseveltConfig.multipart.multiples
+    fse.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
+
+    // generate the test app
+    generateTestApp({
+      appDir: appDir,
+      onServerStart: `(app) => {process.send("something")}`
+    }, options)
+
+    // fork and run app.js as a child process
+    const testApp = fork(path.join(appDir, 'app.js'), { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
+
+    // on the output stream, check
+    testApp.stdout.on('data', (data) => {
+      if (data.includes('Starting roosevelt user configuration audit...')) {
+        startingConfigAuditBool = true
+      }
+    })
+
+    // on the error stream, check config auditor output
+    testApp.stderr.on('data', (data) => {
+      if (data.includes('Missing param "multiples"')) {
+        extraParamBool = true
+      }
+      if (data.includes('Issues have been detected in roosevelt config')) {
+        errorBool = true
+      }
+    })
+
+    testApp.on('message', () => {
+      testApp.send('stop')
+    })
+
+    // when the child process exits, check assertions and finish the test
+    testApp.on('exit', () => {
+      assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the config Auditor')
+      assert.strictEqual(extraParamBool, false, 'configAuditor should not have warned about a missing param in the roosevelt config')
+      assert.strictEqual(errorBool, false, 'configAuditor should not have reported issues with the roosevelt config')
+      done()
+    })
+  })
+
   it('should report that package.json contains a roosevelt script that has been incorrectly placed', function (done) {
     // bool var to hold whether or not a specific log was outputted
     let cleanNotUpToDateBool = false

--- a/test/unit/configAuditorTest.js
+++ b/test/unit/configAuditorTest.js
@@ -530,7 +530,7 @@ describe('Roosevelt Config Auditor Test', function () {
 
   it('should not report that there are missing params if _roosevelt-missing-exempt is set to true', function (done) {
     // bool var to hold whether or not the correct logs are being outputted
-    let extraParamBool = false
+    let missingParamBool = false
     let errorBool = false
     let startingConfigAuditBool = false
 
@@ -558,7 +558,7 @@ describe('Roosevelt Config Auditor Test', function () {
     // on the error stream, check config auditor output
     testApp.stderr.on('data', (data) => {
       if (data.includes('Missing param "multiples"')) {
-        extraParamBool = true
+        missingParamBool = true
       }
       if (data.includes('Issues have been detected in roosevelt config')) {
         errorBool = true
@@ -572,7 +572,7 @@ describe('Roosevelt Config Auditor Test', function () {
     // when the child process exits, check assertions and finish the test
     testApp.on('exit', () => {
       assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the config Auditor')
-      assert.strictEqual(extraParamBool, false, 'configAuditor should not have warned about a missing param in the roosevelt config')
+      assert.strictEqual(missingParamBool, false, 'configAuditor should not have warned about a missing param in the roosevelt config')
       assert.strictEqual(errorBool, false, 'configAuditor should not have reported issues with the roosevelt config')
       done()
     })


### PR DESCRIPTION
This makes the config auditor skip the extra parameters check for `multipart`, `bodyParser`, and `logging`. It also skips the missing parameters check for `multipart` and `bodyParser`.

Closes #545 