### PR TITLE
Changed the way isCertString works...

### DIFF
--- a/roosevelt.js
+++ b/roosevelt.js
@@ -380,8 +380,14 @@ module.exports = function (params) {
     if (typeof testString !== 'string') {
       testString = testString.toString()
     }
-    let endOfLine = require('os').EOL
-    return (testString.substring(testString.length - (endOfLine.length + 5)) === ('-----' + endOfLine))
+    let lastChar = testString.substring(testString.length - 1)
+    // A file path string won't have an end of line character at the end
+    // Looking for either \n or \r allows for nearly any OS someone could
+    // use, and a few that node doesn't work on.
+    if (lastChar === '\n' || lastChar === '\r') {
+      return true
+    }
+    return false
   }
 
   return {


### PR DESCRIPTION
...so that it just looks for either a \n or a \r at the end of the string passed in. If one of those characters is the last character, it assumes the string is a cert string (file path strings won't have end of line characters at the end).