### PR TITLE
change html minifier to not remove html comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Autokiller now sends human-readable GET.
 - Fixed bug which caused the config auditor to report false errors in the case of third party module params being set to configurations other than the default.
 - Fixed bug related to HTTPS cert parsing.
+- Disabling option that html minifier which removes html comments
 - Various dependencies bumped.
 - CI improvements.
 

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -62,7 +62,6 @@
     "enable": true,
     "exceptionRoutes": false,
     "options": {
-      "removeComments": true,
       "collapseWhitespace": true,
       "collapseBooleanAttributes": true,
       "removeAttributeQuotes": true,


### PR DESCRIPTION
It was discussed that it would cause issues to remove comments when using the HTML minifier and with such, the removeComments option will be turned off by default.