### PR TITLE
Add ENV var to control autoKiller for seperate process on the HTML validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next version
 
 - Put your changes here.
+- Added autokiller environment variable to enable/disable the HTML validator autokiller
 
 ## 0.12.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Next version
 
-- Put your changes here.
 - Added autokiller environment variable to enable/disable the HTML validator autokiller
 
 ## 0.12.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next version
 
-- Added autokiller environment variable to enable/disable the HTML validator autokiller
+- Added autokiller environment variable to enable/disable the HTML validator autokiller.
 
 ## 0.12.2
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The following is a list of [environment variables](https://en.wikipedia.org/wiki
   - Set to `detached` to force the HTML validator to run as a detached background process.
   - Set to `attached` to force the HTML validator to run as an attached process.
 - `ROOSEVELT_AUTOKILLER`:
-  - Set to `on` to turn on the HTML validator autokiller on the separate process.
+  - Set to `on` to spawn a process to kill the HTML validator if it is running in the background and idle for more than a certain amount of time. The timeout can be configured in [app behavior params](https://github.com/rooseveltframework/roosevelt#app-behavior-parameters).
   - Set to `off`to turn off the HTML validator autokiller on the separate process.
 
 Environment variable precedence:

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The following is a list of [environment variables](https://en.wikipedia.org/wiki
   - Set to `attached` to force the HTML validator to run as an attached process.
 - `ROOSEVELT_AUTOKILLER`:
   - Set to `on` to turn on the HTML validator autokiller on the separate process.
-  - Set to `off`to turn off the HTML validator autokiller on the separe process.
+  - Set to `off`to turn off the HTML validator autokiller on the separate process.
 
 Environment variable precedence:
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The following is a list of [environment variables](https://en.wikipedia.org/wiki
   - Set to `attached` to force the HTML validator to run as an attached process.
 - `ROOSEVELT_AUTOKILLER`:
   - Set to `on` to spawn a process to kill the HTML validator if it is running in the background and idle for more than a certain amount of time. The timeout can be configured in [app behavior params](https://github.com/rooseveltframework/roosevelt#app-behavior-parameters).
-  - Set to `off`to turn off the HTML validator autokiller on the separate process.
+  - Set to `off`to disable the HTML validator autokiller.
 
 Environment variable precedence:
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ Roosevelt apps created with the app generator come with the following notable [n
 - `node app.js --attach-validator `: Forces the HTML validator to run as an attached process.
   - Default shorthand:
     - `-a`
+- `node app.js --enable-validator-autokiller `: Forces the HTML validator autokiller to be enabled.
+  - Default shorthands:
+    - `--html-validator-autokiller`
+    - `-k`
+- `node app.js --disable-validator-autokiller `: Forces the HTML validator autokiller to be disabled.
+  - Default shorthands:
+    - `--no-autokiller`
+    - `-n`
 - `node app.js --host-public `: Forces Roosevelt to always host the [public folder](https://github.com/rooseveltframework/roosevelt#public-folder-parameters) even when `alwaysHostPublic` is set to false. Useful for testing production mode.
   - Default shorthands:
     - `--statics`

--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ The following is a list of [environment variables](https://en.wikipedia.org/wiki
 - `ROOSEVELT_VALIDATOR`:
   - Set to `detached` to force the HTML validator to run as a detached background process.
   - Set to `attached` to force the HTML validator to run as an attached process.
+- `ROOSEVELT_AUTOKILLER`:
+  - Set to `on` to turn on the HTML validator autokiller on the separate process.
+  - Set to `off`to turn off the HTML validator autokiller on the separe process.
 
 Environment variable precedence:
 

--- a/lib/sourceFlags.js
+++ b/lib/sourceFlags.js
@@ -63,6 +63,16 @@ module.exports = function (enableCLIFlags) {
       case '-a':
         checkFlags('attachValidator', 'backgroundValidator')
         break
+      case '--enable-validator-autokiller':
+      case '--html-validator-autokiller':
+      case '-k':
+        checkFlags('enableAutokiller', 'disableAutokiller')
+        break
+      case '--disable-validator-autokiller':
+      case '--no-autokiller':
+      case '-n':
+        checkFlags('disableAutokiller', 'enableAutokiller')
+        break
       case '--host-public':
       case '--statics':
       case '-s':

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -125,6 +125,11 @@ module.exports = function (app) {
   } else if (process.env.ROOSEVELT_VALIDATOR === 'attached') {
     params.htmlValidator.separateProcess.enable = false
   }
+  if (flags.enableAutokiller) {
+    params.htmlValidator.separateProcess.autoKiller = true
+  } else if (flags.disableAutokiller) {
+    params.htmlValidator.separateProcess.autoKiller = false
+  }
   if (process.env.ROOSEVELT_AUTOKILLER === 'on') {
     params.htmlValidator.separateProcess.autoKiller = true
   } else if (process.env.ROOSEVELT_AUTOKILLER === 'off') {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -125,6 +125,11 @@ module.exports = function (app) {
   } else if (process.env.ROOSEVELT_VALIDATOR === 'attached') {
     params.htmlValidator.separateProcess.enable = false
   }
+  if (process.env.ROOSEVELT_AUTOKILLER === 'on') {
+    params.htmlValidator.separateProcess.autoKiller = true
+  } else if (process.env.ROOSEVELT_AUTOKILLER === 'off') {
+    params.htmlValidator.separateProcess.autoKiller = false
+  }
   if (flags.backgroundValidator) {
     params.htmlValidator.separateProcess.enable = true
   } else if (flags.attachValidator) {

--- a/test/unit/cliFlags.js
+++ b/test/unit/cliFlags.js
@@ -251,6 +251,84 @@ describe('Command Line Tests', function () {
     })
   })
 
+  it('should change the app to enable autokiller ("--enable-validator-autokiller")', function (done) {
+    const testApp = fork(path.join(appDir, 'app.js'), ['--enable-validator-autokiller'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
+
+    testApp.on('message', params => {
+      assert.strictEqual(params.htmlValidator.separateProcess.autoKiller, true)
+      testApp.send('stop')
+    })
+
+    testApp.on('exit', () => {
+      done()
+    })
+  })
+
+  it('should change the app to enable the html Validator autokiller ("--html-validator-autokiller")', function (done) {
+    const testApp = fork(path.join(appDir, 'app.js'), ['--html-validator-autokiller'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
+
+    testApp.on('message', params => {
+      assert.strictEqual(params.htmlValidator.separateProcess.autoKiller, true)
+      testApp.send('stop')
+    })
+
+    testApp.on('exit', () => {
+      done()
+    })
+  })
+
+  it('should change the app to enable the html Validator autokiller ("-k")', function (done) {
+    const testApp = fork(path.join(appDir, 'app.js'), ['-k'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
+
+    testApp.on('message', params => {
+      assert.strictEqual(params.htmlValidator.separateProcess.autoKiller, true)
+      testApp.send('stop')
+    })
+
+    testApp.on('exit', () => {
+      done()
+    })
+  })
+
+  it('should change the app to disable validator ("--disable-validator-autokiller")', function (done) {
+    const testApp = fork(path.join(appDir, 'app.js'), ['--disable-validator-autokiller'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
+
+    testApp.on('message', params => {
+      assert.strictEqual(params.htmlValidator.separateProcess.autoKiller, false)
+      testApp.send('stop')
+    })
+
+    testApp.on('exit', () => {
+      done()
+    })
+  })
+
+  it('should change the app to disable validator ("--no-autokiller")', function (done) {
+    const testApp = fork(path.join(appDir, 'app.js'), ['--no-autokiller'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
+
+    testApp.on('message', params => {
+      assert.strictEqual(params.htmlValidator.separateProcess.autoKiller, false)
+      testApp.send('stop')
+    })
+
+    testApp.on('exit', () => {
+      done()
+    })
+  })
+
+  it('should change the app to disable the html Validator autokiller ("-n")', function (done) {
+    const testApp = fork(path.join(appDir, 'app.js'), ['-n'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
+
+    testApp.on('message', params => {
+      assert.strictEqual(params.htmlValidator.separateProcess.autoKiller, false)
+      testApp.send('stop')
+    })
+
+    testApp.on('exit', () => {
+      done()
+    })
+  })
+
   describe('check combination of flags', function () {
     it('should change the app to put it into dev mode, enable validator, and attach validator ("--development-mode, --enable-validator, --attach-validator")', function (done) {
       const testApp = fork(path.join(appDir, 'app.js'), ['--development-mode', '--enable-validator', '--attach-validator'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })

--- a/test/unit/envParams.js
+++ b/test/unit/envParams.js
@@ -50,4 +50,26 @@ describe('ENV Parameter Tests', function () {
     delete process.env.HTTPS_PORT
     done()
   })
+
+  it('should set validator autokiller param to true for separate processes', function (done) {
+    const temp = process.env.ROOSEVELT_AUTOKILLER
+    process.env.ROOSEVELT_AUTOKILLER = 'on'
+    app = roosevelt({
+      ...appConfig
+    })
+    assert.strictEqual(app.expressApp.get('params').htmlValidator.separateProcess.autoKiller, true)
+    process.env.ROOSEVELT_AUTOKILLER = temp
+    done()
+  })
+
+  it('should set validator autokiller param to false for separate processes', function (done) {
+    const temp = process.env.ROOSEVELT_AUTOKILLER
+    process.env.ROOSEVELT_AUTOKILLER = 'off'
+    app = roosevelt({
+      ...appConfig
+    })
+    assert.strictEqual(app.expressApp.get('params').htmlValidator.separateProcess.autoKiller, false)
+    process.env.ROOSEVELT_AUTOKILLER = temp
+    done()
+  })
 })


### PR DESCRIPTION
This PR 
- Creates an environment variable called ROOSEVELT_AUTOKILLER
- ROOSEVELT_AUTOKILLER should be set to `on` or `off` to change autokiller param
- Updates ReadMe to include the environment variable
- Adds unit test in the envParams
- Closes #591 
- Updates CHANGELOG