### PR TITLE
Add OpenJDK support to HTML Validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added new feature to create custom CSS/JS preprocessors on the fly.
 - Added environment variable to enable/disable the HTML validator autokiller.
 - Various dependencies bumped.
+- Added OpenJDK support for the HTML Validator
 
 ## 0.12.2
 

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -119,7 +119,7 @@ module.exports = function (app, callback) {
         })
 
         javaDetectProcess.stderr.on('data', (data) => {
-          if (data.includes('java version')) {
+          if (data.includes('java version') || data.includes('openjdk version')) {
             cb()
           }
         })


### PR DESCRIPTION
HTML Validator would not start when using OpenJDK. Change fixes so Roosevelt can now run with OpenJDK.