### PR TITLE
Add Open JDK support to the HTML Validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added new feature to create custom CSS/JS preprocessors on the fly.
 - Added environment variable to enable/disable the HTML validator autokiller.
 - Various dependencies bumped.
+- Added OpenJDK support to the Java HTML Validator.
 
 ## 0.12.2
 

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -119,7 +119,7 @@ module.exports = function (app, callback) {
         })
 
         javaDetectProcess.stderr.on('data', (data) => {
-          if (data.includes('java version')) {
+          if (data.includes('java version') || data.includes('openjdk version')) {
             cb()
           }
         })


### PR DESCRIPTION
Allows those running Open JDK to use the HTML validation feature. 