### PR TITLE
Redirect Middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next version
 
-- Put new changes here.
+- Enhancement to `res.redirect()` for custom routers to prepend the prefix to redirects that are relative to the hostname
 
 ## 0.13.0
 

--- a/README.md
+++ b/README.md
@@ -906,6 +906,8 @@ module.exports = (router, app) => { // router is an Express router and app is th
 };
 ```
 
+**Note:** If custom routers are being used, the [res.redirect()](https://expressjs.com/en/api.html#res.redirect) method will prepend the prefix to redirects that are relative to the hostname. To override this setting pass `true` as the last argument.
+
 Sometimes it is also useful to separate controller logic from your routing. This can be done by creating a reusable controller module.
 
 An example would be creating a reusable controller for "404 Not Found" pages:

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -259,7 +259,52 @@ module.exports = function (app) {
                 routers.controllers.forEach((router, routerIndex) => {
                   // remove duplicates from controllers
                   routerControllers = [...new Set(router.files)]
-                  if (!routers.controllers[routerIndex].router) routers.controllers[routerIndex].router = app.get('express').Router()
+                  if (!routers.controllers[routerIndex].router) {
+                    routers.controllers[routerIndex].router = app.get('express').Router()
+                    // router level middleware to override res.redirect()
+                    routers.controllers[routerIndex].router.use((req, res, next) => {
+                      const redirect = res.redirect
+                      // overwrite the res.redirect() function
+                      res.redirect = function () {
+                        let address
+                        let override
+                        let status
+
+                        // remove any trailing slashes for proper concatenation
+                        let prefix = router.prefix.replace(/\/+$/, '')
+
+                        // logic to preserve allowable express arguments
+                        if (arguments.length === 1 && typeof arguments[0] === 'string') {
+                          address = arguments[0]
+                        } else if (arguments.length === 2 && typeof arguments[0] === 'number' && typeof arguments[1] === 'string') {
+                          status = arguments[0]
+                          address = arguments[1]
+                        } else if (arguments.length === 2 && typeof arguments[0] === 'string' && typeof arguments[1] === 'boolean') {
+                          address = arguments[0]
+                          override = arguments[1]
+                        } else if (arguments.length === 3 && typeof arguments[0] === 'number' && typeof arguments[1] === 'string' && typeof arguments[2] === 'boolean') {
+                          status = arguments[0]
+                          address = arguments[1]
+                          override = arguments[2]
+                        } else {
+                          // invalid arguments passed to res.redirect(), set address to 'back' so the application doesn't break
+                          logger.error('Invalid arguments supplied to res.redirect()')
+                          address = 'back'
+                        }
+
+                        if (!override && address.charAt(0) === '/') {
+                          address = prefix + address
+                        }
+
+                        if (status) {
+                          redirect.call(this, status, address)
+                        } else {
+                          redirect.call(this, address)
+                        }
+                      }
+                      next()
+                    })
+                  }
                   routerControllers.forEach(routerController => {
                     if (controller.includes(path.join(app.get('controllersPath'), routerController))) {
                       // if the controller accepts less than one or more than two arguments, it's not defining a route

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -288,7 +288,7 @@ module.exports = function (app) {
                           override = arguments[2]
                         } else {
                           // invalid arguments passed to res.redirect(), set address to 'back' so the application doesn't break
-                          logger.error('Invalid arguments supplied to res.redirect()')
+                          logger.error('Invalid arguments supplied to res.redirect()'.red)
                           address = 'back'
                         }
 

--- a/test/util/mvc/controllers/routerDir/redirects.js
+++ b/test/util/mvc/controllers/routerDir/redirects.js
@@ -1,0 +1,13 @@
+module.exports = (router) => {
+  router.route('/redirect').post((req, res) => {
+    let argArray = []
+    if (req.body.status) argArray.push(parseInt(req.body.status))
+    if (req.body.address) argArray.push(req.body.address)
+    if (req.body.override) argArray.push(req.body.override === 'true')
+    res.redirect(...argArray)
+  })
+
+  router.route('/endpoint').get((req, res) => {
+    res.send('redirection successful')
+  })
+}


### PR DESCRIPTION
This PR adds middleware to enhance `res.redirect()`'s functionality when using custom routers.

Enhancements Include:
- Concatenating the custom routers prefix to all redirects that are relative to the hostname e.g. if there's a prefix `/foo` then `res.redirect('/bar')` would redirect to `/foo/bar`
- Option to override the concatenation of the prefix e.g. e.g. if there's a prefix `/foo` then `res.redirect('/bar', true)` would redirect to `/bar`
- Option to send a status code with the address and the override e.g. if there's a prefix `/foo` then `res.redirect(301, '/bar', true)` would redirect to `/bar` with a 301 status code

This also preserves the current options Express allows as arguments e.g.

```js
res.redirect('http://example.com') // redirect to a different hostname
res.redirect(301, 'http://example.com') // status code as the first arg
res.redirect('../bar') // path-relative redirect
res.redirect('bar') // relative to the current URL
res.redirect('back') // back to the referer
```

TODO:
- [x] Add middleware to custom routers
- [x] Write unit tests
- [x] Update README.md
- [x] Update CHANGELOG.md