### PR TITLE
Travis CI Windows Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
   - "11"
   - "10"
 before_script:
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install jdk11; export PATH=$PATH:"/c/Program Files/Java/jdk-11.0.2/bin"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install jdk8; export PATH=$PATH:"/c/Program Files/Java/jdk1.8.0_201/bin"; fi
 
 script:
   - npm run lint

--- a/test/unit/appBehaviorParamsTest.js
+++ b/test/unit/appBehaviorParamsTest.js
@@ -236,11 +236,14 @@ describe('Roosevelt Multipart/Formidable Section Test', function () {
         .on('error', () => {
           // roosevelt should throw an error
           testApp.send('stop')
-        }).then((res) => {
+        })
+        .end((err, res) => {
+          if (err) {
+            assert.fail(err)
+          }
           if (res.status === 200) {
             // if we get a 200, an error was not thrown and something is wrong
-            assert.fail('Roosevelt somehow was able to parse this form even though the setup of the test should make it fail')
-            testApp.send('stop')
+            assert.fail('Roosevelt was able to parse the form even though we have exceeded the max field size')
           }
         })
     })

--- a/test/unit/appBehaviorParamsTest.js
+++ b/test/unit/appBehaviorParamsTest.js
@@ -244,6 +244,7 @@ describe('Roosevelt Multipart/Formidable Section Test', function () {
           if (res.status === 200) {
             // if we get a 200, an error was not thrown and something is wrong
             assert.fail('Roosevelt was able to parse the form even though we have exceeded the max field size')
+            testApp.send('stop')
           }
         })
     })


### PR DESCRIPTION
This PR downgrades JDK from 11 to 8 due to issues with chocolatey installing JDK 11. The validator only requires JDK 8 or higher and this seems to be the second time this year that JDK 11 has been broken with chocolatey.

This PR also includes a fix for one of the tests outputting a warning because of a missing `.catch()` on a promise