### PR TITLE
fix up ci and testing scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: node_js
 os:
-  - windows
   - linux
   - osx
+  - windows
 node_js:
-  - "11"
   - "10"
-before_script:
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install jdk8; export PATH=$PATH:"/c/Program Files/Java/jdk1.8.0_201/bin"; fi
-
+  - "11"
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      export JAVA_HOME=${JAVA_HOME:-/c/jdk};
+      export PATH=${JAVA_HOME}/bin:${PATH};
+      choco install jdk8 -params 'installdir=c:\\jdk' -y;
+    fi
 script:
   - npm run lint
   - npm run coverage

--- a/package.json
+++ b/package.json
@@ -100,14 +100,14 @@
     "coverage": "nyc mocha --timeout 125000 test/unit",
     "lint": "standard && eslint ./test/unit",
     "postinstall": "node ./lib/scripts/configAuditor.js",
-    "test": "npm run lint && mocha --timeout 125000 test/unit"
+    "test": "mocha --timeout 125000 test/unit"
   },
   "lint-staged": {
     "*.js": "standard"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged && eslint ./test/unit"
     }
   }
 }


### PR DESCRIPTION
- Remove linting from `test` script, because sometimes you want to run an exclusive test on your own machine without having to paste in a mocha command, and the ci doesn't use this script anyway.
- lint-staged wasn't checking for exclusive mocha tests, that's an oops.
- Rejiggered the travis config to handle adding the arbitrary chocolatey installed java version to the path.