### PR TITLE
0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Put your changes here...
 
+## 0.14.2
+
+- Reverted most changes in 0.14.1 to fix [#713](https://github.com/rooseveltframework/roosevelt/issues/713), but preserved modularization of htmlValidator.js so that if any devDependencies are missing, the app will not crash in production mode.
+- Various dependencies bumped.
+
 ## 0.14.1
 
 - Moved several things to devDependencies to shrink production builds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "roosevelt",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "Troy Coutu <autre31415@gmail.com>",
     "Alexander J. Lallier <alexanderlallier@aol.com>"
   ],
-  "version": "0.14.1",
+  "version": "0.14.2",
   "homepage": "https://github.com/rooseveltframework/roosevelt",
   "license": "CC-BY-4.0",
   "main": "roosevelt.js",
@@ -30,7 +30,7 @@
     "formidable": "~1.2.1",
     "fs-extra": "~8.0.1",
     "html-minifier": "~4.0.0",
-    "html-validator": "~4.0.2",
+    "html-validator": "~4.0.3",
     "klaw": "~3.0.0",
     "klaw-sync": "~6.0.0",
     "method-override": "~3.0.0",


### PR DESCRIPTION
- Reverted most changes in 0.14.1 to fix [#713](https://github.com/rooseveltframework/roosevelt/issues/713), but preserved modularization of htmlValidator.js so that if any devDependencies are missing, the app will not crash in production mode.
- Various dependencies bumped.