### PR TITLE
Update renovate config to ignore anything other than stable releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": [
     "config:base",
-    ":preserveSemverRanges"
+    ":preserveSemverRanges",
+    ":ignoreUnstable",
+    ":respectLatest"
   ]
 }


### PR DESCRIPTION
This should (hopefully) eliminate the dreaded vnu-jar pre-release updates.