### PR TITLE
Fixed tests in Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - windows
 node_js:
   - "10"
-  - "11"
+  - "12"
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
       export JAVA_HOME=${JAVA_HOME:-/c/jdk};

--- a/test/util/generateTestApp.js
+++ b/test/util/generateTestApp.js
@@ -26,7 +26,7 @@ module.exports = function (params, options) {
   }
 
   // require roosevelt at the top of every test app
-  contents += `const app = require(\`${options.rooseveltPath}\`)(${util.inspect(params, { depth: null })})\n\n`
+  contents += `const app = require(\`${options.rooseveltPath}\`)(${util.inspect(params, { depth: null, compact: true })})\n\n`
 
   // add express env to params object for testing purposes (this hacky crap is a pretty good sign we should probably refactor the tests to be better than this)
   let defaultMessages = 'let params = app.expressApp.get(\'params\')\n'


### PR DESCRIPTION
Fixed issue with test where code was being split into multiple lines in util.inspect resulting in invalid syntax. Set compact to true which turned code into one line

(Closes #726)