### PR TITLE
WIP: Added ability to symlink subdirectory

### DIFF
--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -114,6 +114,9 @@ module.exports = function (app) {
       if (!areSubDirs.includes(true) && fsr.symlinkSync(staticTarget, linkTarget, 'junction')) {
         symDirs.push(linkTarget)
         logger.info('📁', `${appName} making new symlink `.cyan + `${linkTarget}`.yellow + (' pointing to ').cyan + `${staticTarget}`.yellow)
+      } else {
+        let parentSymDir = symDirs[areSubDirs.indexOf(true)]
+        logger.error(`Symlink failed! Cannot make ${linkTarget} a symlink as a subdirectory of ${parentSymDir}.`)
       }
     }
   })

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -19,6 +19,7 @@ module.exports = function (app) {
   let publicFolderDirs
   let schemaLocation
   let publicDir
+  let symDirs = []
 
   // ensure 404 page exists
   params.errorPages.notFound = path.join(app.get('controllersPath'), params.errorPages.notFound)
@@ -108,7 +109,10 @@ module.exports = function (app) {
 
     // make symlink if it doesn't yet exist
     if (!fsr.fileExists(linkTarget)) {
-      if (fsr.symlinkSync(staticTarget, linkTarget, 'junction')) {
+      // check if the new symlink is in a subdirectory of a previous symlink
+      let areSubDirs = symDirs.map(symDir => !path.relative(symDir, linkTarget).startsWith('..'))
+      if (!areSubDirs.includes(true) && fsr.symlinkSync(staticTarget, linkTarget, 'junction')) {
+        symDirs.push(linkTarget)
         logger.info('📁', `${appName} making new symlink `.cyan + `${linkTarget}`.yellow + (' pointing to ').cyan + `${staticTarget}`.yellow)
       }
     }

--- a/lib/tools/fsr.js
+++ b/lib/tools/fsr.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs')
 const fse = require('fs-extra')
+const path = require('path')
 
 class FSR {
   constructor (app) {
@@ -21,7 +22,12 @@ class FSR {
 
   symlinkSync () {
     if (this.generate) {
-      fs.symlinkSync(...arguments)
+      try {
+        fs.symlinkSync(...arguments)
+      } catch (e) {
+        fse.ensureDirSync(path.resolve(arguments[1], '..'))
+        fs.symlinkSync(...arguments)
+      }
       return true
     }
   }

--- a/test/unit/paramFunctionTest.js
+++ b/test/unit/paramFunctionTest.js
@@ -719,6 +719,49 @@ describe('Parameter Function Tests', function () {
     })
   })
 
+  it('should be able to symlink to directories ', function (done) {
+    // prepare paths to folders
+    let publicPath = path.join(appDir, 'public')
+    let parentDirPath = path.join(publicPath, 'parentDir')
+    let symDirPath = path.join(parentDirPath, 'symDir')
+
+    // create the app.js file
+    generateTestApp({
+      appDir: appDir,
+      generateFolderStructure: true,
+      alwaysHostPublic: true,
+      onServerStart: `(app) => {process.send(app.get("params"))}`,
+      staticsSymlinksToPublic: ['parentDir/symDir']
+    }, options)
+
+    // fork the app.js file and run it as a child process
+    const testApp = fork(path.join(appDir, 'app.js'), { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
+
+    // when the app finishes its initialization, kill it
+    testApp.on('message', () => {
+      testApp.send('stop')
+    })
+
+    // when the app is exiting, check if the parent directory and the symlink subdirectory were created successfully
+    testApp.on('exit', () => {
+      fse.lstat(parentDirPath, (err, stats) => {
+        if (err) {
+          done(err)
+        } else {
+          assert.strictEqual(stats.isDirectory(), true, `parent directory of symlink not created successfully`)
+        }
+      })
+      fse.lstat(symDirPath, (err, stats) => {
+        if (err) {
+          done(err)
+        } else {
+          assert.strictEqual(stats.isSymbolicLink(), true, `symlink to directory not created successfully`)
+        }
+      })
+      done()
+    })
+  })
+
   it('should throw, catch and display an error if the controllersPath passed to roosevelt is not a dictionary', function (done) {
     // bool var to hold whether or not a specific error log was outputted
     let loadControllerFilesFailBool = false


### PR DESCRIPTION
(Closes #723)
Allows symlinking to subdirectories, added code to ensure parent folder of the directory that will symlink  to statics folder exists and then symlink

Example:

### Statics
```
📂myDirectory
    📂nestedDirectory
        📄some.css
```
### package.json
```
"staticsSymlinksToPublic": [
  "someFolder/linkedDirectory: myDirectory/nestedDirectory"
],
```

This will create (```↪``` means symlink)
### Public
```
📂someFolder
    📂linkedDirectory ↪
        📄some.css
```