### PR TITLE
0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## Next version
 
-Fixed frontend reload on HTML validator error page
-Added informational comment above front end reload script tag to state that it is injected
+- Put your changes here...
+
+## 0.14.5
+
+- `staticsSymlinksToPublic` will now create missing subdirectories necessary to create a symlink in a target location.
+- Fixed a bug which caused Java hs_err_pid error logs to pile up in your app directory under certain conditions.
+- Fixed a bug which caused frontend reload to not work on the various error pages.
+- Added code comment above frontend reload script tag to explain that it is injected by Roosevelt.
+- Did some copyediting on frontend reload logging.
+- Various dependencies bumped.
 
 ## 0.14.4
 

--- a/lib/htmlValidator.js
+++ b/lib/htmlValidator.js
@@ -66,9 +66,9 @@ module.exports = function (app, callback) {
 
         res.on('end', () => {
           if (rawData.includes('Nu Html Checker')) {
-            logger.info('✅', `Detached validator found on port: ${validatorOptions.port}`.green)
+            logger.info('✅', `Detached validator found on port ${validatorOptions.port}`.green)
             clearTimeout(validatorTimeout)
-            logger.info('🎧', `HTML validator listening on port: ${params.htmlValidator.port}`.bold)
+            logger.info('🎧', `HTML validator listening on port ${params.htmlValidator.port}`.bold)
             applyValidatorMiddleware()
             resolve()
           } else {
@@ -84,7 +84,7 @@ module.exports = function (app, callback) {
 
       function spawnNewValidator () {
         validatorProcess = spawn(
-          'java', ['-Xss1024k', '-cp', vnu, 'nu.validator.servlet.Main', params.htmlValidator.port], { detached: params.htmlValidator.separateProcess.enable }
+          'java', ['-Xss1024k', '-XX:ErrorFile=' + os.tmpdir() + '/java_error%p.log', '-cp', vnu, 'nu.validator.servlet.Main', params.htmlValidator.port], { detached: params.htmlValidator.separateProcess.enable }
         )
         logger.info('☕️', 'Starting HTML validator...'.yellow)
 
@@ -92,9 +92,9 @@ module.exports = function (app, callback) {
           if (`${data}`.includes('INFO:oejs.Server:main: Started')) {
             clearTimeout(validatorTimeout)
             if (params.htmlValidator.separateProcess.enable) {
-              logger.info('🎧', `HTML validator listening on port: ${params.htmlValidator.port} (as a detached, background process)`.bold)
+              logger.info('🎧', `HTML validator listening on port ${params.htmlValidator.port} (as a detached, background process)`.bold)
             } else {
-              logger.info('🎧', `HTML validator listening on port: ${params.htmlValidator.port}`.bold)
+              logger.info('🎧', `HTML validator listening on port ${params.htmlValidator.port}`.bold)
             }
             applyValidatorMiddleware()
             resolve()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "roosevelt",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -166,9 +166,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
-      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",
@@ -1660,11 +1660,12 @@
       }
     },
     "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "dash-ast": {
@@ -3605,9 +3606,9 @@
       }
     },
     "inquirer": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
-      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.0.tgz",
+      "integrity": "sha512-O3qJQ+fU/AI1K2y5/RjqefMEQTdJQf6sPTvyRA1bx6D634ADxcu97u6YOUciIeU2OWIuvpUsQs6Wx3Fdi3eFaQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -4288,9 +4289,9 @@
       }
     },
     "lint-staged": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.2.0.tgz",
-      "integrity": "sha512-DxguyxGOIfb67wZ6EOrqzjAbw6ZH9XK3YS74HO+erJf6+SAQeJJPN//GBOG5xhdt2THeuXjVPaHcCYOWGZwRbA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.2.1.tgz",
+      "integrity": "sha512-n0tDGR/rTCgQNwXnUf/eWIpPNddGWxC32ANTNYsj2k02iZb7Cz5ox2tytwBu+2r0zDXMEMKw7Y9OD/qsav561A==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.1",
@@ -5758,12 +5759,13 @@
       },
       "dependencies": {
         "find-up": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.0.0.tgz",
-          "integrity": "sha512-zoH7ZWPkRdgwYCDVoQTzqjG8JSPANhtvLhh4KVUHyKnaUJJrNeFmWIkTcNuJmR3GLMEmGYEf2S2bjgx26JTF+Q==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
-            "locate-path": "^5.0.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "locate-path": {
@@ -5783,6 +5785,12 @@
           "requires": {
             "p-limit": "^2.2.0"
           }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
         }
       }
     },
@@ -5836,9 +5844,9 @@
       }
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -5937,9 +5945,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.32",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
+      "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw==",
       "dev": true
     },
     "public-encrypt": {
@@ -6653,9 +6661,9 @@
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
     "simple-git": {
-      "version": "1.113.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.113.0.tgz",
-      "integrity": "sha512-i9WVsrK2u0G/cASI9nh7voxOk9mhanWY9eGtWBDSYql6m49Yk5/Fan6uZsDr/xmzv8n+eQ8ahKCoEr8cvU3h+g==",
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.116.0.tgz",
+      "integrity": "sha512-Pbo3tceqMYy0j3U7jzMKabOWcx5+67GdgQUjpK83XUxGhA+1BX93UPvlWNzbCRoFwd7EJTyDSCC2XCoT4NTLYQ==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
@@ -7383,9 +7391,9 @@
       }
     },
     "table": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
-      "integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.1.tgz",
+      "integrity": "sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==",
       "dev": true,
       "requires": {
         "ajv": "^6.9.1",
@@ -7665,6 +7673,11 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
+    },
+    "type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "description": "Roosevelt MVC web framework",
   "author": "Roosevelt Framework Team <rooseveltframework@gmail.com>",
   "contributors": [
-    "Eric Newport <kethinov@gmail.com>",
-    "Troy Coutu <autre31415@gmail.com>",
-    "Alexander J. Lallier <alexanderlallier@aol.com>"
+    {
+      "name": "Contributors",
+      "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
+    }
   ],
-  "version": "0.14.4",
+  "version": "0.14.5",
   "homepage": "https://github.com/rooseveltframework/roosevelt",
   "license": "CC-BY-4.0",
   "main": "roosevelt.js",
@@ -45,7 +46,7 @@
     "fkill": "~6.2.0",
     "html-validator": "~4.0.3",
     "husky": "~2.4.1",
-    "lint-staged": "~8.2.0",
+    "lint-staged": "~8.2.1",
     "mocha": "~6.1.4",
     "nyc": "~14.1.1",
     "prismjs": "~1.16.0",

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -434,7 +434,7 @@ module.exports = function (params) {
         if (httpReloadPromise) {
           httpReloadPromise.then(httpReload => {
             httpReload.startWebSocketServer().then(() => {
-              logger.log('🎧', `Reload HTTP server is listening on port: ${params.frontendReload.port}`.bold)
+              logger.log('🎧', `Frontend reload HTTP server is listening on port ${params.frontendReload.port}`.bold)
             })
           }).catch(function (err) {
             logger.error(('Reload was unable to initialize - ' + err.toString()).red)
@@ -446,7 +446,7 @@ module.exports = function (params) {
         if (httpsReloadPromise) {
           httpsReloadPromise.then(httpsReload => {
             httpsReload.startWebSocketServer().then(() => {
-              logger.log('🎧', `Reload HTTPS server is listening on port: ${params.frontendReload.httpsPort || params.frontendReload.port}`.bold)
+              logger.log('🎧', `Frontend reload HTTPS server is listening on port ${params.frontendReload.httpsPort || params.frontendReload.port}`.bold)
             }).catch(function (err) {
               logger.error((`Reload was unable to start - ${err.toString()}`).red)
             })

--- a/test/unit/htmlValidatorTest.js
+++ b/test/unit/htmlValidatorTest.js
@@ -778,13 +778,13 @@ describe('HTML Validator/Kill Validator Test', function () {
         const testApp2 = fork(path.join(appDir, 'app.js'), ['--dev'], { 'stdio': ['pipe', 'pipe', 'pipe', 'ipc'] })
 
         testApp2.stdout.on('data', (data) => {
-          if (data.includes('Detached validator found on port: 2500')) {
+          if (data.includes('Detached validator found on port 2500')) {
             detachedValidatorFound2Bool = true
           }
           if (data.includes('Starting HTML validator...')) {
             startingHTMLValidator2Bool = true
           }
-          if (data.includes('HTML validator listening on port: 2500')) {
+          if (data.includes('HTML validator listening on port 2500')) {
             detachedValidatorListen2Bool = true
           }
         })

--- a/test/unit/reloadFrontendTest.js
+++ b/test/unit/reloadFrontendTest.js
@@ -47,7 +47,7 @@ describe('Reload Frontend Tests', function () {
 
     // process.stdout
     testApp.stdout.on('data', (data) => {
-      if (data.includes('Reload HTTP server is listening on port:')) {
+      if (data.includes('Frontend reload HTTP server is listening on port')) {
         foundReload = true
         testApp.send('stop')
       }
@@ -91,7 +91,7 @@ describe('Reload Frontend Tests', function () {
 
     // process.stdout
     testApp.stdout.on('data', (data) => {
-      if (data.includes('Reload HTTPS server is listening on port:')) {
+      if (data.includes('Frontend reload HTTPS server is listening on port')) {
         foundReload = true
         testApp.send('stop')
       }
@@ -135,7 +135,7 @@ describe('Reload Frontend Tests', function () {
 
     // process.stdout
     testApp.stdout.on('data', (data) => {
-      if (data.includes('Reload HTTPS server is listening on port:') || data.includes('Reload HTTP server is listening on port:')) {
+      if (data.includes('Frontend reload HTTPS server is listening on port') || data.includes('Frontend reload HTTP server is listening on port')) {
         foundReload++
         testApp.send('stop')
       }
@@ -162,7 +162,7 @@ describe('Reload Frontend Tests', function () {
 
     // process.stdout
     testApp.stdout.on('data', (data) => {
-      if (data.includes('Reload HTTP server is listening on port:')) {
+      if (data.includes('Frontend reload HTTP server is listening on port')) {
         reloadFound = true
       }
     })
@@ -198,7 +198,7 @@ describe('Reload Frontend Tests', function () {
 
     // process.stdout
     testApp.stdout.on('data', (data) => {
-      if (data.includes('Reload HTTP server is listening on port:')) {
+      if (data.includes('Frontend reload HTTP server is listening on port')) {
         reloadFound = true
       }
     })


### PR DESCRIPTION
- `staticsSymlinksToPublic` will now create missing subdirectories necessary to create a symlink in a target location.
- Fixed a bug which caused Java hs_err_pid error logs to pile up in your app directory under certain conditions.
- Fixed a bug which caused frontend reload to not work on the various error pages.
- Added code comment above frontend reload script tag to explain that it is injected by Roosevelt.
- Did some copyediting on frontend reload logging.
- Various dependencies bumped.