### PR TITLE
Fixed getDevDeps script so the postinstall script will work correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next version
 
+- Fixed a bug where postinstall script would remove devDeps on an additional run of `npm i`
 - Postinstall script checks if Roosevelt itself is a devDependency of the app before installing its own devDeps (no longer installs Roosevelt devDeps when running `npm i` in Roosevelt sub modules)
 - Fixed a bug which required the folder name of a roosevelt fork/clone to match exactly "roosevelt" to run tests in it successfully
 

--- a/lib/scripts/getDevDeps.js
+++ b/lib/scripts/getDevDeps.js
@@ -15,17 +15,32 @@ if (fs.existsSync(pkgPath)) {
   isRooseveltDep = pkg.dependencies.roosevelt
 }
 
+// check if Roosevelt's devDeps are already installed to avoid infinite postinstalls
+let areDevDepsInstalled = true
+let rooseveltPkgPath = path.join(process.cwd(), 'package.json')
+let rooseveltNodeModulesPath = path.join(process.cwd(), 'node_modules')
+if (fs.existsSync(rooseveltPkgPath)) {
+  let devDeps = require(rooseveltPkgPath).devDependencies
+  let devDepsKeys = Object.keys(devDeps)
+  if (devDepsKeys.length > 0) {
+    let devDepPath = path.join(rooseveltNodeModulesPath, devDepsKeys[0])
+    areDevDepsInstalled = fs.existsSync(devDepPath)
+  }
+}
+
 /**
  * check for deployment environment variable ROOSEVELT_DEPLOYMENT
  * if it exists don't install Roosevelt devDeps
- * otherwise, install devDeps as long as Roosevelt itself isn't a devDep
+ * otherwise, install devDeps as long as the following criteria are met:
+ * - Roosevelt isn't a devDep but is a direct dependency
+ * - Roosevelt's dev dependencies aren't already installed
  */
 if (process.env.ROOSEVELT_DEPLOYMENT) {
   logger.warn('📦', 'Environment variable "ROOSEVELT_DEPLOYMENT" is set. Skipping installation of Roosevelt devDependencies. You may not be able to run Roosevelt in development mode unless you run `npm run dev-install`')
-} else if (isRooseveltDevDep === undefined && isRooseveltDep !== undefined) {
+} else if (isRooseveltDevDep === undefined && isRooseveltDep !== undefined && !areDevDepsInstalled) {
   logger.log('📦', 'Environment variable "ROOSEVELT_DEPLOYMENT" not set. Installing Roosevelt\'s devDependencies...')
   try {
-    execSync('npm install --only=dev --ignore-scripts', { stdio: ['inherit', 'inherit', 'inherit'] })
+    execSync('npm install --only=dev', { stdio: 'inherit' })
     logger.log('✅', 'Installed Roosevelt\'s devDependencies to support using Roosevelt in development mode. You can remove Roosevelt\'s devDependencies by running `npm run dev-prune` to shrink production builds.'.green)
   } catch (e) {
     logger.error(e)


### PR DESCRIPTION
(Closes #762)
Checks in Roosevelt's node_modules folder for one of its dev dependencies before installing devDeps, as long as devDeps aren't already installed it will install them as expected

Todo:
- [x] add to CHANGELOG.md