### PR TITLE
Fixed an error that would occur in getDevDeps when keys are missing from pkg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next version
 
+- Fixed a bug where not having "devDependencies" or "dependencies" objects in your app's package.json would error when using `npm install`
 - Sources Roosevelt configs internally using [source-configs](https://www.npmjs.com/package/source-configs)
 - Breaking change: Moved css minification from roosevelt-less to Roosevelt using clean-css as a direct dependency. The clean-css library had an update with breaking changes so the rooseveltConfig params in "cleanCSS", 'advanced' and 'aggressiveMerging', are now outdated
 

--- a/lib/scripts/getDevDeps.js
+++ b/lib/scripts/getDevDeps.js
@@ -11,8 +11,12 @@ let isRooseveltDevDep
 let isRooseveltDep
 if (fs.existsSync(pkgPath)) {
   const pkg = require(pkgPath)
-  isRooseveltDevDep = pkg.devDependencies.roosevelt
-  isRooseveltDep = pkg.dependencies.roosevelt
+  if (pkg.devDependencies !== undefined) {
+    isRooseveltDevDep = pkg.devDependencies.roosevelt
+  }
+  if (pkg.dependencies !== undefined) {
+    isRooseveltDep = pkg.dependencies.roosevelt
+  }
 }
 
 // check if Roosevelt's devDeps are already installed to avoid infinite postinstalls


### PR DESCRIPTION
Added more thorough checks to getDevDeps, since it would error whenever the "dependencies" or "devDependencies" keys were missing from the package.json