### PR TITLE
Allow Roosevelt apps to be configured with a rooseveltConfig.json config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next version
 
+- Rename `multipart` param to `formidable`.
+- Update internal usage of formidable api.
+
 ## 0.16.1
 
 - Stopped the config auditor from complaining about obsolete scripts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next version
 
+- Added ability to configure Roosevelt via a rooseveltConfig.json config file placed in app root.
 - Rename `multipart` param to `formidable`.
 - Update internal usage of formidable api.
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Resolves to:
       }
       ```
 
-- `multipart`: Settings to pass along to [formidable](https://github.com/felixge/node-formidable) using [formidable's API](https://github.com/felixge/node-formidable#api) for multipart form processing. Access files uploaded in your controllers by examining the `req.files` object. Roosevelt will remove any files uploaded to the `uploadDir` when the request ends automatically. To keep any, be sure to move them before the request ends. To disable multipart forms entirely, set this parameter to false.
+- `formidable`: Settings to pass along to [formidable](https://github.com/felixge/node-formidable) using [formidable's API](https://github.com/felixge/node-formidable#api) for multipart form processing. Access files uploaded in your controllers by examining the `req.files` object. Roosevelt will remove any files uploaded to the `uploadDir` when the request ends automatically. To keep any, be sure to move them before the request ends. To disable multipart forms entirely, set this parameter to false.
 
   - Default: *[Boolean]*
 

--- a/README.md
+++ b/README.md
@@ -265,17 +265,21 @@ require('roosevelt')().startServer();
 
 Roosevelt will determine your app's name by examining `"name"` in `package.json`. If none is provided, it will use `Roosevelt Express` instead.
 
-Also, while it is recommended that you pass parameters to Roosevelt via `package.json` under `"rooseveltConfig"`, you can also pass parameters programmatically via Roosevelt's constructor like so:
+There are multiple ways to pass a configuration to Roosevelt:
 
-```js
-require('roosevelt')({
+- A `rooseveltConfig.json` file located in the root directory of your app.
+- Via package.json under `"rooseveltConfig"`.
+- Programmatically via Roosevelt's constructor like so:
+
+  ```js
+  require('roosevelt')({
   paramName: 'paramValue',
   param2:    'value2',
   etc:       'etc'
-}).startServer();
-```
+  }).startServer();
+  ```
 
-This is particularly useful for setting parameters that can't be defined in `package.json` such as event handlers (see below).
+  - This is particularly useful for setting parameters that can't be defined in `package.json` or `rooseveltConfig.json` such as event handlers (see below).
 
 In addition, all parameters support [template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) style variables. For example:
 

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -28,7 +28,7 @@
       "modelValue": "_disableValidator"
     }
   },
-  "multipart": {
+  "formidable": {
     "multiples": true
   },
   "toobusy": {

--- a/lib/enableMultipart.js
+++ b/lib/enableMultipart.js
@@ -3,15 +3,15 @@
 require('colors')
 
 const fs = require('fs-extra')
-const formidable = require('formidable')
+const Formidable = require('formidable')
 
 module.exports = app => {
   const appName = app.get('appName')
   const logger = app.get('logger')
-  const params = app.get('params').multipart
+  const params = app.get('params').formidable
 
   // store formidable module in express variable
-  app.set('formidable', formidable)
+  app.set('formidable', Formidable)
 
   // apply middleware for handling form data
   app.use((req, res, next) => {
@@ -20,7 +20,7 @@ module.exports = app => {
     // only process forms with multipart content-type
     if (typeof contentType === 'string' && contentType.includes('multipart/form-data')) {
       // generate form object with formidable
-      const form = new formidable.IncomingForm(params)
+      const form = new Formidable(params)
 
       form.parse(req, (err, fields, files) => {
         if (err) {

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -64,7 +64,7 @@ module.exports = app => {
   }
 
   // enable multipart
-  if (typeof params.multipart === 'object') {
+  if (typeof params.formidable === 'object') {
     app = require('./enableMultipart.js')(app)
   }
 

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -17,9 +17,7 @@ function configAudit (appDir) {
   const defaultScripts = require('../defaults/scripts')
   const defaultScriptKeys = Object.keys(defaultScripts)
   let pkg
-  let userConfig
-  let userConfigKeys
-  let userScripts
+  let cfg
   let errors
   let processEnv
   if (!appDir) {
@@ -36,19 +34,592 @@ function configAudit (appDir) {
   }
 
   try {
-    // if package or rooseveltConfig cannot be found (e.g., script triggered without app present), skip audit
+    // check for existence of package.json and rooseveltConfig within
     pkg = require(path.join(appDir, 'package.json'))
     if (!pkg.rooseveltConfig) {
       throw new Error('rooseveltConfig not found!')
     }
+  } catch {
+    pkg = {}
+  }
 
-    // Make a deep copy of the package.json
-    userConfig = JSON.parse(JSON.stringify(pkg.rooseveltConfig))
-    userConfigKeys = Object.keys(userConfig)
-
-    userScripts = pkg.scripts || {}
+  try {
+    // check for existence of rooseveltConfig.json
+    cfg = require(path.join(appDir, 'rooseveltConfig.json'))
   } catch (e) {
-    return
+    // skip audit if package config was also not found
+    if (!pkg.rooseveltConfig) {
+      return
+    }
+  }
+
+  logger.info('📋', 'Starting rooseveltConfig audit...')
+
+  if (cfg) {
+    logger.info('📋', 'Scanning rooseveltConfig.json...')
+
+    // audit config file if it exists
+    audit(cfg, 'file')
+  }
+
+  if (pkg.rooseveltConfig) {
+    logger.info('📋', 'Scanning package.json...')
+
+    // audit package.json if it exists
+    audit(pkg, 'package')
+  }
+
+  /**
+   * Audit a given Roosevelt config
+   * @param {object} config - configuration object to test
+   * @param {string} source - source of configuration (package/config file)
+   */
+  function audit (config, source) {
+    let userConfig
+    let userConfigKeys
+    let userScripts
+
+    // make deep copies of configuration object
+    if (source === 'package') {
+      userConfig = JSON.parse(JSON.stringify(config.rooseveltConfig))
+      userConfigKeys = Object.keys(userConfig)
+      userScripts = config.scripts || {}
+    } else if (source === 'file') {
+      userConfig = JSON.parse(JSON.stringify(config))
+      userConfigKeys = Object.keys(userConfig)
+    }
+
+    /**
+     * To check for extra params, call `foundExtra()` in the default case
+     * Auditing an object requires a `switch`, cases for each param, and to push/pop from `keyStack`
+     * Check types by calling `checkTypes` and passing it a list of possible types it should be
+    */
+    const keyStack = []
+    for (const key of userConfigKeys) {
+      const userParam = userConfig[key]
+
+      keyStack.push(key)
+      switch (key) {
+        case 'alwaysHostPublic':
+          checkTypes(userParam, key, ['boolean'])
+          break
+        case 'checkDependencies':
+          checkTypes(userParam, key, ['boolean'])
+          break
+        case 'clientViews': {
+          checkTypes(userParam, key, ['object'])
+          const clientViewParam = userParam || {}
+          for (const clientViewKey of Object.keys(clientViewParam)) {
+            keyStack.push(clientViewKey)
+            switch (clientViewKey) {
+              case 'whitelist':
+                checkTypes(clientViewParam[clientViewKey], clientViewKey, ['null', 'object'])
+                break
+              case 'blacklist':
+                checkTypes(clientViewParam[clientViewKey], clientViewKey, ['null', 'object'])
+                break
+              case 'output':
+                checkTypes(clientViewParam[clientViewKey], clientViewKey, ['string'])
+                break
+              case 'minify':
+                checkTypes(clientViewParam[clientViewKey], clientViewKey, ['boolean'])
+                break
+              case 'minifyOptions':
+                checkTypes(clientViewParam[clientViewKey], clientViewKey, ['null', 'object'])
+                break
+              case 'exposeAll':
+                checkTypes(clientViewParam[clientViewKey], clientViewKey, ['boolean'])
+                break
+              case 'defaultBundle':
+                checkTypes(clientViewParam[clientViewKey], clientViewKey, ['string'])
+                break
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(clientViewKey)
+          }
+          break
+        }
+        case 'controllersPath':
+          checkTypes(userParam, key, ['string'])
+          break
+        case 'cores':
+          checkTypes(userParam, key, ['number', 'string'])
+          break
+        case 'enableCLIFlags':
+          checkTypes(userParam, key, ['boolean'])
+          break
+        case 'favicon':
+          checkTypes(userParam, key, ['null', 'string'])
+          break
+        case 'generateFolderStructure':
+          checkTypes(userParam, key, ['boolean'])
+          break
+        case 'https': {
+          checkTypes(userParam, key, ['boolean', 'object'])
+          const httpsParam = userParam || {}
+          for (const httpsKey of Object.keys(httpsParam)) {
+            keyStack.push(httpsKey)
+            switch (httpsKey) {
+              case 'enable':
+                checkTypes(httpsParam[httpsKey], httpsKey, ['boolean'])
+                break
+              case 'force':
+                checkTypes(httpsParam[httpsKey], httpsKey, ['boolean'])
+                break
+              case 'port':
+                checkTypes(httpsParam[httpsKey], httpsKey, ['string', 'number'])
+                break
+              case 'authInfoPath':
+                checkTypes(httpsParam[httpsKey], httpsKey, ['null', 'object'])
+                break
+              case 'caCert':
+                checkTypes(httpsParam[httpsKey], httpsKey, ['null', 'string'])
+                break
+              case 'requestCert':
+                checkTypes(httpsParam[httpsKey], httpsKey, ['null', 'boolean'])
+                break
+              case 'rejectUnauthorized':
+                checkTypes(httpsParam[httpsKey], httpsKey, ['null', 'boolean'])
+                break
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(httpsKey)
+          }
+          break
+        }
+        case 'localhostOnly':
+          checkTypes(userParam, key, ['boolean'])
+          break
+        case 'minify':
+          checkTypes(userParam, key, ['boolean'])
+          break
+        case 'mode':
+          checkTypes(userParam, key, ['string'])
+          break
+        case 'modelsPath':
+          checkTypes(userParam, key, ['string'])
+          break
+        case 'formidable':
+          checkTypes(userParam, key, ['boolean', 'object'])
+          break
+        case 'port':
+          checkTypes(userParam, key, ['number', 'string'])
+          break
+        case 'publicFolder':
+          checkTypes(userParam, key, ['string'])
+          break
+        case 'routers':
+          checkTypes(userParam, key, ['boolean', 'object'])
+          break
+        case 'shutdownTimeout':
+          checkTypes(userParam, key, ['number'])
+          break
+        case 'staticsRoot':
+          checkTypes(userParam, key, ['string'])
+          break
+        case 'staticsSymlinksToPublic':
+          checkTypes(userParam, key, ['array'])
+          break
+        case 'versionedPublic':
+          checkTypes(userParam, key, ['boolean'])
+          break
+        case 'viewEngine':
+          checkTypes(userParam, key, ['array', 'null', 'string'])
+          break
+        case 'viewsPath':
+          checkTypes(userParam, key, ['string'])
+          break
+        case 'bodyParser': {
+          checkTypes(userParam, key, ['object'])
+          const bodyParserParam = userParam || {}
+          for (const bodyParserKey of Object.keys(bodyParserParam)) {
+            keyStack.push(bodyParserKey)
+            switch (bodyParserKey) {
+              case 'urlEncoded':
+                checkTypes(bodyParserParam[bodyParserKey], bodyParserKey, ['object'])
+                break
+              case 'json':
+                checkTypes(bodyParserParam[bodyParserKey], bodyParserKey, ['object'])
+                break
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(bodyParserKey)
+          }
+          break
+        }
+        case 'css': {
+          checkTypes(userParam, key, ['object'])
+          const cssParam = userParam || {}
+          for (const cssKey of Object.keys(cssParam)) {
+            keyStack.push(cssKey)
+            switch (cssKey) {
+              case 'sourcePath':
+                checkTypes(cssParam[cssKey], cssKey, ['string'])
+                break
+              case 'compiler': {
+                checkTypes(cssParam[cssKey], cssKey, ['null', 'object', 'string'])
+                const cssCompilerParam = cssParam[cssKey] || {}
+                for (const cssCompilerKey of Object.keys(cssCompilerParam)) {
+                  keyStack.push(cssCompilerKey)
+                  switch (cssCompilerKey) {
+                    case 'enable':
+                      checkTypes(cssCompilerParam[cssCompilerKey], cssCompilerKey, ['boolean'])
+                      break
+                    case 'module':
+                      checkTypes(cssCompilerParam[cssCompilerKey], cssCompilerKey, ['string'])
+                      break
+                    case 'options':
+                      checkTypes(cssCompilerParam[cssCompilerKey], cssCompilerKey, ['object', 'null'])
+                      break
+                    default:
+                      foundExtra(['rooseveltConfig', ...keyStack])
+                  }
+                  keyStack.pop(cssCompilerKey)
+                }
+                break
+              }
+              case 'minifier': {
+                checkTypes(cssParam[cssKey], cssKey, ['null', 'object'])
+                const cssMinifierParam = cssParam[cssKey] || {}
+                for (const minifierKey of Object.keys(cssMinifierParam)) {
+                  keyStack.push(minifierKey)
+                  switch (minifierKey) {
+                    case 'enable':
+                      checkTypes(cssMinifierParam[minifierKey], minifierKey, ['boolean'])
+                      break
+                    case 'options':
+                      checkTypes(cssMinifierParam[minifierKey], minifierKey, ['object', 'null'])
+                      break
+                    default:
+                      foundExtra(['rooseveltConfig', ...keyStack])
+                  }
+                  keyStack.pop(minifierKey)
+                }
+                break
+              }
+              case 'whitelist':
+                checkTypes(cssParam[cssKey], cssKey, ['array', 'null'])
+                break
+              case 'output':
+                checkTypes(cssParam[cssKey], cssKey, ['string'])
+                break
+              case 'versionFile':
+                checkTypes(cssParam[cssKey], cssKey, ['null', 'object'])
+                break
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(cssKey)
+          }
+          break
+        }
+        case 'errorPages': {
+          checkTypes(userParam, key, ['object'])
+          const errorPagesParam = userParam || {}
+          for (const errorPagesKey of Object.keys(errorPagesParam)) {
+            keyStack.push(errorPagesKey)
+            switch (errorPagesKey) {
+              case 'notFound':
+                checkTypes(errorPagesParam[errorPagesKey], errorPagesKey, ['string'])
+                break
+              case 'internalServerError':
+                checkTypes(errorPagesParam[errorPagesKey], errorPagesKey, ['string'])
+                break
+              case 'serviceUnavailable':
+                checkTypes(errorPagesParam[errorPagesKey], errorPagesKey, ['string'])
+                break
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(errorPagesKey)
+          }
+          break
+        }
+        case 'frontendReload': {
+          checkTypes(userParam, key, ['object'])
+          const reloadParam = userParam || {}
+          for (const reloadKey of Object.keys(reloadParam)) {
+            keyStack.push(reloadKey)
+            switch (reloadKey) {
+              case 'enable':
+                checkTypes(reloadParam[reloadKey], reloadKey, ['boolean'])
+                break
+              case 'port':
+                checkTypes(reloadParam[reloadKey], reloadKey, ['number'])
+                break
+              case 'httpsPort':
+                checkTypes(reloadParam[reloadKey], reloadKey, ['number'])
+                break
+              case 'verbose':
+                checkTypes(reloadParam[reloadKey], reloadKey, ['boolean'])
+                break
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(reloadKey)
+          }
+          break
+        }
+        case 'htmlMinifier': {
+          checkTypes(userParam, key, ['object'])
+          const htmlMinParam = userParam || {}
+          for (const htmlMinKey of Object.keys(htmlMinParam)) {
+            keyStack.push(htmlMinKey)
+            switch (htmlMinKey) {
+              case 'enable':
+                checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['boolean'])
+                break
+              case 'exceptionRoutes':
+                checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['array', 'boolean', 'string'])
+                break
+              case 'options':
+                checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['object'])
+                break
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(htmlMinKey)
+          }
+          break
+        }
+        case 'htmlValidator': {
+          checkTypes(userParam, key, ['object'])
+          const validatorParam = userParam || {}
+          for (const validatorKey of Object.keys(validatorParam)) {
+            keyStack.push(validatorKey)
+            switch (validatorKey) {
+              case 'enable':
+                checkTypes(validatorParam[validatorKey], validatorKey, ['boolean'])
+                break
+              case 'separateProcess': {
+                checkTypes(validatorParam[validatorKey], validatorKey, ['object'])
+                const sepProcParam = validatorParam[validatorKey] || {}
+                for (const sepProcKey of Object.keys(sepProcParam)) {
+                  keyStack.push(sepProcKey)
+                  switch (sepProcKey) {
+                    case 'enable':
+                      checkTypes(sepProcParam[sepProcKey], sepProcKey, ['boolean'])
+                      break
+                    case 'autoKiller':
+                      checkTypes(sepProcParam[sepProcKey], sepProcKey, ['boolean'])
+                      break
+                    case 'autoKillerTimeout':
+                      checkTypes(sepProcParam[sepProcKey], sepProcKey, ['number'])
+                      break
+                    default:
+                      foundExtra(['rooseveltConfig', ...keyStack])
+                  }
+                  keyStack.pop(sepProcKey)
+                }
+                break
+              }
+              case 'port':
+                checkTypes(validatorParam[validatorKey], validatorKey, ['number', 'string'])
+                break
+              case 'showWarnings':
+                checkTypes(validatorParam[validatorKey], validatorKey, ['boolean'])
+                break
+              case 'exceptions': {
+                checkTypes(validatorParam[validatorKey], validatorKey, ['object'])
+                const exceptionsParam = validatorParam[validatorKey] || {}
+                for (const exceptionKey of Object.keys(exceptionsParam)) {
+                  keyStack.push(exceptionKey)
+                  switch (exceptionKey) {
+                    case 'requestHeader':
+                      checkTypes(exceptionsParam[exceptionKey], exceptionKey, ['string'])
+                      break
+                    case 'modelValue':
+                      checkTypes(exceptionsParam[exceptionKey], exceptionKey, ['string'])
+                      break
+                    default:
+                      foundExtra(['rooseveltConfig', ...keyStack])
+                  }
+                  keyStack.pop(exceptionKey)
+                }
+                break
+              }
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(validatorKey)
+          }
+          break
+        }
+        case 'logging': {
+          checkTypes(userParam, key, ['object'])
+          const loggingParam = userParam || {}
+          for (const loggingKey of Object.keys(loggingParam)) {
+            keyStack.push(loggingKey)
+            switch (loggingKey) {
+              case 'methods': {
+                checkTypes(loggingParam[loggingKey], loggingKey, ['object'])
+                const methodsParam = loggingParam[loggingKey] || {}
+                for (const methodsKey of Object.keys(methodsParam)) {
+                  keyStack.push(methodsKey)
+                  switch (methodsKey) {
+                    case 'http':
+                      checkTypes(methodsParam[methodsKey], methodsKey, ['boolean'])
+                      break
+                    case 'info':
+                      checkTypes(methodsParam[methodsKey], methodsKey, ['boolean'])
+                      break
+                    case 'warn':
+                      checkTypes(methodsParam[methodsKey], methodsKey, ['boolean'])
+                      break
+                    case 'error':
+                      checkTypes(methodsParam[methodsKey], methodsKey, ['boolean'])
+                      break
+                    case 'verbose':
+                      checkTypes(methodsParam[methodsKey], methodsKey, ['boolean'])
+                      break
+                    default:
+                    // ignore extra custom log types in the methods object
+                  }
+                  keyStack.pop(methodsKey)
+                }
+                break
+              }
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(loggingKey)
+          }
+          break
+        }
+        case 'js': {
+          checkTypes(userParam, key, ['object'])
+          const jsParam = userParam || {}
+          for (const jsKey of Object.keys(jsParam)) {
+            keyStack.push(jsKey)
+            switch (jsKey) {
+              case 'sourcePath':
+                checkTypes(jsParam[jsKey], jsKey, ['string'])
+                break
+              case 'webpack': {
+                checkTypes(jsParam[jsKey], jsKey, ['object'])
+                const bundlerParam = jsParam[jsKey] || {}
+                for (const bundlerKey of Object.keys(bundlerParam)) {
+                  keyStack.push(bundlerKey)
+                  switch (bundlerKey) {
+                    case 'enable':
+                      checkTypes(bundlerParam[bundlerKey], bundlerKey, ['boolean'])
+                      break
+                    case 'bundles':
+                      checkTypes(bundlerParam[bundlerKey], bundlerKey, ['array'])
+                      break
+                    default:
+                      foundExtra(['rooseveltConfig', ...keyStack])
+                  }
+                  keyStack.pop(bundlerKey)
+                }
+                break
+              }
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(jsKey)
+          }
+          break
+        }
+        case 'toobusy': {
+          checkTypes(userParam, key, ['object'])
+          const busyParam = userParam || {}
+          for (const busyKey of Object.keys(busyParam)) {
+            keyStack.push(busyKey)
+            switch (busyKey) {
+              case 'maxLagPerRequest':
+                checkTypes(busyParam[busyKey], busyKey, ['number'])
+                break
+              case 'lagCheckInterval':
+                checkTypes(busyParam[busyKey], busyKey, ['number'])
+                break
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(busyKey)
+          }
+          break
+        }
+        default:
+          foundExtra(['rooseveltConfig', ...keyStack])
+      }
+      keyStack.pop(key)
+    }
+
+    if (userScripts) {
+      let hasProdScript = false
+      let hasDevScript = false
+
+      for (const script of defaultScriptKeys) {
+        switch (script) {
+          case 'start':
+          case 'production':
+          case 'prod':
+          case 'p':
+            if (userScripts[script] !== undefined) {
+              hasProdScript = true
+            }
+            break
+          case 'development':
+          case 'dev':
+          case 'd':
+            if (userScripts[script] !== undefined) {
+              hasDevScript = true
+            }
+            break
+          case 'kill-validator':
+            checkMissingScript(userScripts, script)
+            checkOutdatedScript(userScripts, script)
+            break
+          case 'kv':
+            break
+          case 'config-audit':
+            checkMissingScript(userScripts, script)
+            checkOutdatedScript(userScripts, script)
+            break
+          case 'a':
+            break
+          case 'standard':
+            break
+          case 'stylelint':
+            break
+          case 'lint':
+          case 'l':
+            break
+          case 'test':
+            if (userScripts[script] === undefined) {
+              logger.warn(` Missing recommended script "${script}"!`)
+              errors = true
+            }
+            break
+        }
+      }
+
+      // output warning for missing start script
+      if (!hasProdScript) {
+        logger.warn(' Missing production run script(s).')
+        errors = true
+      }
+      if (!hasDevScript) {
+        logger.warn(' Missing development run script(s).')
+        errors = true
+      }
+    }
+
+    if (errors) {
+      logger.error(`Issues have been detected in ${source === 'package' ? 'package.json' : 'rooseveltConfig.json'}, please consult https://github.com/rooseveltframework/roosevelt#configure-your-app-with-parameters for details on each param.`.bold)
+      logger.error('Or see https://github.com/rooseveltframework/roosevelt/blob/master/lib/defaults/config.json for the latest sample rooseveltConfig.'.bold)
+    } else {
+      logger.info('✅', 'rooseveltConfig audit completed with no errors found.'.green)
+    }
+
+    // detect if roosevelt is being updated from a pre 0.16 version
+    if (source === 'package' && pkg.rooseveltConfig.cleanTimer) {
+      logger.error('Your Roosevelt config was created under an old version of Roosevelt. Because of breaking API changes you may need to remove previous build artifacts that were generated by the previous version of Roosevelt such as most commonly: statics/.build and statics/js/.bundled. You can remove this warning by upgrading your Roosevelt config to the latest version of Roosevelt. Be sure to update your nodemonConfig and .gitignore as well. See https://github.com/rooseveltframework/roosevelt/blob/master/lib/defaults/config.json for the latest default config.'.bold)
+    }
   }
 
   /**
@@ -57,7 +628,7 @@ function configAudit (appDir) {
    * @param {Array} keyList - list of keys from the keyStack
    */
   function foundExtra (keyList) {
-    logger.error('⚠️', ` Extra param "${keyList.pop()}" found in ${keyList.join('.')}, this can be removed.`.bold)
+    logger.error('⚠️', ` Extra param "${keyList.pop()}" found in ${keyList.join('.')}, this can be removed.`)
     errors = true
   }
 
@@ -106,472 +677,10 @@ function configAudit (appDir) {
         }
       }
       if (isCorrectType === false) {
-        logger.error('⚠️', ` The type of param '${key}' should be one of the supported types: ${types.join(', ')}`)
+        logger.error('⚠️', ` The type of param "${key}" should be one of the supported types: ${types.join(', ')}`)
         errors = true
       }
     }
-  }
-
-  logger.info('📋', 'Starting rooseveltConfig audit...')
-
-  /**
-   * To check for extra params, call `foundExtra()` in the default case
-   * Auditing an object requires a `switch`, cases for each param, and to push/pop from `keyStack`
-   * Check types by calling `checkTypes` and passing it a list of possible types it should be
-  */
-  const keyStack = []
-  for (const key of userConfigKeys) {
-    const userParam = userConfig[key]
-
-    keyStack.push(key)
-    switch (key) {
-      case 'alwaysHostPublic':
-        checkTypes(userParam, key, ['boolean'])
-        break
-      case 'checkDependencies':
-        checkTypes(userParam, key, ['boolean'])
-        break
-      case 'clientViews': {
-        checkTypes(userParam, key, ['object'])
-        const clientViewParam = userParam || {}
-        for (const clientViewKey of Object.keys(clientViewParam)) {
-          keyStack.push(clientViewKey)
-          switch (clientViewKey) {
-            case 'whitelist':
-              checkTypes(clientViewParam[clientViewKey], clientViewKey, ['null', 'object'])
-              break
-            case 'blacklist':
-              checkTypes(clientViewParam[clientViewKey], clientViewKey, ['null', 'object'])
-              break
-            case 'output':
-              checkTypes(clientViewParam[clientViewKey], clientViewKey, ['string'])
-              break
-            case 'minify':
-              checkTypes(clientViewParam[clientViewKey], clientViewKey, ['boolean'])
-              break
-            case 'minifyOptions':
-              checkTypes(clientViewParam[clientViewKey], clientViewKey, ['null', 'object'])
-              break
-            case 'exposeAll':
-              checkTypes(clientViewParam[clientViewKey], clientViewKey, ['boolean'])
-              break
-            case 'defaultBundle':
-              checkTypes(clientViewParam[clientViewKey], clientViewKey, ['string'])
-              break
-            default:
-              foundExtra(['rooseveltConfig', ...keyStack])
-          }
-          keyStack.pop(clientViewKey)
-        }
-        break
-      }
-      case 'controllersPath':
-        checkTypes(userParam, key, ['string'])
-        break
-      case 'cores':
-        checkTypes(userParam, key, ['number', 'string'])
-        break
-      case 'enableCLIFlags':
-        checkTypes(userParam, key, ['boolean'])
-        break
-      case 'favicon':
-        checkTypes(userParam, key, ['null', 'string'])
-        break
-      case 'generateFolderStructure':
-        checkTypes(userParam, key, ['boolean'])
-        break
-      case 'https': {
-        checkTypes(userParam, key, ['boolean', 'object'])
-        const httpsParam = userParam || {}
-        for (const httpsKey of Object.keys(httpsParam)) {
-          keyStack.push(httpsKey)
-          switch (httpsKey) {
-            case 'enable':
-              checkTypes(httpsParam[httpsKey], httpsKey, ['boolean'])
-              break
-            case 'force':
-              checkTypes(httpsParam[httpsKey], httpsKey, ['boolean'])
-              break
-            case 'port':
-              checkTypes(httpsParam[httpsKey], httpsKey, ['string', 'number'])
-              break
-            case 'authInfoPath':
-              checkTypes(httpsParam[httpsKey], httpsKey, ['null', 'object'])
-              break
-            case 'caCert':
-              checkTypes(httpsParam[httpsKey], httpsKey, ['null', 'string'])
-              break
-            case 'requestCert':
-              checkTypes(httpsParam[httpsKey], httpsKey, ['null', 'boolean'])
-              break
-            case 'rejectUnauthorized':
-              checkTypes(httpsParam[httpsKey], httpsKey, ['null', 'boolean'])
-              break
-            default:
-              foundExtra(['rooseveltConfig', ...keyStack])
-          }
-          keyStack.pop(httpsKey)
-        }
-        break
-      }
-      case 'localhostOnly':
-        checkTypes(userParam, key, ['boolean'])
-        break
-      case 'minify':
-        checkTypes(userParam, key, ['boolean'])
-        break
-      case 'mode':
-        checkTypes(userParam, key, ['string'])
-        break
-      case 'modelsPath':
-        checkTypes(userParam, key, ['string'])
-        break
-      case 'formidable':
-        checkTypes(userParam, key, ['boolean', 'object'])
-        break
-      case 'port':
-        checkTypes(userParam, key, ['number', 'string'])
-        break
-      case 'publicFolder':
-        checkTypes(userParam, key, ['string'])
-        break
-      case 'routers':
-        checkTypes(userParam, key, ['boolean', 'object'])
-        break
-      case 'shutdownTimeout':
-        checkTypes(userParam, key, ['number'])
-        break
-      case 'staticsRoot':
-        checkTypes(userParam, key, ['string'])
-        break
-      case 'staticsSymlinksToPublic':
-        checkTypes(userParam, key, ['array'])
-        break
-      case 'versionedPublic':
-        checkTypes(userParam, key, ['boolean'])
-        break
-      case 'viewEngine':
-        checkTypes(userParam, key, ['array', 'null', 'string'])
-        break
-      case 'viewsPath':
-        checkTypes(userParam, key, ['string'])
-        break
-      case 'bodyParser': {
-        checkTypes(userParam, key, ['object'])
-        const bodyParserParam = userParam || {}
-        for (const bodyParserKey of Object.keys(bodyParserParam)) {
-          keyStack.push(bodyParserKey)
-          switch (bodyParserKey) {
-            case 'urlEncoded':
-              checkTypes(bodyParserParam[bodyParserKey], bodyParserKey, ['object'])
-              break
-            case 'json':
-              checkTypes(bodyParserParam[bodyParserKey], bodyParserKey, ['object'])
-              break
-            default:
-              foundExtra(['rooseveltConfig', ...keyStack])
-          }
-          keyStack.pop(bodyParserKey)
-        }
-        break
-      }
-      case 'css': {
-        checkTypes(userParam, key, ['object'])
-        const cssParam = userParam || {}
-        for (const cssKey of Object.keys(cssParam)) {
-          keyStack.push(cssKey)
-          switch (cssKey) {
-            case 'sourcePath':
-              checkTypes(cssParam[cssKey], cssKey, ['string'])
-              break
-            case 'compiler': {
-              checkTypes(cssParam[cssKey], cssKey, ['null', 'object', 'string'])
-              const cssCompilerParam = cssParam[cssKey] || {}
-              for (const cssCompilerKey of Object.keys(cssCompilerParam)) {
-                keyStack.push(cssCompilerKey)
-                switch (cssCompilerKey) {
-                  case 'enable':
-                    checkTypes(cssCompilerParam[cssCompilerKey], cssCompilerKey, ['boolean'])
-                    break
-                  case 'module':
-                    checkTypes(cssCompilerParam[cssCompilerKey], cssCompilerKey, ['string'])
-                    break
-                  case 'options':
-                    checkTypes(cssCompilerParam[cssCompilerKey], cssCompilerKey, ['object', 'null'])
-                    break
-                  default:
-                    foundExtra(['rooseveltConfig', ...keyStack])
-                }
-                keyStack.pop(cssCompilerKey)
-              }
-              break
-            }
-            case 'minifier': {
-              checkTypes(cssParam[cssKey], cssKey, ['null', 'object'])
-              const cssMinifierParam = cssParam[cssKey] || {}
-              for (const minifierKey of Object.keys(cssMinifierParam)) {
-                keyStack.push(minifierKey)
-                switch (minifierKey) {
-                  case 'enable':
-                    checkTypes(cssMinifierParam[minifierKey], minifierKey, ['boolean'])
-                    break
-                  case 'options':
-                    checkTypes(cssMinifierParam[minifierKey], minifierKey, ['object', 'null'])
-                    break
-                  default:
-                    foundExtra(['rooseveltConfig', ...keyStack])
-                }
-                keyStack.pop(minifierKey)
-              }
-              break
-            }
-            case 'whitelist':
-              checkTypes(cssParam[cssKey], cssKey, ['array', 'null'])
-              break
-            case 'output':
-              checkTypes(cssParam[cssKey], cssKey, ['string'])
-              break
-            case 'versionFile':
-              checkTypes(cssParam[cssKey], cssKey, ['null', 'object'])
-              break
-            default:
-              foundExtra(['rooseveltConfig', ...keyStack])
-          }
-          keyStack.pop(cssKey)
-        }
-        break
-      }
-      case 'errorPages': {
-        checkTypes(userParam, key, ['object'])
-        const errorPagesParam = userParam || {}
-        for (const errorPagesKey of Object.keys(errorPagesParam)) {
-          keyStack.push(errorPagesKey)
-          switch (errorPagesKey) {
-            case 'notFound':
-              checkTypes(errorPagesParam[errorPagesKey], errorPagesKey, ['string'])
-              break
-            case 'internalServerError':
-              checkTypes(errorPagesParam[errorPagesKey], errorPagesKey, ['string'])
-              break
-            case 'serviceUnavailable':
-              checkTypes(errorPagesParam[errorPagesKey], errorPagesKey, ['string'])
-              break
-            default:
-              foundExtra(['rooseveltConfig', ...keyStack])
-          }
-          keyStack.pop(errorPagesKey)
-        }
-        break
-      }
-      case 'frontendReload': {
-        checkTypes(userParam, key, ['object'])
-        const reloadParam = userParam || {}
-        for (const reloadKey of Object.keys(reloadParam)) {
-          keyStack.push(reloadKey)
-          switch (reloadKey) {
-            case 'enable':
-              checkTypes(reloadParam[reloadKey], reloadKey, ['boolean'])
-              break
-            case 'port':
-              checkTypes(reloadParam[reloadKey], reloadKey, ['number'])
-              break
-            case 'httpsPort':
-              checkTypes(reloadParam[reloadKey], reloadKey, ['number'])
-              break
-            case 'verbose':
-              checkTypes(reloadParam[reloadKey], reloadKey, ['boolean'])
-              break
-            default:
-              foundExtra(['rooseveltConfig', ...keyStack])
-          }
-          keyStack.pop(reloadKey)
-        }
-        break
-      }
-      case 'htmlMinifier': {
-        checkTypes(userParam, key, ['object'])
-        const htmlMinParam = userParam || {}
-        for (const htmlMinKey of Object.keys(htmlMinParam)) {
-          keyStack.push(htmlMinKey)
-          switch (htmlMinKey) {
-            case 'enable':
-              checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['boolean'])
-              break
-            case 'exceptionRoutes':
-              checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['array', 'boolean', 'string'])
-              break
-            case 'options':
-              checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['object'])
-              break
-            default:
-              foundExtra(['rooseveltConfig', ...keyStack])
-          }
-          keyStack.pop(htmlMinKey)
-        }
-        break
-      }
-      case 'htmlValidator': {
-        checkTypes(userParam, key, ['object'])
-        const validatorParam = userParam || {}
-        for (const validatorKey of Object.keys(validatorParam)) {
-          keyStack.push(validatorKey)
-          switch (validatorKey) {
-            case 'enable':
-              checkTypes(validatorParam[validatorKey], validatorKey, ['boolean'])
-              break
-            case 'separateProcess': {
-              checkTypes(validatorParam[validatorKey], validatorKey, ['object'])
-              const sepProcParam = validatorParam[validatorKey] || {}
-              for (const sepProcKey of Object.keys(sepProcParam)) {
-                keyStack.push(sepProcKey)
-                switch (sepProcKey) {
-                  case 'enable':
-                    checkTypes(sepProcParam[sepProcKey], sepProcKey, ['boolean'])
-                    break
-                  case 'autoKiller':
-                    checkTypes(sepProcParam[sepProcKey], sepProcKey, ['boolean'])
-                    break
-                  case 'autoKillerTimeout':
-                    checkTypes(sepProcParam[sepProcKey], sepProcKey, ['number'])
-                    break
-                  default:
-                    foundExtra(['rooseveltConfig', ...keyStack])
-                }
-                keyStack.pop(sepProcKey)
-              }
-              break
-            }
-            case 'port':
-              checkTypes(validatorParam[validatorKey], validatorKey, ['number', 'string'])
-              break
-            case 'showWarnings':
-              checkTypes(validatorParam[validatorKey], validatorKey, ['boolean'])
-              break
-            case 'exceptions': {
-              checkTypes(validatorParam[validatorKey], validatorKey, ['object'])
-              const exceptionsParam = validatorParam[validatorKey] || {}
-              for (const exceptionKey of Object.keys(exceptionsParam)) {
-                keyStack.push(exceptionKey)
-                switch (exceptionKey) {
-                  case 'requestHeader':
-                    checkTypes(exceptionsParam[exceptionKey], exceptionKey, ['string'])
-                    break
-                  case 'modelValue':
-                    checkTypes(exceptionsParam[exceptionKey], exceptionKey, ['string'])
-                    break
-                  default:
-                    foundExtra(['rooseveltConfig', ...keyStack])
-                }
-                keyStack.pop(exceptionKey)
-              }
-              break
-            }
-            default:
-              foundExtra(['rooseveltConfig', ...keyStack])
-          }
-          keyStack.pop(validatorKey)
-        }
-        break
-      }
-      case 'logging': {
-        checkTypes(userParam, key, ['object'])
-        const loggingParam = userParam || {}
-        for (const loggingKey of Object.keys(loggingParam)) {
-          keyStack.push(loggingKey)
-          switch (loggingKey) {
-            case 'methods': {
-              checkTypes(loggingParam[loggingKey], loggingKey, ['object'])
-              const methodsParam = loggingParam[loggingKey] || {}
-              for (const methodsKey of Object.keys(methodsParam)) {
-                keyStack.push(methodsKey)
-                switch (methodsKey) {
-                  case 'http':
-                    checkTypes(methodsParam[methodsKey], methodsKey, ['boolean'])
-                    break
-                  case 'info':
-                    checkTypes(methodsParam[methodsKey], methodsKey, ['boolean'])
-                    break
-                  case 'warn':
-                    checkTypes(methodsParam[methodsKey], methodsKey, ['boolean'])
-                    break
-                  case 'error':
-                    checkTypes(methodsParam[methodsKey], methodsKey, ['boolean'])
-                    break
-                  case 'verbose':
-                    checkTypes(methodsParam[methodsKey], methodsKey, ['boolean'])
-                    break
-                  default:
-                    // ignore extra custom log types in the methods object
-                }
-                keyStack.pop(methodsKey)
-              }
-              break
-            }
-            default:
-              // ignore extra params in logging object
-          }
-          keyStack.pop(loggingKey)
-        }
-        break
-      }
-      case 'js': {
-        checkTypes(userParam, key, ['object'])
-        const jsParam = userParam || {}
-        for (const jsKey of Object.keys(jsParam)) {
-          keyStack.push(jsKey)
-          switch (jsKey) {
-            case 'sourcePath':
-              checkTypes(jsParam[jsKey], jsKey, ['string'])
-              break
-            case 'webpack': {
-              checkTypes(jsParam[jsKey], jsKey, ['object'])
-              const bundlerParam = jsParam[jsKey] || {}
-              for (const bundlerKey of Object.keys(bundlerParam)) {
-                keyStack.push(bundlerKey)
-                switch (bundlerKey) {
-                  case 'enable':
-                    checkTypes(bundlerParam[bundlerKey], bundlerKey, ['boolean'])
-                    break
-                  case 'bundles':
-                    checkTypes(bundlerParam[bundlerKey], bundlerKey, ['array'])
-                    break
-                  default:
-                    foundExtra(['rooseveltConfig', ...keyStack])
-                }
-                keyStack.pop(bundlerKey)
-              }
-              break
-            }
-            default:
-              foundExtra(['rooseveltConfig', ...keyStack])
-          }
-          keyStack.pop(jsKey)
-        }
-        break
-      }
-      case 'toobusy': {
-        checkTypes(userParam, key, ['object'])
-        const busyParam = userParam || {}
-        for (const busyKey of Object.keys(busyParam)) {
-          keyStack.push(busyKey)
-          switch (busyKey) {
-            case 'maxLagPerRequest':
-              checkTypes(busyParam[busyKey], busyKey, ['number'])
-              break
-            case 'lagCheckInterval':
-              checkTypes(busyParam[busyKey], busyKey, ['number'])
-              break
-            default:
-              foundExtra(['rooseveltConfig', ...keyStack])
-          }
-          keyStack.pop(busyKey)
-        }
-        break
-      }
-      default:
-        foundExtra(['rooseveltConfig', ...keyStack])
-    }
-    keyStack.pop(key)
   }
 
   /**
@@ -582,7 +691,7 @@ function configAudit (appDir) {
    */
   function checkMissingScript (scripts, scriptKey) {
     if (scripts[scriptKey] === undefined) {
-      logger.error('⚠️', ` Missing script "${scriptKey}"!`.bold)
+      logger.error('⚠️', ` Missing script "${scriptKey}"!`)
       errors = true
     }
   }
@@ -596,79 +705,9 @@ function configAudit (appDir) {
   function checkOutdatedScript (scripts, scriptKey) {
     if (scripts !== undefined && scripts[scriptKey] !== undefined) {
       if (scripts[scriptKey].includes('roosevelt') && scripts[scriptKey] !== defaultScripts[scriptKey].value) {
-        logger.error('⚠️', ` Detected outdated script "${scriptKey}". Update contents to "${defaultScripts[scriptKey].value}" to restore functionality.`.bold)
+        logger.error('⚠️', ` Detected outdated script "${scriptKey}". Update contents to "${defaultScripts[scriptKey].value}" to restore functionality.`)
         errors = true
       }
     }
-  }
-
-  let hasProdScript = false
-  let hasDevScript = false
-
-  for (const script of defaultScriptKeys) {
-    switch (script) {
-      case 'start':
-      case 'production':
-      case 'prod':
-      case 'p':
-        if (userScripts[script] !== undefined) {
-          hasProdScript = true
-        }
-        break
-      case 'development':
-      case 'dev':
-      case 'd':
-        if (userScripts[script] !== undefined) {
-          hasDevScript = true
-        }
-        break
-      case 'kill-validator':
-        checkMissingScript(userScripts, script)
-        checkOutdatedScript(userScripts, script)
-        break
-      case 'kv':
-        break
-      case 'config-audit':
-        checkMissingScript(userScripts, script)
-        checkOutdatedScript(userScripts, script)
-        break
-      case 'a':
-        break
-      case 'standard':
-        break
-      case 'stylelint':
-        break
-      case 'lint':
-      case 'l':
-        break
-      case 'test':
-        if (userScripts[script] === undefined) {
-          logger.warn(` Missing recommended script "${script}"!`.bold)
-          errors = true
-        }
-        break
-    }
-  }
-
-  // output warning for missing start script
-  if (!hasProdScript) {
-    logger.warn(' Missing production run script(s).'.bold)
-    errors = true
-  }
-  if (!hasDevScript) {
-    logger.warn(' Missing development run script(s).'.bold)
-    errors = true
-  }
-
-  if (errors) {
-    logger.error('Issues have been detected in rooseveltConfig, please consult https://github.com/rooseveltframework/roosevelt#configure-your-app-with-parameters for details on each param.'.bold)
-    logger.error('Or see https://github.com/rooseveltframework/roosevelt/blob/master/lib/defaults/config.json for the latest sample rooseveltConfig.'.bold)
-  } else {
-    logger.info('✅', 'rooseveltConfig audit completed with no errors found.'.green)
-  }
-
-  // detect if roosevelt is being updated from a pre 0.16 version
-  if (pkg.rooseveltConfig.cleanTimer) {
-    logger.error('Your Roosevelt config was created under an old version of Roosevelt. Because of breaking API changes you may need to remove previous build artifacts that were generated by the previous version of Roosevelt such as most commonly: statics/.build and statics/js/.bundled. You can remove this warning by upgrading your Roosevelt config to the latest version of Roosevelt. Be sure to update your nodemonConfig and .gitignore as well. See https://github.com/rooseveltframework/roosevelt/blob/master/lib/defaults/config.json for the latest default config.'.bold)
   }
 }

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -226,7 +226,7 @@ function configAudit (appDir) {
       case 'modelsPath':
         checkTypes(userParam, key, ['string'])
         break
-      case 'multipart':
+      case 'formidable':
         checkTypes(userParam, key, ['boolean', 'object'])
         break
       case 'port':

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -157,8 +157,8 @@ module.exports = (params, app) => {
         }
       }
     },
-    multipart: {
-      default: defaults.multipart
+    formidable: {
+      default: defaults.formidable
     },
     toobusy: {
       maxLagPerRequest: {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -9,6 +9,7 @@ const defaults = require('./defaults/config')
 const template = require('es6-template-strings')
 let pkg
 let pkgConfig
+let configFile
 
 module.exports = (params, app) => {
   const appDir = params.appDir
@@ -23,12 +24,20 @@ module.exports = (params, app) => {
   // ensure rooseveltConfig is an object
   pkgConfig = pkg.rooseveltConfig || {}
 
+  // determine if app has a config file
+  try {
+    configFile = require(path.join(appDir, 'rooseveltConfig.json'))
+  } catch {
+    configFile = {}
+  }
+
   // source-configs configuration
   const config = {
     sources: [
       'command line',
       'environment variable',
       params,
+      configFile,
       pkgConfig
     ],
     logging: false,

--- a/test/configAuditor.js
+++ b/test/configAuditor.js
@@ -1,662 +1,175 @@
 /* eslint-env mocha */
 
+const appCleaner = require('./util/appCleaner')
+const appGenerator = require('./util/appGenerator')
 const assert = require('assert')
-const cleanupTestApp = require('./util/cleanupTestApp')
-const { fork } = require('child_process')
+const execa = require('execa')
 const fs = require('fs-extra')
-const generateTestApp = require('./util/generateTestApp')
 const path = require('path')
 
-describe('config auditor', function () {
-  // path to the test app Directory
-  const appDir = path.join(__dirname, 'app/configAuditorTest')
+describe('config auditor', () => {
+  const appDir = path.join(__dirname, 'app/configAudit')
+  let pkgJson
+  let configFile
 
-  // options to pass into test app generator
-  const options = { rooseveltPath: '../../../roosevelt', method: 'startServer', stopServer: true }
+  beforeEach(() => {
+    // wipe out contents of package and config file
+    pkgJson = {}
+    configFile = {}
 
-  // variable to hold the data that will be written to the package.json file for each test
-  let packageJSONSource = {}
-
-  beforeEach(function (done) {
-    // create sample config
+    // make copies of the default config and scripts
     const sampleContent = JSON.parse(JSON.stringify(require('../lib/defaults/config.json')))
-    // grab the content of the script file
     const scriptContent = JSON.parse(fs.readFileSync(path.join(__dirname, '../lib/defaults/scripts.json')).toString('utf8'))
-    // add the defaultContent to packageJSONSource
-    packageJSONSource.rooseveltConfig = sampleContent
-    // separate the commands from the rest of the data in the scripts file
-    packageJSONSource.scripts = {}
-    const keys = Object.keys(scriptContent)
-    for (let x = 0; x < keys.length; x++) {
-      packageJSONSource.scripts[keys[x]] = scriptContent[keys[x]].value
+
+    // attach default config to sample package.json
+    pkgJson.rooseveltConfig = sampleContent
+
+    // attach default scripts to sample package.json
+    pkgJson.scripts = {}
+    for (const key of Object.keys(scriptContent)) {
+      pkgJson.scripts[key] = scriptContent[key].value
     }
-    done()
+
+    // attach default config to sample rooseveltConfig.json
+    configFile = sampleContent
   })
 
-  // clean up the test app directory after each test
-  afterEach(function (done) {
-    cleanupTestApp(appDir, (err) => {
-      if (err) {
-        throw err
-      } else {
-        done()
-      }
-    })
+  // wipe out the test app directory after each test
+  afterEach(async () => {
+    // wipe out the test app directory
+    await appCleaner('configAudit')
   })
 
-  it('should report that no errors have been found after running the config auditor', function (done) {
-    // bool var to hold whether or not the right logs were outputted
-    let startingConfigAuditBool = false
-    let noErrorsBool = false
-
-    // generate the package.json file
-    fs.ensureDirSync(appDir)
-    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
-
-    // generate the test app
-    generateTestApp({
-      appDir: appDir,
-      onServerStart: '(app) => {process.send("something")}'
-    }, options)
-
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the output stream, check for config auditor data
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        startingConfigAuditBool = true
-      }
-      if (data.includes('rooseveltConfig audit completed with no errors found.')) {
-        noErrorsBool = true
+  it('should start the config audit automatically on first app run', async () => {
+    // generate a sample Roosevelt app
+    appGenerator({
+      location: 'configAudit',
+      method: 'initServer',
+      config: {
+        mode: 'development',
+        generateFolderStructure: false,
+        htmlValidator: {
+          enable: false
+        }
       }
     })
 
-    testApp.on('message', () => {
-      testApp.send('stop')
-    })
+    // generate package.json for that Roosevelt app
+    fs.writeJSONSync(path.join(appDir, 'package.json'), pkgJson)
 
-    // when the child process exits, check assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the config Auditor')
-      assert.strictEqual(noErrorsBool, true, 'config Auditor is reporting back that there is an error even though the package.json file does not have one')
-      done()
-    })
+    // spin up the app
+    const { stdout } = await execa.node(path.join(appDir, 'app.js'))
+
+    // confirm via logging that the audit script started
+    assert(stdout.includes('rooseveltConfig audit'), 'Config audit did not start')
+
+    // in this case no errors should have been reported
+    assert(!stdout.includes('Issues have been detected'), 'Issues were detected in what should have been a valid config')
   })
 
-  it('should be able to scan the package.json file in the test App Directory and find which parameters are extra', function (done) {
-    // bool vars to hold whether or not the right logs and errors are being outputted
-    let startingConfigAuditBool = false
-    let rooseveltConfigExtraBool = false
-    let bodyParserExtraBool = false
-    let cssExtraBool = false
-    let errorPagesExtraBool = false
-    let frontendReloadExtraBool = false
-    let htmlMinifierExtraBool = false
-    let loggingExtraBool = false
-    let methodsExtraBool = false
-    let htmlValidatorExtraBool = false
-    let separateProcessExtraBool = false
-    let exceptionsExtraBool = false
-    let jsExtraBool = false
-    let bundlerExtraBool = false
-    let toobusyExtraBool = false
+  it('should detect and complain about a wide variety of problems in package.json', async () => {
+    // add a whole lot of invalid stuff to a default config
+    pkgJson.rooseveltConfig.port = []
+    pkgJson.rooseveltConfig.extraParam = true
+    pkgJson.rooseveltConfig.bodyParser.extraParam = true
+    pkgJson.rooseveltConfig.css.extraParam = true
+    pkgJson.rooseveltConfig.errorPages.extraParam = true
+    pkgJson.rooseveltConfig.frontendReload.extraParam = true
+    pkgJson.rooseveltConfig.htmlMinifier.extraParam = true
+    pkgJson.rooseveltConfig.htmlValidator.extraParam = true
+    pkgJson.rooseveltConfig.htmlValidator.separateProcess.extraParam = true
+    pkgJson.rooseveltConfig.htmlValidator.exceptions.extraParam = true
+    pkgJson.rooseveltConfig.logging.extraParam = true
+    pkgJson.rooseveltConfig.js.extraParam = true
+    pkgJson.rooseveltConfig.js.webpack.extraParam = true
+    pkgJson.rooseveltConfig.toobusy.extraParam = true
 
-    // write the package.json file
+    // botch some scripts
+    delete pkgJson.scripts['config-audit']
+    pkgJson.scripts['kill-validator'] = 'node /roosevelt/lol/wrong/place.js'
+
+    // write package.json to app directory
     fs.ensureDirSync(path.join(appDir))
-    packageJSONSource.rooseveltConfig.extraParam = true
-    packageJSONSource.rooseveltConfig.bodyParser.extraParam = true
-    packageJSONSource.rooseveltConfig.css.extraParam = true
-    packageJSONSource.rooseveltConfig.errorPages.extraParam = true
-    packageJSONSource.rooseveltConfig.frontendReload.extraParam = true
-    packageJSONSource.rooseveltConfig.htmlMinifier.extraParam = true
-    packageJSONSource.rooseveltConfig.htmlValidator.extraParam = true
-    packageJSONSource.rooseveltConfig.htmlValidator.separateProcess.extraParam = true
-    packageJSONSource.rooseveltConfig.htmlValidator.exceptions.extraParam = true
-    packageJSONSource.rooseveltConfig.logging.extraParam = true
-    packageJSONSource.rooseveltConfig.logging.methods.extraParam = true
-    packageJSONSource.rooseveltConfig.js.extraParam = true
-    packageJSONSource.rooseveltConfig.js.webpack.extraParam = true
-    packageJSONSource.rooseveltConfig.toobusy.extraParam = true
-    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
+    fs.writeJSONSync(path.join(appDir, 'package.json'), pkgJson)
 
-    // generate the test app
-    generateTestApp({
-      appDir: appDir,
-      onServerStart: '(app) => {process.send("something")}'
-    }, options)
+    // spin up the auditor script
+    const { stderr } = await execa.node('../../../lib/scripts/configAuditor.js', { cwd: appDir })
 
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the output stream, check for specific logs
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        startingConfigAuditBool = true
-      }
-    })
-
-    // on the error stream, check for error specific logs
-    testApp.stderr.on('data', (data) => {
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig, this can be removed.')) {
-        rooseveltConfigExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.bodyParser, this can be removed.')) {
-        bodyParserExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.css, this can be removed.')) {
-        cssExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.errorPages, this can be removed.')) {
-        errorPagesExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.frontendReload, this can be removed.')) {
-        frontendReloadExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.htmlMinifier, this can be removed.')) {
-        htmlMinifierExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.logging, this can be removed.')) {
-        loggingExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.logging.methods, this can be removed.')) {
-        methodsExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator, this can be removed.')) {
-        htmlValidatorExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator.separateProcess, this can be removed.')) {
-        separateProcessExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator.exceptions, this can be removed.')) {
-        exceptionsExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.js, this can be removed.')) {
-        jsExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.js.webpack, this can be removed.')) {
-        bundlerExtraBool = true
-      }
-      if (data.includes('Extra param "extraParam" found in rooseveltConfig.toobusy, this can be removed.')) {
-        toobusyExtraBool = true
-      }
-    })
-
-    testApp.on('message', () => {
-      testApp.send('stop')
-    })
-
-    // when the child process exits, check assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the configAuditor')
-      assert.strictEqual(rooseveltConfigExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig`')
-      assert.strictEqual(bodyParserExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig.bodyParser`')
-      assert.strictEqual(cssExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig.css`')
-      assert.strictEqual(errorPagesExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig.errorPages`')
-      assert.strictEqual(frontendReloadExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig.frontendReload`')
-      assert.strictEqual(htmlMinifierExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig.htmlMinifier`')
-      assert.strictEqual(loggingExtraBool, false, 'configAuditor reported that the package.json file has an extra param in `rooseveltConfig.logging` when it should have been ignored')
-      assert.strictEqual(methodsExtraBool, false, 'configAuditor reported that the package.json file has an extra param in `rooseveltConfig.logging.methods` when it should have been ignored')
-      assert.strictEqual(htmlValidatorExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig.htmlValidator`')
-      assert.strictEqual(separateProcessExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig.htmlValidator.separateProcess`')
-      assert.strictEqual(exceptionsExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig.htmlValidator.exceptions`')
-      assert.strictEqual(jsExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig.js`')
-      assert.strictEqual(bundlerExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig.js.bundler`')
-      assert.strictEqual(toobusyExtraBool, true, 'configAuditor did not report that the package.json file has an extra param in `rooseveltConfig.toobusy`')
-      done()
-    })
+    // check stderr to ensure it found all the problems
+    assert(stderr.includes('The type of param "port" should be one of the supported types'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.bodyParser,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.css,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.errorPages,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.frontendReload,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlMinifier,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.logging,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator.separateProcess,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator.exceptions,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js.webpack,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.toobusy,'))
+    assert(stderr.includes('Detected outdated script "kill-validator"'))
+    assert(stderr.includes('Missing script "config-audit"'))
   })
 
-  it('should not execute the configAuditor if the app already has a public folder in the app Directory', function (done) {
-    // bool var to hold whether or not a specific log was given
-    let startingConfigAuditBool = false
+  it('should detect and complain about a wide variety of problems in rooseveltConfig.json', async () => {
+    // add a whole lot of invalid stuff to a default config
+    configFile.port = []
+    configFile.extraParam = true
+    configFile.bodyParser.extraParam = true
+    configFile.css.extraParam = true
+    configFile.errorPages.extraParam = true
+    configFile.frontendReload.extraParam = true
+    configFile.htmlMinifier.extraParam = true
+    configFile.htmlValidator.extraParam = true
+    configFile.htmlValidator.separateProcess.extraParam = true
+    configFile.htmlValidator.exceptions.extraParam = true
+    configFile.logging.extraParam = true
+    configFile.js.extraParam = true
+    configFile.js.webpack.extraParam = true
+    configFile.toobusy.extraParam = true
 
-    // write the package.json file
-    fs.ensureDirSync(appDir)
-    delete packageJSONSource.rooseveltConfig.modelsPath
-    delete packageJSONSource.rooseveltConfig.viewsPath
-    delete packageJSONSource.rooseveltConfig.controllersPath
-    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
+    // write rooseveltConfig.json to app directory
+    fs.ensureDirSync(path.join(appDir))
+    fs.writeJSONSync(path.join(appDir, 'rooseveltConfig.json'), configFile)
 
-    // create a public folder inside the app Directory
-    fs.ensureDir(path.join(appDir, 'public'))
+    // spin up the auditor script
+    const { stderr } = await execa.node('../../../lib/scripts/configAuditor.js', { cwd: appDir })
 
-    // generate the test app
-    generateTestApp({
-      appDir: appDir,
-      onServerStart: '(app) => {process.send("something")}'
-    }, options)
-
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the output stream, check for specific logs
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        startingConfigAuditBool = true
-      }
-    })
-
-    // when the app finishes initialization, kill it
-    testApp.on('message', () => {
-      testApp.send('stop')
-    })
-
-    // when the child process exits, check for assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(startingConfigAuditBool, false, 'Roosevelt should not have started the config auditor when app already has a public folder in the app directory')
-      done()
-    })
+    // check stderr to ensure it found all the problems
+    assert(stderr.includes('The type of param "port" should be one of the supported types'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.bodyParser,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.css,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.errorPages,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.frontendReload,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlMinifier,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.logging,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator.separateProcess,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator.exceptions,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js.webpack,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.toobusy,'))
   })
 
-  it('should not start the audit if there is not a package.json file located in the test app Directory', function (done) {
-    // bool var to hold whether or not the audit looked at the files
-    let rooseveltAuditStartedBool = false
-
-    // generate the test app
-    generateTestApp({
-      appDir: appDir,
-      onServerStart: '(app) => {process.send("something")}'
-    }, options)
-
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the output stream, check for specific logs to see if it would log out that the config audtior is starting
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        rooseveltAuditStartedBool = true
-      }
-    })
-
-    // when the app finishes initialization, kill it
-    testApp.on('message', () => {
-      testApp.send('stop')
-    })
-
-    // when the child process exits, check for assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(rooseveltAuditStartedBool, false, 'the config Auditor was still started even though there is no package.json file in the app Directory')
-      done()
-    })
-  })
-
-  it('should not start the audit if there is a package.json file located in the test app Directory but no rooseveltConfig property in it', function (done) {
-    // bool var to hold whether or not the audit looked at the files
-    let rooseveltAuditStartedBool = false
-
-    // package.json source string
-    packageJSONSource = {
-      appDir: appDir,
-      generateFolderStructure: true
-    }
-
-    // generate the package.json file
-    fs.ensureDirSync(appDir)
-    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
-
-    // generate the test app
-    generateTestApp({
-      appDir: appDir,
-      onServerStart: '(app) => {process.send("something")}'
-    }, options)
-
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the output stream, check for specific logs to see if it would log out that the config audtior is starting
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        rooseveltAuditStartedBool = true
-      }
-    })
-
-    // when the app finishes initialization, kill it
-    testApp.on('message', () => {
-      testApp.send('stop')
-    })
-
-    testApp.on('exit', () => {
-      assert.strictEqual(rooseveltAuditStartedBool, false, 'the config Auditor was still started even though there is no package.json file in the app Directory')
-      done()
-    })
-  })
-
-  it('should report that there are some extra params in the package.json file', function (done) {
-    // bool var to hold whether the right logs were given
-    let startingConfigAuditBool = false
-    let error1Bool = false
-    let error2Bool = false
-    let extraWarningsJSBool = false
-
-    // write the package.json file
-    fs.ensureDirSync(appDir)
-    packageJSONSource.rooseveltConfig.js.warnings = true
-    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
-
-    // generate the test app
-    generateTestApp({
-      appDir: appDir,
-      onServerStart: '(app) => {process.send("something")}'
-    }, options)
-
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the error strean, check the console output for missing parameters
-    testApp.stderr.on('data', (data) => {
-      if (data.includes('Extra param "warnings" found in rooseveltConfig.js, this can be removed.')) {
-        extraWarningsJSBool = true
-      }
-      if (data.includes('Issues have been detected in rooseveltConfig')) {
-        error1Bool = true
-      }
-      if (data.includes('for the latest sample rooseveltConfig.')) {
-        error2Bool = true
-      }
-    })
-
-    // on the output stream check to see if the config auditor has started
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        startingConfigAuditBool = true
-      }
-    })
-
-    testApp.on('message', () => {
-      testApp.send('stop')
-    })
-
-    // when the child process exits, check assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the configAuditor')
-      assert.strictEqual(extraWarningsJSBool, true, 'The config Auditor did not report that an extra param of warnings is in the JS param')
-      assert.strictEqual(error1Bool, true, 'configAuditor did not report that we had issues with the roosevelt config')
-      assert.strictEqual(error2Bool, true, 'configAuditor did not report where a user can go to for examples of correct syntax and values')
-      done()
-    })
-  })
-
-  it('should report that there are extra params in the rooseveltConfig object', function (done) {
-    // bool var to hold whether or not the correct logs are being outputted
-    let extraTurboParamBool = false
-    let extraMaxServersBool = false
-    let error1Bool = false
-    let error2Bool = false
-    let startingConfigAuditBool = false
-
-    // generate the package.json file
-    fs.ensureDirSync(appDir)
-    packageJSONSource.rooseveltConfig.turbo = true
-    packageJSONSource.rooseveltConfig.maxServers = 4
-    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
-
-    // generate the test app
-    generateTestApp({
-      appDir: appDir,
-      onServerStart: '(app) => {process.send("something")}'
-    }, options)
-
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the output stream, check
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        startingConfigAuditBool = true
-      }
-    })
-
-    // on the error stream, check config auditor output
-    testApp.stderr.on('data', (data) => {
-      if (data.includes('Extra param "turbo" found in rooseveltConfig, this can be removed.')) {
-        extraTurboParamBool = true
-      }
-      if (data.includes('Extra param "maxServers" found in rooseveltConfig, this can be removed.')) {
-        extraMaxServersBool = true
-      }
-      if (data.includes('Issues have been detected in rooseveltConfig')) {
-        error1Bool = true
-      }
-      if (data.includes('for the latest sample rooseveltConfig.')) {
-        error2Bool = true
-      }
-    })
-
-    testApp.on('message', () => {
-      testApp.send('stop')
-    })
-
-    // when the child process exits, check assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the config Auditor')
-      assert.strictEqual(extraTurboParamBool, true, 'config Auditor did not spot the extra turbo param in the rooseveltConfig')
-      assert.strictEqual(extraMaxServersBool, true, 'config Auditor did not sport the extra maxServers param in the rooseveltConfig')
-      assert.strictEqual(error1Bool, true, 'configAuditor did not report that we had issues with the roosevelt config')
-      assert.strictEqual(error2Bool, true, 'configAuditor did not report where a user can go to for examples of correct syntax and values')
-      done()
-    })
-  })
-
-  it('should report that package.json contains a roosevelt script that has been incorrectly placed', function (done) {
-    // bool var to hold whether or not a specific log was outputted
-    let cleanNotUpToDateBool = false
-    let startingConfigAuditBool = false
-    let error1Bool = false
-    let error2Bool = false
-
-    // generate the package.json file
-    fs.ensureDirSync(appDir)
-    packageJSONSource.scripts['config-audit'] = 'node ./node_modules/roosevelt/is_not_correct.js'
-    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
-
-    // generate the test app
-    generateTestApp({
-      appDir: appDir,
-      onServerStart: '(app) => {process.send("something")}'
-    }, options)
-
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, 'app.js'), { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the output stream, check to see if the config auditor is running
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        startingConfigAuditBool = true
-      }
-    })
-
-    // on the error stream check to see
-    testApp.stderr.on('data', (data) => {
-      if (data.includes('Detected outdated script "config-audit". Update contents to "node ./node_modules/roosevelt/lib/scripts/configAuditor.js" to restore functionality.')) {
-        cleanNotUpToDateBool = true
-      }
-      if (data.includes('Issues have been detected in rooseveltConfig')) {
-        error1Bool = true
-      }
-      if (data.includes('for the latest sample rooseveltConfig.')) {
-        error2Bool = true
-      }
-    })
-
-    testApp.on('message', () => {
-      testApp.send('stop')
-    })
-
-    // when the child process exits, check for assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(error1Bool, true, 'configAuditor did not report that we had issues with the roosevelt config')
-      assert.strictEqual(error2Bool, true, 'configAuditor did not report where a user can go to for examples of correct syntax and values')
-      assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the config Auditor')
-      assert.strictEqual(cleanNotUpToDateBool, true, 'configAuditor did not report that one of its scripts is not up to date with what it should be')
-      done()
-    })
-  })
-
-  it('should not run the config Auditor if it has a cwd without a node_modules folder', function (done) {
-    // bool var to hold whether or not a specific log was outputted
-    let startingConfigAuditBool = false
-
-    // create a node_modules directory in the test app
-    fs.ensureDirSync(appDir)
-    fs.mkdirSync(path.join(appDir, 'node_modules'))
-
-    // set env.INIT_CWD to a location that does not have a node_modules folder
-    process.env.INIT_CWD = path.join(appDir, './util')
-
-    // fork the configAuditor.js file and run it as a child process
-    const testApp = fork(path.join(appDir, '../../../lib/scripts/configAuditor.js'), [], { cwd: appDir, stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // check the output stream to see if the config auditor is running
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        startingConfigAuditBool = true
-      }
-    })
-
-    // when the child process exits, check assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(startingConfigAuditBool, false, 'Roosevelt started its config Auditor even when it was not suppose to')
-      done()
-    })
-  })
-
-  it('should be able to run the auditor if a node modules folder is located in the cwd', function (done) {
-    // bool var to hold whether or not the right logs were outputted
-    let startingConfigAuditBool = false
-    let noErrorsBool = false
-
-    // generate the package.json file
-    fs.ensureDirSync(appDir)
-    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
-
-    // set env.INIT_CWD to the correct location
-    process.env.INIT_CWD = appDir
-
-    // create a node_modules folder
-    fs.ensureDirSync(path.join(appDir, 'node_modules'))
-
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, '../../../lib/scripts/configAuditor.js'), [], { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the output stream
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        startingConfigAuditBool = true
-      }
-      if (data.includes('rooseveltConfig audit completed with no errors found.')) {
-        noErrorsBool = true
-      }
-    })
-
-    // when the child process exits, check assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the config Auditor')
-      assert.strictEqual(noErrorsBool, true, 'config Auditor is reporting back that there is an error even though the package.json file does not have one')
-      done()
-    })
-  })
-
-  it('should use the env var cwd if it matches the processes cwd', function (done) {
-    // bool var to hold whether or not the right logs were outputted
-    let startingConfigAuditBool = false
-    let noErrorsBool = false
-
-    // set env.INIT_CWD to the correct location
-    process.env.INIT_CWD = appDir
-
-    // generate the package.json file
-    fs.ensureDirSync(appDir)
-    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
-
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, '../../../lib/scripts/configAuditor.js'), [], { cwd: appDir, stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the output stream
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        startingConfigAuditBool = true
-      }
-      if (data.includes('rooseveltConfig audit completed with no errors found.')) {
-        noErrorsBool = true
-      }
-    })
-
-    // when the child process exits, check assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the config Auditor')
-      assert.strictEqual(noErrorsBool, true, 'config Auditor is reporting back that there is an error even though the package.json file does not have one')
-      done()
-    })
-  })
-
-  it('should display an error when setting a config param to an unsupported type', function (done) {
-    // bool var to see if the right logs are being logged
-    let startingConfigAuditBool = false
-    let typeErrorBool = false
-
-    // set the port to null and generate the package.json file
-    fs.ensureDirSync(appDir)
-    packageJSONSource.rooseveltConfig.port = null
-    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
-
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, '../../../lib/scripts/configAuditor.js'), [], { cwd: appDir, stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the output stream
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        startingConfigAuditBool = true
-      }
-    })
-
-    // on the error stream
-    testApp.stderr.on('data', (data) => {
-      if (data.includes('The type of param \'port\' should be one of the supported types: number, string')) {
-        typeErrorBool = true
-      }
-    })
-
-    // when the child process exits, check assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the config Auditor')
-      assert.strictEqual(typeErrorBool, true, 'config Auditor is not reporting back that the param is an unsupported type')
-      done()
-    })
-  })
-
-  it('should display an error when a script is missing', function (done) {
-    // bool var to see if the right logs are being logged
-    let startingConfigAuditBool = false
-    let missingScriptBool = false
-
-    // set the css object to a number and generate the package.json file
-    fs.ensureDirSync(appDir)
-    delete packageJSONSource.scripts['config-audit']
-    fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify(packageJSONSource))
-
-    // fork and run app.js as a child process
-    const testApp = fork(path.join(appDir, '../../../lib/scripts/configAuditor.js'), [], { cwd: appDir, stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
-
-    // on the output stream
-    testApp.stdout.on('data', (data) => {
-      if (data.includes('Starting rooseveltConfig audit...')) {
-        startingConfigAuditBool = true
-      }
-    })
-
-    // on the error stream
-    testApp.stderr.on('data', (data) => {
-      if (data.includes('Missing script "config-audit"!')) {
-        missingScriptBool = true
-      }
-    })
-
-    // when the child process exits, check assertions and finish the test
-    testApp.on('exit', () => {
-      assert.strictEqual(startingConfigAuditBool, true, 'Roosevelt did not start the config Auditor')
-      assert.strictEqual(missingScriptBool, true, 'config Auditor is not reporting back that the script is missing')
-      done()
-    })
+  it('should scan and detect problems in both package.json and rooseveltConfig.json', async () => {
+    // add invalid entries to package and config file
+    pkgJson.rooseveltConfig.extraParam = true
+    configFile.extraParam = true
+
+    // write rooseveltConfig.json to app directory
+    fs.ensureDirSync(path.join(appDir))
+    fs.writeJSONSync(path.join(appDir, 'package.json'), pkgJson)
+    fs.writeJSONSync(path.join(appDir, 'rooseveltConfig.json'), configFile)
+
+    // spin up the auditor script
+    const { stderr } = await execa.node('../../../lib/scripts/configAuditor.js', { cwd: appDir })
+
+    // check stderr to ensure it found all the problems
+    assert(stderr.includes('Issues have been detected in rooseveltConfig.json'))
+    assert(stderr.includes('Issues have been detected in package.json'))
   })
 })

--- a/test/multipart.js
+++ b/test/multipart.js
@@ -50,7 +50,7 @@ describe('multipart/formidable', () => {
         enable: false
       },
       // set some stingy limitations to easily test the config takes effect
-      multipart: {
+      formidable: {
         uploadDir: tmpDir,
         multiples: false,
         maxFieldsSize: 2

--- a/test/sourceParams.js
+++ b/test/sourceParams.js
@@ -114,6 +114,47 @@ describe('sourceParams', () => {
       }
     })
 
+    it('should set params from rooseveltConfig.json', () => {
+      // set app directory
+      const appDir = path.join(__dirname, 'app/sourceParams')
+
+      // build roosevelt config from sample
+      const configJson = {
+        ...sampleConfig,
+        enableCLIFlags: false
+      }
+
+      // create app directory
+      fs.ensureDirSync(path.join(appDir))
+
+      // generate rooseveltConfig.json with sample config
+      fs.writeJSONSync(path.join(appDir, 'rooseveltConfig.json'), configJson)
+
+      // initialize roosevelt
+      const app = require('../roosevelt')({
+        appDir: appDir
+      })
+
+      const appConfig = app.expressApp.get('params')
+
+      // do some param post-processing that matches what we expect from roosevelt
+      configJson.staticsRoot = path.join(appDir, configJson.staticsRoot)
+      configJson.publicFolder = (path.join(appDir, configJson.publicFolder))
+      configJson.css.sourcePath = path.join(configJson.staticsRoot, configJson.css.sourcePath)
+      configJson.css.output = path.join(configJson.publicFolder, configJson.css.output)
+      configJson.js.sourcePath = path.join(configJson.staticsRoot, configJson.js.sourcePath)
+      configJson.clientViews.output = path.join(configJson.staticsRoot, configJson.clientViews.output)
+
+      // for each param, test that its value is set in roosevelt
+      for (const key in appConfig) {
+        const param = appConfig[key]
+
+        if (!blacklist.includes(key)) {
+          assert.deepStrictEqual(param, configJson[key], `${key} was not correctly set`)
+        }
+      }
+    })
+
     it('should resolve variables in params', () => {
       // build roosevelt config with lots of variables
       const config = {

--- a/test/sourceParams.js
+++ b/test/sourceParams.js
@@ -130,7 +130,7 @@ describe('sourceParams', () => {
         https: {
           port: '${(port + 1)}' // eslint-disable-line
         },
-        multipart: {
+        formidable: {
           multiples: '${versionedPublic}' // eslint-disable-line
         },
         css: {
@@ -166,7 +166,7 @@ describe('sourceParams', () => {
       assert.deepStrictEqual(appConfig.css.whitelist[0], path.join(appConfig.staticsRoot, 'coolCss/hello.js'), 'partial param variable not parsed correctly')
       assert.deepStrictEqual(appConfig.staticsSymlinksToPublic[0], path.join(appConfig.staticsRoot, 'coolJavaScript'), 'param variable within array not parsed correctly')
       assert.deepStrictEqual(appConfig.js.webpack.bundles[0].output, path.join(appConfig.staticsRoot, 'coolCss/hello.js'), 'deeply nested param variable not parsed correctly')
-      assert.deepStrictEqual(appConfig.multipart.multiples, true, 'true param variable not parsed correctly')
+      assert.deepStrictEqual(appConfig.formidable.multiples, true, 'true param variable not parsed correctly')
       assert.deepStrictEqual(appConfig.alwaysHostPublic, false, 'false param variable not parsed correctly')
     })
   })

--- a/test/util/sampleConfig.json
+++ b/test/util/sampleConfig.json
@@ -41,7 +41,7 @@
       "modelValue": "value"
     }
   },
-  "multipart": {
+  "formidable": {
     "multiples": "value"
   },
   "toobusy": {


### PR DESCRIPTION
- Added ability to configure Roosevelt via a rooseveltConfig.json config file placed in app root.
- Rename `multipart` param to `formidable`.
- Update internal usage of formidable api.
- Rewrote the config auditor tests

Closes #688