### PR TITLE
Fix CSS bug where new CSS files were not being written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Refactored internal `fsr` module.
 - Updated internal usage of formidable API.
 - Various dependencies bumped.
+- Fixed bug where changes CSS files were not be written to the output directory.
 
 ## 0.16.2
 

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -283,7 +283,7 @@ module.exports = (app, callback) => {
               }
 
               // check existing file for matching content before writing
-              if (!content && content !== newCSS) {
+              if (!content || content !== newCSS) {
                 fsr.writeFileSync(outpath, newCSS, ['📝', `${appName} writing new CSS file ${outpath}`.green])
               }
               resolve()


### PR DESCRIPTION
Changes to CSS files were not be written. The application would write the files for the first time if the CSS output directory didn't exist but then didn't update the files after that.

I tracked it down to a bad statement logic. Please give it a look and see if I interpenetrated the problem/solution correctly.

Probably need a unit test adjustment to catch this as well.