### PR TITLE
Properly fix CSS bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next version
 
-- Put your changes here...
+- Fixed a CSS bug where CSS files were still not being written due to a file existence check.
+- Fixed a CSS bug where empty CSS files were being written because their LESS equivalent would never generate CSS in that particular file.
 
 ## 0.17.0
 

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -223,7 +223,7 @@ module.exports = (app, callback) => {
       }
 
       // compare existing content to new content before generating
-      if (!versionData && versionData !== versionCode) {
+      if (!versionData || versionData !== versionCode) {
         fsr.writeFileSync(versionFile, versionCode, ['📝', `${appName} writing new versioned CSS file to reflect new version ${app.get('appVersion')} to ${versionFile}`.green])
       }
     }
@@ -282,8 +282,9 @@ module.exports = (app, callback) => {
                 content = fs.readFileSync(outpath, 'utf8')
               }
 
-              // check existing file for matching content before writing
-              if (!content || content !== newCSS) {
+              // check that the newCSS has content before writing the file. It is possible that the less file has no valid CSS and results in an empty CSS file. In this case don't write it.
+              // also, check existing file for matching content before writing
+              if (newCSS !== '' && (!content || content !== newCSS)) {
                 fsr.writeFileSync(outpath, newCSS, ['📝', `${appName} writing new CSS file ${outpath}`.green])
               }
               resolve()

--- a/lib/tools/fsr.js
+++ b/lib/tools/fsr.js
@@ -40,13 +40,13 @@ class FSR {
   }
 
   /**
-   * Write new file if app is configured to write files and if file doesn't exist
+   * Write new file if app is configured to write files
    * @param {string} path - Path of file to create
    * @param {string} contents - Contents of file
    * @param {array} log - Log to output if file is created, , if omitted a generic one will be printed
    */
   writeFileSync (path, contents, log) {
-    if (this.generate && !this.fileExists(path)) {
+    if (this.generate) {
       fs.outputFileSync(path, contents)
       if (log) {
         this.logger.info(...log)


### PR DESCRIPTION
I don't know what happened here, I'm really perplexed how I saw this working in my original fix #885. Maybe I didn't (probably didn't)? The code says it shouldn't have, hence this fix.

Anyways, I had @w00tedness double check on his machine this time, but I'd like you guys to try it as well.

* Add optional parameter to the file helper writeFileSync to optional overwrite the existing file.
* Changed the writeFileSync param to take a single object since there are now two optional params.
* Applied logic from !855 to the versionedFile as well.