### PR TITLE
0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next version
 
+- Put your changes here...
+
+## 0.18.0
+
 - Replaced the vnu-jar based HTML validator with express-html-validator 🎉.
   - Roosevelt no longer does any background process management as a result.
 - Moved all developer facing dependencies to optionalDependencies.

--- a/README.md
+++ b/README.md
@@ -1092,6 +1092,7 @@ Note: When a custom preprocessor is defined in this way it will override the sel
 
 # Documentation for previous versions of Roosevelt
 
+- *[0.17.x](https://github.com/rooseveltframework/roosevelt/blob/18eae61db07704e5cbf02cbb4e0a998f7e34fa2c/README.md)*
 - *[0.16.x](https://github.com/rooseveltframework/roosevelt/blob/b33046c0281084a2dc0cde26dc38c2a538484c57/README.md)*
 - *[0.15.x](https://github.com/rooseveltframework/roosevelt/blob/1b5680c67ed79a2285b536d735c526413613eb9b/README.md)*
 - *[0.14.x](https://github.com/rooseveltframework/roosevelt/blob/16e5e59083cecf2e2395e6d77d0cc5db0d0f7342/README.md)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "roosevelt",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5306,12 +5306,13 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.2.4.tgz",
-      "integrity": "sha512-doTMGKXQAT34c3S3gwDrTnXmCZp/z1/92D8suPqqh755sKPT18ew1NoPNHxJdrvv1D4WrJ7CEnx79Ns3EdEFbg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.2.6.tgz",
+      "integrity": "sha512-2oEBWyPZHkdyjKcIv2U6ay80Q52ZMlZZrUnfsV0WTVcgzPlt3o2t5UFy2v8ETUTsIDZ0xSJVnffWCgD3LF6xTQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
+        "cli-truncate": "2.1.0",
         "commander": "^5.1.0",
         "cosmiconfig": "^6.0.0",
         "debug": "^4.1.1",
@@ -6767,14 +6768,13 @@
       }
     },
     "object.entries": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
-      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
+      "integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
+        "es-abstract": "^1.17.5",
         "has": "^1.0.3"
       }
     },
@@ -8457,9 +8457,9 @@
       }
     },
     "standard-engine": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.0.1.tgz",
-      "integrity": "sha512-XtR9NfoTqvHkWQCwL1aLMwXw1Qxy5s4rdSIqetgBNw+8faNbQ+BbB49hPhKXjxxfC4yg+fpH0lx/T5fuUbpDcQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.1.0.tgz",
+      "integrity": "sha512-DVJnWM1CGkag4ucFLGdiYWa5/kJURPONmMmk17p8FT5NE4UnPZB1vxWnXnRo2sPSL78pWJG8xEM+1Tu19z0deg==",
       "dev": true,
       "requires": {
         "deglob": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.17.1",
+  "version": "0.18.0",
   "files": [
     "defaultErrorPages",
     "lib",
@@ -52,7 +52,7 @@
     "eslint-plugin-mocha": "~7.0.0",
     "husky": "~4.2.5",
     "less": "~3.11.1",
-    "lint-staged": "~10.2.4",
+    "lint-staged": "~10.2.6",
     "mocha": "~7.1.2",
     "node-sass": "~4.14.1",
     "proxyquire": "~2.1.3",


### PR DESCRIPTION
- Replaced the vnu-jar based HTML validator with express-html-validator 🎉.
  - Roosevelt no longer does any background process management as a result.
- Moved all developer facing dependencies to optionalDependencies.
  - They can be omitted from installion when using `npm i --no-optional`.
- Refactored frontend reload implementation.
- check-dependencies now only runs in dev mode.
- API changes:
  - Removed `separateProcess` from `htmlValidator`.
  - Removed `port` from `htmlValidator`.
  - Removed `showWarnings` from `htmlValidator`.
  - Added `validatorConfig` to `htmlValidator` which respresents a set of rules for the validator to check for.
    - Rules can also be set in a `.htmlValidate.json` placed in the app root.
  - Removed `verbose` from `frontendReload`.
    - These logs are now controlled by the general verbose logging param.
  - Removed `ROOSEVELT_VALIDATOR` environment variable.
  - Removed `ROOSEVELT_AUTOKILLER` environment variable.
  - Removed `--attach-validator` and `-a` cli flags.
  - Removed `--background-validator` and `-b` cli flags.
  - Removed `--disable-validator-autokiller`, `--no-autokiller`, and `-n` cli flags.
  - Removed `--enable-validator-autokiller`, `--html-validator-autokiller`, and `-k` cli flags.
- Removed dependencies:
  - execa
  - fkill
  - html-validator
  - prismjs
  - ps-node
  - tamper
  - vnu-jar
- Various dependencies bumped.