### PR TITLE
0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Next version
 
+- Put your changes here...
+
+## 0.18.1
+
 - Changed `passphrase` option from `https.p12.passphrase` to `https.passphrase` so it can be used for certAndKey configurations as well.
+- CI improvements.
+- Various dependencies bumped.
 
 ## 0.18.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "roosevelt",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.18.0",
+  "version": "0.18.1",
   "files": [
     "defaultErrorPages",
     "lib",


### PR DESCRIPTION
- Changed `passphrase` option from `https.p12.passphrase` to `https.passphrase` so it can be used for certAndKey configurations as well.
- CI improvements.
- Various dependencies bumped.