### PR TITLE
0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - `alwaysHostPublic` was renamed to `hostPublic`.
   - The `--host-public` command line flag was removed, since it is no logner needed because `hostPublic` defaults to true now.
   - New command line flag added called `production-proxy` to let you opt-in to `localhostOnly` and `alwaysHostPublic` being set to true and false respectively as before.
+- Various dependencies bumped.
 
 ## 0.18.3
 

--- a/README.md
+++ b/README.md
@@ -141,10 +141,11 @@ Roosevelt apps created with the app generator come with the following notable [n
     - `npm run dev`
     - `npm run d`
   - Script is short for: `nodemon app.js --development-mode`
-- `npm run proddev`: Runs the app in production mode, but with the public folder hosted by the Roosevelt app. This is useful for doing development in production mode without having to stage a complex simulation of your production environment, which would likely include hosting static files via another web server better-suited to serving statics like Apache or nginx.
+- `npm run production-proxy`: Runs the app in production mode, but with `localhostOnly` set to true and `hostPublic` set to false. This mode will make it so your app only listens to requests coming from localhost and does not serve anything in the public folder. This mode is useful when you want to host your app behind a reverse proxy from Apache or nginx and [is considered a best practice for Node.js deployments](https://expressjs.com/en/advanced/best-practice-performance.html#use-a-reverse-proxy).
   - Default shorthands:
-    - `npm run pd`
-  - Script is short for: `nodemon app.js --host-public`
+    - `npm run prodproxy`
+    - `npm run x`
+  - Script is short for: `nodemon app.js --production-proxy`
 - `npm run config-audit`: Scans current `rooseveltConfig` and `scripts` in `package.json` and warns about any parameters or npm scripts that don't match the current Roosevelt API:
   - Default shorthand:
     - `npm run a`
@@ -174,7 +175,7 @@ Roosevelt apps created with the app generator come with the following notable [n
   - Default shorthands:
     - `--raw`
     - `-r`
-- `node app.js --host-public`: Forces Roosevelt to always host the [public folder](https://github.com/rooseveltframework/roosevelt#public-folder-parameters) even when `alwaysHostPublic` is set to false. Useful for testing production mode.
+- `node app.js --host-public`: Forces Roosevelt to always host the [public folder](https://github.com/rooseveltframework/roosevelt#public-folder-parameters) even when `hostPublic` is set to false. Useful for testing `production-proxy` mode.
   - Default shorthands:
     - `--statics`
     - `-s`
@@ -805,7 +806,7 @@ Resolves to:
 
   ## Public folder parameters
 
-- `publicFolder`: All files and folders in this directory will be exposed as static files in development mode or when `alwaysHostPublic` is enabled.
+- `publicFolder`: All files and folders in this directory will be exposed as static files in development mode or when `hostPublic` is enabled.
 
   - Default: *[String]* `"public"`.
 
@@ -839,7 +840,7 @@ Resolves to:
 
   - Default: *[Boolean]* `false`.
 
-- `alwaysHostPublic`:  By default in production mode Roosevelt will not expose the public folder. It's recommended instead that you host the public folder yourself directly through another web server, such as Apache or nginx. However, if you wish to override this behavior and have Roosevelt host your public folder even in production mode, then set this setting to true.
+- `hostPublic`: Whether or not to allow Roosevelt to host the public folder. By default in `production-proxy` mode Roosevelt will not expose the public folder. It's recommended instead that you host the public folder yourself directly through another web server, such as Apache or nginx.
 
   - Default: *[Boolean]* `false`.
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Roosevelt apps created with the app generator come with the following notable [n
     - `npm run dev`
     - `npm run d`
   - Script is short for: `nodemon app.js --development-mode`
-- `npm run production-proxy`: Runs the app in production mode, but with `localhostOnly` set to true and `hostPublic` set to false. This mode will make it so your app only listens to requests coming from localhost and does not serve anything in the public folder. This mode is useful when you want to host your app behind a reverse proxy from Apache or nginx and [is considered a best practice for Node.js deployments](https://expressjs.com/en/advanced/best-practice-performance.html#use-a-reverse-proxy).
+- `npm run production-proxy`: Runs the app in production mode, but with `localhostOnly` set to true and `hostPublic` set to false. This mode will make it so your app only listens to requests coming from localhost and does not serve anything in the public folder. This mode is useful when you want to host your app behind a reverse proxy from a web server like Apache or nginx and [is considered a best practice for Node.js deployments](https://expressjs.com/en/advanced/best-practice-performance.html#use-a-reverse-proxy).
   - Default shorthands:
     - `npm run prodproxy`
     - `npm run x`

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -3,7 +3,7 @@
   "mode": "production",
   "enableCLIFlags": true,
   "generateFolderStructure": false,
-  "localhostOnly": true,
+  "localhostOnly": false,
   "logging": {
     "methods": {
       "http": true,
@@ -101,7 +101,7 @@
   "favicon": "none",
   "symlinks": [],
   "versionedPublic": false,
-  "alwaysHostPublic": false,
+  "hostPublic": true,
   "clientViews": {
     "allowlist": {},
     "blocklist": {},

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -111,7 +111,7 @@ module.exports = app => {
   fsr.ensureDirSync(app.get('controllersPath'))
 
   // map statics for developer mode
-  if (params.alwaysHostPublic || app.get('env') === 'development') {
+  if (params.hostPublic || app.get('env') === 'development') {
     app.use(prefix || '/', express.static(app.get('publicFolder')))
   }
 

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -100,7 +100,7 @@ function configAudit (appDir) {
 
       keyStack.push(key)
       switch (key) {
-        case 'alwaysHostPublic':
+        case 'hostPublic':
           checkTypes(userParam, key, ['boolean'])
           break
         case 'checkDependencies':

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -43,8 +43,10 @@ module.exports = (params, app) => {
     logging: false,
     // handle configuration edge cases
     transform: (params, flags) => {
-      // handle --production-mode, --prod, -p cli flags
-      if (flags.productionMode || flags.prod || flags.p) {
+      // handle --production-mode, --prod, -p cli flags etc
+      if (flags.productionProxyMode || flags.prodproxy || flags.x) {
+        params.mode = 'production-proxy'
+      } else if (flags.productionMode || flags.prod || flags.p) {
         params.mode = 'production'
       } else if (flags.developmentMode || flags.dev || flags.d) {
         // handle --development-mode, --dev, -d cli flags
@@ -286,9 +288,8 @@ module.exports = (params, app) => {
     versionedPublic: {
       default: defaults.versionedPublic
     },
-    alwaysHostPublic: {
-      commandLineArg: ['--host-public', '--statics', '-s'],
-      default: defaults.alwaysHostPublic
+    hostPublic: {
+      default: defaults.hostPublic
     },
     clientViews: {
       allowlist: {
@@ -400,7 +401,7 @@ module.exports = (params, app) => {
   const logger = new Logger(params.logging)
 
   // set mode specific overrides
-  if (params.mode === 'production') {
+  if (params.mode === 'production' || params.mode === 'production-proxy') {
     process.env.NODE_ENV = 'production'
 
     // html validator is always disabled in production mode
@@ -410,6 +411,17 @@ module.exports = (params, app) => {
 
     // minification is always disabled in development mode
     params.minify = false
+  }
+
+  // hostPublic always true in dev mode
+  if (params.mode === 'development') {
+    params.hostPublic = true
+  }
+
+  // force localhostOnly and hostPublic off in production-proxy mode
+  if (params.mode === 'production-proxy') {
+    params.localhostOnly = true
+    params.hostPublic = false
   }
 
   // handle HTTP_PROXY edge case

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -62,7 +62,7 @@ module.exports = (params, app) => {
       }
 
       // default mode param to production if its value is invalid
-      if (params.mode !== 'production' && params.mode !== 'development') {
+      if (params.mode !== 'production-proxy' && params.mode !== 'production' && params.mode !== 'development') {
         params.mode = 'production'
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "roosevelt",
-  "version": "0.18.3",
+  "version": "0.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -845,11 +845,6 @@
         }
       }
     },
-    "bowser": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.9.0.tgz",
-      "integrity": "sha512-2ld76tuLBNFekRgmJfT2+3j5MIrP6bFict8WAIT3beq+srz1gcKNAdNKMqHqauQt63NmAa88HfP1/Ypa9Er3HA=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1163,11 +1158,6 @@
           "dev": true
         }
       }
-    },
-    "camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caseless": {
       "version": "0.12.0",
@@ -1674,11 +1664,6 @@
         "safe-buffer": "5.1.2"
       }
     },
-    "content-security-policy-builder": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.1.0.tgz",
-      "integrity": "sha512-/MtLWhJVvJNkA9dVLAp6fg9LxD2gfI6R2Fi1hPmfjYXSahJJzcfvoeDOxSyp4NvxMuwWv3WMssE9o31DoULHrQ=="
-    },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -1885,11 +1870,6 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "dasherize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
-      "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
     },
     "debug": {
       "version": "2.6.9",
@@ -2117,11 +2097,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
-    },
-    "dont-sniff-mimetype": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz",
-      "integrity": "sha512-ZjI4zqTaxveH2/tTlzS1wFp+7ncxNZaIEWYg3lzZRHkKf5zPT/MnEG6WL0BhHMJUabkh8GeU5NL5j+rEUCb7Ug=="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -2423,9 +2398,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.5.0.tgz",
-      "integrity": "sha512-vlUP10xse9sWt9SGRtcr1LAC67BENcQMFeV+w5EvLEoFe3xJ8cF1Skd0msziRx/VMC+72B4DxreCE+OR12OA6Q==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.6.0.tgz",
+      "integrity": "sha512-QlAManNtqr7sozWm5TF4wIH9gmUm2hE3vNRUvyoYAa4y1l5/jxD/PQStEjBMQtCqZmSep8UxrcecI60hOpe61w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -3393,11 +3368,6 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
-    "feature-policy": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
-      "integrity": "sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ=="
-    },
     "fecha": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
@@ -4135,50 +4105,9 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "helmet": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.23.3.tgz",
-      "integrity": "sha512-U3MeYdzPJQhtvqAVBPntVgAvNSOJyagwZwyKsFdyRa8TV3pOKVFljalPOCxbw5Wwf2kncGhmP0qHjyazIdNdSA==",
-      "requires": {
-        "depd": "2.0.0",
-        "dont-sniff-mimetype": "1.1.0",
-        "feature-policy": "0.3.0",
-        "helmet-crossdomain": "0.4.0",
-        "helmet-csp": "2.10.0",
-        "hide-powered-by": "1.1.0",
-        "hpkp": "2.0.0",
-        "hsts": "2.2.0",
-        "nocache": "2.1.0",
-        "referrer-policy": "1.2.0",
-        "x-xss-protection": "1.3.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        }
-      }
-    },
-    "helmet-crossdomain": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/helmet-crossdomain/-/helmet-crossdomain-0.4.0.tgz",
-      "integrity": "sha512-AB4DTykRw3HCOxovD1nPR16hllrVImeFp5VBV9/twj66lJ2nU75DP8FPL0/Jp4jj79JhTfG+pFI2MD02kWJ+fA=="
-    },
-    "helmet-csp": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.10.0.tgz",
-      "integrity": "sha512-Rz953ZNEFk8sT2XvewXkYN0Ho4GEZdjAZy4stjiEQV3eN7GDxg1QKmYggH7otDyIA7uGA6XnUMVSgeJwbR5X+w==",
-      "requires": {
-        "bowser": "2.9.0",
-        "camelize": "1.0.0",
-        "content-security-policy-builder": "2.1.0",
-        "dasherize": "2.0.0"
-      }
-    },
-    "hide-powered-by": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.1.0.tgz",
-      "integrity": "sha512-Io1zA2yOA1YJslkr+AJlWSf2yWFkKjvkcL9Ni1XSUqnGLr/qRQe2UI3Cn/J9MsJht7yEVCe0SscY1HgVMujbgg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.0.0.tgz",
+      "integrity": "sha512-HyoRKKHhWhO6+EBfgRLkuZR4/+NXc1nJB7x0bWwW89i9eoPciK0qUqyZNOA/zowpgrW9C4+J5toqMkZrpBOlkg=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -4203,26 +4132,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
-    },
-    "hpkp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hpkp/-/hpkp-2.0.0.tgz",
-      "integrity": "sha1-EOFCJk52IVpdMMROxD3mTe5tFnI="
-    },
-    "hsts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.2.0.tgz",
-      "integrity": "sha512-ToaTnQ2TbJkochoVcdXYm4HOCliNozlviNsg+X2XQLQvZNI/kCHR9rZxVYpJB3UPcHz80PgxRyWQ7PdU1r+VBQ==",
-      "requires": {
-        "depd": "2.0.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        }
-      }
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -4992,6 +4901,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
     "is-plain-object": {
@@ -6123,9 +6038,9 @@
       }
     },
     "mocha": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.0.1.tgz",
-      "integrity": "sha512-vefaXfdYI8+Yo8nPZQQi0QO2o+5q9UIMX1jZ1XMmK3+4+CQjc7+B0hPdUeglXiTlr8IHMVRo63IhO9Mzt6fxOg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.0.tgz",
+      "integrity": "sha512-sI0gaI1I/jPVu3KFpnveWGadfe3JNBAENqgTUPgLZAUppu725zS2mrVztzAgIR8DUscuS4doEBTx9LATC+HSeA==",
       "dev": true,
       "requires": {
         "ansi-colors": "4.1.1",
@@ -6144,7 +6059,7 @@
         "ms": "2.1.2",
         "object.assign": "4.1.0",
         "promise.allsettled": "1.0.2",
-        "serialize-javascript": "3.0.0",
+        "serialize-javascript": "4.0.0",
         "strip-json-comments": "3.0.1",
         "supports-color": "7.1.0",
         "which": "2.0.2",
@@ -6152,7 +6067,7 @@
         "workerpool": "6.0.0",
         "yargs": "13.3.2",
         "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.0"
+        "yargs-unparser": "1.6.1"
       },
       "dependencies": {
         "braces": {
@@ -6311,10 +6226,13 @@
           }
         },
         "serialize-javascript": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.0.0.tgz",
-          "integrity": "sha512-skZcHYw2vEX4bw90nAr2iTTsz6x2SrHEnfxgKYmZlvJYBEZrvbKtobJWlQ20zczKb3bsHHXXTYt48zBA7ni9cw==",
-          "dev": true
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
         },
         "string-width": {
           "version": "3.1.0",
@@ -6583,11 +6501,6 @@
       "requires": {
         "lower-case": "^1.1.1"
       }
-    },
-    "nocache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
-      "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -7673,11 +7586,6 @@
           }
         }
       }
-    },
-    "referrer-policy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/referrer-policy/-/referrer-policy-1.2.0.tgz",
-      "integrity": "sha512-LgQJIuS6nAy1Jd88DCQRemyE3mS+ispwlqMk3b0yjZ257fI1v9c+/p6SD5gP5FGyXUIgrNOAfmyioHwZtYv2VA=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -10070,11 +9978,6 @@
       "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
       "optional": true
     },
-    "x-xss-protection": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.3.0.tgz",
-      "integrity": "sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg=="
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -10171,14 +10074,16 @@
       }
     },
     "yargs-unparser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
+      "integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
       "dev": true,
       "requires": {
+        "camelcase": "^5.3.1",
+        "decamelize": "^1.2.0",
         "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
+        "is-plain-obj": "^1.1.0",
+        "yargs": "^14.2.3"
       },
       "dependencies": {
         "cliui": {
@@ -10227,12 +10132,13 @@
           }
         },
         "yargs": {
-          "version": "13.3.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
           "dev": true,
           "requires": {
             "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
             "find-up": "^3.0.0",
             "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
@@ -10241,13 +10147,13 @@
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.2"
+            "yargs-parser": "^15.0.1"
           }
         },
         "yargs-parser": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.18.3",
+  "version": "0.19.0",
   "files": [
     "defaultErrorPages",
     "lib",
@@ -32,7 +32,7 @@
     "express": "~4.17.1",
     "formidable": "~1.2.2",
     "fs-extra": "~9.0.1",
-    "helmet": "~3.23.3",
+    "helmet": "~4.0.0",
     "html-minifier": "~4.0.0",
     "klaw": "~3.0.0",
     "klaw-sync": "~6.0.0",
@@ -48,12 +48,12 @@
   "devDependencies": {
     "c8": "~7.2.1",
     "codecov": "~3.7.1",
-    "eslint": "~7.5.0",
+    "eslint": "~7.6.0",
     "eslint-plugin-mocha": "~7.0.1",
     "husky": "~4.2.5",
     "less": "~3.12.2",
     "lint-staged": "~10.2.11",
-    "mocha": "~8.0.1",
+    "mocha": "~8.1.0",
     "node-sass": "~4.14.1",
     "proxyquire": "~2.1.3",
     "sinon": "~9.0.2",

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -372,11 +372,6 @@ module.exports = params => {
       }
     }
 
-    // shut down the process if both the htmlValidator and the app are trying to use the same port
-    if (params.port === params.htmlValidator.port) {
-      logger.error(`${appName} and the HTML validator are both trying to use the same port. You'll need to change the port setting on one of them to proceed.`)
-      process.exit(1)
-    }
 
     function serverPush (server, serverPort, serverFormat) {
       servers.push(server.listen(serverPort, (params.localhostOnly ? 'localhost' : null), startupCallback(serverFormat, serverPort)).on('error', (err) => {

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -379,7 +379,7 @@ module.exports = params => {
     }
 
     function serverPush (server, serverPort, serverFormat) {
-      servers.push(server.listen(serverPort, (params.localhostOnly && appEnv !== 'development' ? 'localhost' : null), startupCallback(serverFormat, serverPort)).on('error', (err) => {
+      servers.push(server.listen(serverPort, (params.localhostOnly ? 'localhost' : null), startupCallback(serverFormat, serverPort)).on('error', (err) => {
         if (err.message.includes('EADDRINUSE')) {
           logger.error(`Another process is using port ${serverPort}. Either kill that process or change this app's port number.`)
         }
@@ -393,12 +393,11 @@ module.exports = params => {
       return async function () {
         function finalMessages () {
           logger.info('🎧', `${appName} ${proto.trim()} server listening on port ${port} (${appEnv} mode)`.bold)
-
-          // if running in prod, warn why public static assets don't load
-          if (appEnv === 'production') {
-            if (!params.alwaysHostPublic) {
-              logger.warn('IMPORTANT: Hosting of public folder is disabled by default in production mode. Your CSS, JS, images, and other files served via your public folder will not load unless you serve them via another web server. If you wish to override this behavior and have Roosevelt host your public folder even in production mode, then set "alwaysHostPublic" to true or pass the "--host-public" command line flag. See the Roosevelt documentation for more information: https://github.com/rooseveltframework/roosevelt')
-            }
+          if (params.localhostOnly) {
+            logger.warn(`${appName} will only respond to requests coming from localhost. If you wish to override this behavior and have it respond to requests coming from localhost, then set "localhostOnly" to true. See the Roosevelt documentation for more information: https://github.com/rooseveltframework/roosevelt`)
+          }
+          if (!params.hostPublic) {
+            logger.warn('Hosting of public folder is disabled. Your CSS, JS, images, and other files served via your public folder will not load unless you serve them via another web server. If you wish to override this behavior and have Roosevelt host your public folder even in production mode, then set "hostPublic" to true. See the Roosevelt documentation for more information: https://github.com/rooseveltframework/roosevelt')
           }
         }
 

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -372,7 +372,6 @@ module.exports = params => {
       }
     }
 
-
     function serverPush (server, serverPort, serverFormat) {
       servers.push(server.listen(serverPort, (params.localhostOnly ? 'localhost' : null), startupCallback(serverFormat, serverPort)).on('error', (err) => {
         if (err.message.includes('EADDRINUSE')) {

--- a/test/htmlMinify.js
+++ b/test/htmlMinify.js
@@ -23,6 +23,8 @@ describe('HTML Minification Tests', function () {
     },
     generateFolderStructure: true,
     viewEngine: 'html:teddy',
+    // this line gives us free coverage of an unrelated warning
+    hostPublic: false,
     htmlMinifier: {
       enable: true,
       exceptionRoutes: false,

--- a/test/htmlMinify.js
+++ b/test/htmlMinify.js
@@ -23,8 +23,7 @@ describe('HTML Minification Tests', function () {
     },
     generateFolderStructure: true,
     viewEngine: 'html:teddy',
-    // this line gives us free coverage of an unrelated warning
-    hostPublic: false,
+    hostPublic: false, // this line gives us free coverage of an unrelated warning
     htmlMinifier: {
       enable: true,
       exceptionRoutes: false,

--- a/test/rooseveltTest.js
+++ b/test/rooseveltTest.js
@@ -607,7 +607,7 @@ describe('Roosevelt.js Tests', function () {
     const server = http.createServer(function (req, res) {
       res.statusCode = 200
       res.end()
-    }).listen(43711, 'localhost')
+    }).listen(43711)
 
     // generate the test app
     generateTestApp({

--- a/test/routing.js
+++ b/test/routing.js
@@ -70,7 +70,7 @@ describe('routing', () => {
     // spin up a roosevelt app
     roosevelt({
       ...appConfig,
-      alwaysHostPublic: true,
+      hostPublic: true,
       onServerStart: app => {
         // bind app to test context
         context.app = app
@@ -122,7 +122,7 @@ describe('routing', () => {
     // spin up a roosevelt app
     roosevelt({
       ...appConfig,
-      alwaysHostPublic: true,
+      hostPublic: true,
       routePrefix: 'foo',
       onServerStart: app => {
         // bind app to test context

--- a/test/sourceParams.js
+++ b/test/sourceParams.js
@@ -198,7 +198,7 @@ describe('sourceParams', () => {
           }
         ],
         versionedPublic: true,
-        alwaysHostPublic: '${enableCLIFlags}' // eslint-disable-line
+        hostPublic: '${enableCLIFlags}' // eslint-disable-line
       }
 
       // initialize roosevelt
@@ -213,7 +213,7 @@ describe('sourceParams', () => {
       assert.deepStrictEqual(appConfig.symlinks[0].dest, path.join(appConfig.publicFolder, 'js'), 'param variable within array not parsed correctly')
       assert.deepStrictEqual(appConfig.js.webpack.bundles[0].output, path.join(appConfig.staticsRoot, 'coolCss/hello.js'), 'deeply nested param variable not parsed correctly')
       assert.deepStrictEqual(appConfig.formidable.multiples, true, 'true param variable not parsed correctly')
-      assert.deepStrictEqual(appConfig.alwaysHostPublic, false, 'false param variable not parsed correctly')
+      assert.deepStrictEqual(appConfig.hostPublic, false, 'false param variable not parsed correctly')
     })
   })
 
@@ -318,54 +318,6 @@ describe('sourceParams', () => {
       const appConfig = app.expressApp.get('params')
 
       assert.deepStrictEqual(appConfig.mode, 'development')
-    })
-
-    it('should enable alwaysHostPublic via --host-public', () => {
-      // add the cli flag
-      process.argv.push('--host-public')
-
-      // initialize roosevelt with inverse configs
-      const app = require('../roosevelt')({
-        mode: 'production',
-        alwaysHostPublic: false,
-        ...config
-      })
-
-      const appConfig = app.expressApp.get('params')
-
-      assert.deepStrictEqual(appConfig.alwaysHostPublic, true)
-    })
-
-    it('should enable alwaysHostPublic via --statics', () => {
-      // add the cli flag
-      process.argv.push('--statics')
-
-      // initialize roosevelt with inverse configs
-      const app = require('../roosevelt')({
-        mode: 'production',
-        alwaysHostPublic: false,
-        ...config
-      })
-
-      const appConfig = app.expressApp.get('params')
-
-      assert.deepStrictEqual(appConfig.alwaysHostPublic, true)
-    })
-
-    it('should enable alwaysHostPublic via -s', () => {
-      // add the cli flag
-      process.argv.push('--statics')
-
-      // initialize roosevelt with inverse configs
-      const app = require('../roosevelt')({
-        mode: 'production',
-        alwaysHostPublic: false,
-        ...config
-      })
-
-      const appConfig = app.expressApp.get('params')
-
-      assert.deepStrictEqual(appConfig.alwaysHostPublic, true)
     })
 
     it('should enable html validator via --enable-validator', () => {

--- a/test/sourceParams.js
+++ b/test/sourceParams.js
@@ -230,6 +230,51 @@ describe('sourceParams', () => {
       process.argv = processArgv.slice()
     })
 
+    it('should set production proxy mode via --production-proxy-mode', () => {
+      // add the cli flag
+      process.argv.push('--production-proxy-mode')
+
+      // initialize roosevelt with inverse configs
+      const app = require('../roosevelt')({
+        mode: 'development',
+        ...config
+      })
+
+      const appConfig = app.expressApp.get('params')
+
+      assert.deepStrictEqual(appConfig.mode, 'production-proxy')
+    })
+
+    it('should set production proxy mode via --prodproxy', () => {
+      // add the cli flag
+      process.argv.push('--prodproxy')
+
+      // initialize roosevelt with inverse configs
+      const app = require('../roosevelt')({
+        mode: 'development',
+        ...config
+      })
+
+      const appConfig = app.expressApp.get('params')
+
+      assert.deepStrictEqual(appConfig.mode, 'production-proxy')
+    })
+
+    it('should set production proxy mode via -x', () => {
+      // add the cli flag
+      process.argv.push('-x')
+
+      // initialize roosevelt with inverse configs
+      const app = require('../roosevelt')({
+        mode: 'development',
+        ...config
+      })
+
+      const appConfig = app.expressApp.get('params')
+
+      assert.deepStrictEqual(appConfig.mode, 'production-proxy')
+    })
+
     it('should set production mode via --production-mode', () => {
       // add the cli flag
       process.argv.push('--production-mode')

--- a/test/util/sampleConfig.json
+++ b/test/util/sampleConfig.json
@@ -100,7 +100,7 @@
   "publicFolder": "value",
   "favicon": "value",
   "versionedPublic": "value",
-  "alwaysHostPublic": "value",
+  "hostPublic": "value",
   "checkDependencies": "value",
   "cores": "value",
   "frontendReload": {


### PR DESCRIPTION
- Breaking: Production mode behavior [changed significantly](https://github.com/rooseveltframework/roosevelt/issues/934):
  - `localhostOnly` and `alwaysHostPublic` defaults were flipped to false and true respectively.
  - `alwaysHostPublic` was renamed to `hostPublic`.
  - The `--host-public` command line flag was removed, since it is no logner needed because `hostPublic` defaults to true now.
  - New command line flag added called `production-proxy` to let you opt-in to `localhostOnly` and `alwaysHostPublic` being set to true and false respectively as before.
- Various dependencies bumped.