### PR TITLE
0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ## 0.19.2
 
-- Fixed various bugs in `clientViews` feature.
+- Breaking: `clientViews` no longer exports a function, instead exporting a JSON object.
+- Breaking: `clientViews` will no longer minify templates by default.
+- Fixed bug with `clientViews` `exposeAll` feature that would cause it to scoop up any system files that might be present in your views directories.
+- Fixed bug with `clientViews` blocklist mistakenly defaulting to an object instead of an array which could cause crashes in some configurations.
+- Fixed bug with CSS preprocessor that would cause it to scoop up any system files that might be present in your CSS directories.
 - Various dependencies bumped.
 
 ## 0.19.1

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -104,12 +104,12 @@
   "versionedPublic": false,
   "hostPublic": true,
   "clientViews": {
-    "allowlist": [],
+    "allowlist": {},
     "blocklist": [],
     "output": "templates",
     "exposeAll": false,
     "defaultBundle": "bundle.js",
-    "minify": true,
+    "minify": false,
     "minifyOptions": {}
   }
 }

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -7,6 +7,7 @@ const path = require('path')
 const klawSync = require('klaw-sync')
 const CleanCSS = require('clean-css')
 const prequire = require('parent-require')
+const gitignoreScanner = require('./tools/gitignoreScanner')
 
 module.exports = (app, callback) => {
   const params = app.get('params')
@@ -23,6 +24,7 @@ module.exports = (app, callback) => {
   let versionFile
   let versionData
   let versionCode = '/* do not edit; generated automatically by Roosevelt */ '
+  const gitignoreFiles = gitignoreScanner(path.join(app.get('appDir'), '.gitignore'))
 
   // skip compiling if feature is disabled or generateFolderStructure is false
   if (params.css.compiler === 'none' || params.css.compiler === null || !params.css.compiler.enable || !params.generateFolderStructure) {
@@ -238,7 +240,7 @@ module.exports = (app, callback) => {
     file = file.path || file
 
     // filter out non css files
-    if (file !== '.' && file !== '..' && file !== 'Thumbs.db' && !fs.lstatSync(usingAllowlist ? path.join(cssPath, file.split(':')[0]) : file).isDirectory()) {
+    if (!gitignoreFiles.includes(path.basename(file)) && !gitignoreFiles.includes(file) && file !== '.' && file !== '..') {
       // generate a promise for each file
       promises.push(
         new Promise((resolve, reject) => {

--- a/lib/tools/viewsBundler.js
+++ b/lib/tools/viewsBundler.js
@@ -6,6 +6,7 @@ module.exports = app => {
   const fse = require('fs-extra')
   const path = require('path')
   const klaw = require('klaw-sync')
+  const gitignoreScanner = require('./gitignoreScanner')
   const htmlMinifier = require('html-minifier').minify
   const fsr = require('./fsr')(app)
   const logger = app.get('logger')
@@ -48,13 +49,7 @@ module.exports = app => {
     // Load in each template for each bundle
     for (const file of bundleFilepaths) {
       fileName = file
-      let fileNameAndPath = path.join(viewsPath, file)
-
-      // Add .html if the extension is blank
-      if (path.extname(file) === '') {
-        fileName += '.html'
-        fileNameAndPath += '.html'
-      }
+      const fileNameAndPath = path.join(viewsPath, file)
 
       try {
         contents = fse.readFileSync(fileNameAndPath, 'utf8').trim()
@@ -84,7 +79,15 @@ module.exports = app => {
     const blocklistPaths = blocklist.map(blocklistItem => path.join(viewsPath, blocklistItem))
     const allFilePaths = klaw(viewsPath, { filter: item => !blocklistPaths.includes(item.path), nodir: true }).map(file => file.path)
 
+    const excludedFiles = gitignoreScanner(allFilePaths)
     for (const filePath of allFilePaths) {
+      // exclude system files from being harvested
+      const parts = filePath.split('/')
+      const justFileName = parts[parts.length - 1]
+      if (excludedFiles.includes(justFileName)) {
+        continue
+      }
+
       if (filesCache.includes(filePath)) {
         logger.log('💭', 'file already exposed. continuing...'.bold)
         continue
@@ -173,7 +176,7 @@ module.exports = app => {
 
     fileData = '/* Do not edit; generated automatically by Roosevelt */\n\n/* eslint-disable */\n\n'
 
-    fileData += `module.exports = function() {\n  return ${JSON.stringify(bundle)}\n}\n`
+    fileData += `module.exports = ${JSON.stringify(bundle)}`
 
     // save the file
     fsr.writeFileSync(writePath, fileData, ['📝', `${appName} writing new JS file ${writePath}`.green])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "roosevelt",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5107,9 +5107,9 @@
       }
     },
     "js-base64": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.3.tgz",
-      "integrity": "sha512-fiUvdfCaAXoQTHdKMgTvg6IkecXDcVz6V5rlftUTclF9IKBjMizvSdQaCl/z/6TApDeby5NL+axYou3i0mu1Pg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true
     },
     "js-tokens": {
@@ -6038,9 +6038,9 @@
       }
     },
     "mocha": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.0.tgz",
-      "integrity": "sha512-sI0gaI1I/jPVu3KFpnveWGadfe3JNBAENqgTUPgLZAUppu725zS2mrVztzAgIR8DUscuS4doEBTx9LATC+HSeA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.1.tgz",
+      "integrity": "sha512-p7FuGlYH8t7gaiodlFreseLxEmxTgvyG9RgPHODFPySNhwUehu8NIb0vdSt3WFckSneswZ0Un5typYcWElk7HQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "4.1.1",
@@ -9290,9 +9290,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA=="
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
+      "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.19.1",
+  "version": "0.19.2",
   "files": [
     "defaultErrorPages",
     "lib",

--- a/test/viewsBundler.js
+++ b/test/viewsBundler.js
@@ -308,7 +308,8 @@ describe('Views Bundler Tests', function () {
       clientViews: {
         allowlist: {
           'output.js': ['a.html']
-        }
+        },
+        minify: true
       },
       generateFolderStructure: true
     }, options)
@@ -325,7 +326,7 @@ describe('Views Bundler Tests', function () {
           if (fsr.fileExists(file.path)) {
             delete require.cache[require.resolve(file.path)]
           }
-          const templateJSON = require(file.path)()
+          const templateJSON = require(file.path)
 
           for (const key in templateJSON) {
             const template = templateJSON[key]
@@ -366,7 +367,7 @@ describe('Views Bundler Tests', function () {
           if (fsr.fileExists(file.path)) {
             delete require.cache[require.resolve(file.path)]
           }
-          const templateJSON = require(file.path)()
+          const templateJSON = require(file.path)
 
           for (const key in templateJSON) {
             const template = templateJSON[key]
@@ -390,6 +391,7 @@ describe('Views Bundler Tests', function () {
         allowlist: {
           'output.js': ['a.html']
         },
+        minify: true,
         minifyOptions
       },
       generateFolderStructure: true
@@ -407,7 +409,7 @@ describe('Views Bundler Tests', function () {
           if (fsr.fileExists(file.path)) {
             delete require.cache[require.resolve(file.path)]
           }
-          const templateJSON = require(file.path)()
+          const templateJSON = require(file.path)
 
           for (const key in templateJSON) {
             const template = templateJSON[key]
@@ -449,7 +451,7 @@ describe('Views Bundler Tests', function () {
           if (fsr.fileExists(file.path)) {
             delete require.cache[require.resolve(file.path)]
           }
-          const templateJSON = require(file.path)()
+          const templateJSON = require(file.path)
 
           for (const key in templateJSON) {
             const template = templateJSON[key]
@@ -556,7 +558,7 @@ describe('Views Bundler Tests', function () {
           if (fsr.fileExists(file.path)) {
             delete require.cache[require.resolve(file.path)]
           }
-          const templateJSON = require(file.path)()
+          const templateJSON = require(file.path)
           const templates = Object.keys(templateJSON)
 
           blocklist.forEach(notExposedFile => {
@@ -598,7 +600,7 @@ describe('Views Bundler Tests', function () {
           if (fsr.fileExists(file.path)) {
             delete require.cache[require.resolve(file.path)]
           }
-          const templateJSON = require(file.path)()
+          const templateJSON = require(file.path)
           const templates = Object.keys(templateJSON)
 
           blocklist.forEach(notExposedFile => {
@@ -639,7 +641,7 @@ describe('Views Bundler Tests', function () {
         if (fsr.fileExists(outputBundle.path)) {
           delete require.cache[require.resolve(outputBundle.path)]
         }
-        const templateJSON = require(outputBundle.path)()
+        const templateJSON = require(outputBundle.path)
         const templates = Object.keys(templateJSON)
 
         assert.strictEqual(templates.length, 1)
@@ -675,7 +677,7 @@ describe('Views Bundler Tests', function () {
         if (fsr.fileExists(outputBundle.path)) {
           delete require.cache[require.resolve(outputBundle.path)]
         }
-        const templateJSON = require(outputBundle.path)()
+        const templateJSON = require(outputBundle.path)
         const templates = Object.keys(templateJSON)
 
         assert.strictEqual(templates.length, 1)


### PR DESCRIPTION
- Breaking: `clientViews` no longer exports a function, instead exporting a JSON object.
- Breaking: `clientViews` will no longer minify templates by default.
- Fixed bug with `clientViews` `exposeAll` feature that would cause it to scoop up any system files that might be present in your views directories.
- Fixed bug with `clientViews` blocklist mistakenly defaulting to an object instead of an array which could cause crashes in some configurations.
- Fixed bug with CSS preprocessor that would cause it to scoop up any system files that might be present in your CSS directories.
- Various dependencies bumped.