### PR TITLE
Make symlink creation a separate step ran first in app startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next version
 
-- Put your changes here...
+- Moved symlink creation to a separate step and made it the first thing that is done on app startup
 
 ## 0.19.3
 

--- a/lib/generateSymlinks.js
+++ b/lib/generateSymlinks.js
@@ -1,0 +1,39 @@
+const fs = require('fs-extra')
+const path = require('path')
+
+module.exports = app => {
+  const params = app.get('params')
+  const appName = app.get('appName')
+  const fsr = require('./tools/fsr')(app)
+  const logger = app.get('logger')
+  const publicDir = params.publicFolder
+
+  // generate public and statics directories
+  fsr.ensureDirSync(publicDir)
+  fsr.ensureDirSync(params.staticsRoot)
+
+  // process symlinks
+  if (params.generateFolderStructure) {
+    for (const symlink of params.symlinks) {
+      // append appDir to each path that is relative
+      const source = path.isAbsolute(symlink.source) ? symlink.source : path.join(app.get('appDir'), symlink.source)
+      const dest = path.isAbsolute(symlink.dest) ? symlink.dest : path.join(app.get('appDir'), symlink.dest)
+
+      // first ensure the source exists
+      if (fsr.fileExists(source)) {
+        // then check if the destination already exists
+        if (fsr.fileExists(dest)) {
+          // then check if the destination is a symlink
+          if (!fs.lstatSync(dest).isSymbolicLink()) {
+            logger.error(`Symlink destination "${dest}" is already a file that exists. Skipping symlink creation.`)
+          }
+        } else {
+          fs.ensureSymlinkSync(source, dest)
+          logger.info('📁', `${appName} making new symlink `.cyan + `${dest}`.yellow + (' pointing to ').cyan + `${source}`.yellow)
+        }
+      } else {
+        logger.error(`Symlink source "${source}" does not exist. Skipping symlink creation.`)
+      }
+    }
+  }
+}

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -15,7 +15,6 @@ module.exports = app => {
   const fsr = require('./tools/fsr')(app)
   const params = app.get('params')
   const prefix = params.routePrefix
-  const publicDir = params.publicFolder
   let controllerFiles
 
   // ensure 404 page exists
@@ -74,35 +73,6 @@ module.exports = app => {
       res.on('error', function () { params.onReqAfterRoute(req, res) })
       next()
     })
-  }
-
-  // generate public and statics directories
-  fsr.ensureDirSync(publicDir)
-  fsr.ensureDirSync(params.staticsRoot)
-
-  // process symlinks
-  if (params.generateFolderStructure) {
-    for (const symlink of params.symlinks) {
-      // append appDir to each path that is relative
-      const source = path.isAbsolute(symlink.source) ? symlink.source : path.join(app.get('appDir'), symlink.source)
-      const dest = path.isAbsolute(symlink.dest) ? symlink.dest : path.join(app.get('appDir'), symlink.dest)
-
-      // first ensure the source exists
-      if (fsr.fileExists(source)) {
-        // then check if the destination already exists
-        if (fsr.fileExists(dest)) {
-          // then check if the destination is a symlink
-          if (!fs.lstatSync(dest).isSymbolicLink()) {
-            logger.error(`Symlink destination "${dest}" is already a file that exists. Skipping symlink creation.`)
-          }
-        } else {
-          fs.ensureSymlinkSync(source, dest)
-          logger.info('📁', `${appName} making new symlink `.cyan + `${dest}`.yellow + (' pointing to ').cyan + `${source}`.yellow)
-        }
-      } else {
-        logger.error(`Symlink source "${source}" does not exist. Skipping symlink creation.`)
-      }
-    }
   }
 
   // generate mvc directories

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -213,6 +213,8 @@ module.exports = params => {
     }
     initialized = true
 
+    require('./lib/generateSymlinks')(app)
+
     // Inject reload javascript HTML tag
     require('./lib/injectReload')(app)
 


### PR DESCRIPTION
Move symlinks creation to a separate step so they could be used safely without having an order of operations problem. This is first thing done on app startup so all symlinks are in place before trying to do any processing of any files.