### PR TITLE
Fixed bug to make Roosevelt respond to NODE_ENV properly (Closes #970)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next version
 
-- Put your changes here...
+- Fix bug so that Roosevelt listens to NODE_ENV when command line arguments aren't specified
 
 ## 0.19.3
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -61,8 +61,8 @@ module.exports = (params, app) => {
         params.htmlValidator.enable = true
       }
 
-      // default mode param to production if its value is invalid
-      if (params.mode !== 'production-proxy' && params.mode !== 'production' && params.mode !== 'development') {
+      // default mode param to production if its value is invalid and the NODE_ENV isn't set.
+      if (params.mode !== 'production-proxy' && params.mode !== 'production' && params.mode !== 'development' && !process.env.NODE_ENV) {
         params.mode = 'production'
       }
 
@@ -87,6 +87,7 @@ module.exports = (params, app) => {
       default: defaults.port
     },
     mode: {
+      envVar: ['NODE_ENV'],
       default: defaults.mode
     },
     enableCLIFlags: {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -61,8 +61,8 @@ module.exports = (params, app) => {
         params.htmlValidator.enable = true
       }
 
-      // default mode param to production if its value is invalid and the NODE_ENV isn't set.
-      if (params.mode !== 'production-proxy' && params.mode !== 'production' && params.mode !== 'development' && !process.env.NODE_ENV) {
+      // default mode param to production if its value is invalid
+      if (params.mode !== 'production-proxy' && params.mode !== 'production' && params.mode !== 'development') {
         params.mode = 'production'
       }
 

--- a/test/globalHooks.js
+++ b/test/globalHooks.js
@@ -1,0 +1,12 @@
+/* eslint-env mocha */
+
+// Global before/after each hook that resets the NODE_ENV variable as Roosevelt explicitly sets it and the testing environment is one continuous process, so if you don't reset the ENV it will override the Roosevelt test params
+beforeEach((done) => {
+  process.env.NODE_ENV = ''
+  done()
+})
+
+afterEach((done) => {
+  process.env.NODE_ENV = ''
+  done()
+})


### PR DESCRIPTION
When a command line argument for node environment isn't specified, look next to NODE_ENV, then fallback to production default

(Closes #970)