### PR TITLE
0.19.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "roosevelt",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.19.3",
+  "version": "0.19.4",
   "files": [
     "defaultErrorPages",
     "lib",


### PR DESCRIPTION
- Fixed bug that caused Roosevelt to not listen to `NODE_ENV`.
- Moved symlink creation to a separate step and made happen earlier in the app initialization process to maek it easier to work with the various Roosevelt server starting events.
- Various dependencies bumped.