### PR TITLE
Extra error logging for rooseveltConfig

### DIFF
--- a/lib/setExpressConfigs.js
+++ b/lib/setExpressConfigs.js
@@ -79,6 +79,8 @@ module.exports = function (app) {
     viewEngineParam.forEach(registerViewEngine)
   } else if (viewEngineParam !== 'none' && viewEngineParam !== null) {
     registerViewEngine(viewEngineParam)
+  } else {
+    logger.warn('No view engine specified. viewEngine has been disabled.')
   }
 
   return app

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -27,7 +27,10 @@ module.exports = (params, app) => {
   // determine if app has a config file
   try {
     configFile = require(path.join(appDir, 'rooseveltConfig.json'))
-  } catch {
+  } catch (err) {
+    if (err.name === 'SyntaxError') {
+      console.error(err)
+    }
     configFile = {}
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1191,7 +1191,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -5383,7 +5382,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -5471,14 +5469,7 @@
       "dev": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "make-dir": "^2.1.0",
-        "mime": "^1.4.1",
-        "needle": "^2.5.2",
         "parse-node-version": "^1.0.1",
-        "source-map": "~0.6.0",
         "tslib": "^1.10.0"
       },
       "bin": {
@@ -7299,9 +7290,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
       "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
-      "dependencies": {
-        "clipboard": "^2.0.0"
-      },
       "optionalDependencies": {
         "clipboard": "^2.0.0"
       }


### PR DESCRIPTION
Resolves #955. Previously, if there was a syntax error when parsing rooseveltConfig.json, the config was just silently ignored. Now it will log that error. It also adds another warning to explicitly show when no view engine is specified.