### PR TITLE
Remove upgrade-insecure-request from helmet config

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ Resolves to:
   - To disable multipart forms entirely, set `formidable` to `false`.
 
 - `helmet`: Parameters to pass to the [helmet](https://github.com/helmetjs/helmet) module.
+  - Default: *[Object]*
+    The default options are specified in the [helmet docs](https://helmetjs.github.io/), with the exception of the upgrade-insecure-requests in the content security policy, which has been removed.
 
 - `toobusy`: Parameters to pass to the [node-toobusy](https://github.com/STRML/node-toobusy) module.
 

--- a/lib/setExpressConfigs.js
+++ b/lib/setExpressConfigs.js
@@ -47,7 +47,13 @@ module.exports = function (app) {
 
   // set helmet middleware
   if (params.mode !== 'development') {
-    app.use(helmet(params.helmet))
+    let contentSecurityPolicy = params.helmet.contentSecurityPolicy
+    if (contentSecurityPolicy === undefined) {
+      contentSecurityPolicy = {}
+      contentSecurityPolicy.directives = helmet.contentSecurityPolicy.getDefaultDirectives()
+      delete contentSecurityPolicy.directives['upgrade-insecure-requests']
+    }
+    app.use(helmet({ ...params.helmet, contentSecurityPolicy }))
   }
 
   // close connections gracefully if server is being shut down


### PR DESCRIPTION
The default config for helmet's content security policy has been altered to remove the upgrade-insecure-request parameter. Closes #964 .