### PR TITLE
Allow overriding of default flags and env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,27 @@ Environment variable precedence:
 - Environment variables supersede your app's [parameters](https://github.com/rooseveltframework/roosevelt#configure-your-app-with-parameters).
 - Environment variables can be overridden with [command line arguments](https://github.com/rooseveltframework/roosevelt#available-command-line-arguments).
 
+## Overriding recognized command line flags and environment variables
+
+You can override the default command line flags and environment variables by providing a schema from [source-configs](https://github.com/rooseveltframework/source-configs) with a 'rooseveltConfig' section. For instance, to set the number of cores from the command line with '--num-cores' or '-n' instead of '--cores' or '-c', you could write:
+```javascript
+const schema = {
+  rooseveltConfig: {
+    cores: {
+      commandLineArg: ['--num-cores', '-n'],
+      envVar: ['NUM_CORES']
+    }
+  }
+}
+require('roosevelt')({
+  'generateFolderStructure': true
+}, schema).startServer()
+```
+
+Note that this also adds an environment variable.
+
+This will override the default for any recognized Roosevelt parameter.
+
 # Default directory structure
 
 - `app.js`: Entry point to your application. Feel free to rename this, but make sure to update `package.json`'s reference to it.

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -11,7 +11,7 @@ let pkg
 let pkgConfig
 let configFile
 
-module.exports = (params, app) => {
+module.exports = (params, app, appSchema) => {
   const appDir = params.appDir
 
   // determine if app has a package.json
@@ -346,6 +346,12 @@ module.exports = (params, app) => {
       default: {}
     }
   }
+
+  // If a schema is passed in, update any necessary command line flags and environment variables
+  if (appSchema !== undefined && appSchema.rooseveltConfig !== undefined) {
+    updateFlagsAndEnvVars(schema, appSchema.rooseveltConfig)
+  }
+
   params = sourceConfigs(schema, config)
 
   // resolve path params
@@ -502,4 +508,16 @@ module.exports = (params, app) => {
   }
 
   return params
+}
+
+// Recursively sets the command line flags and environment variables of the schema based on given params.
+function updateFlagsAndEnvVars (schema, params) {
+  for (const key in params) {
+    if (key === 'commandLineArg' || key === 'envVar') {
+      console.log(`setting ${key} to ${params[key]}`)
+      schema[key] = params[key]
+    } else if (schema[key] !== undefined) {
+      updateFlagsAndEnvVars(schema[key], params[key])
+    }
+  }
 }

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -9,7 +9,7 @@ const os = require('os')
 const fs = require('fs-extra')
 const fsr = require('./lib/tools/fsr')()
 
-module.exports = params => {
+module.exports = (params, schema) => {
   params = params || {} // ensure params are an object
 
   // appDir is either specified by the user or sourced from the parent require
@@ -39,7 +39,7 @@ module.exports = params => {
   app.set('router', router)
 
   // source user supplied params
-  params = require('./lib/sourceParams')(params, app)
+  params = require('./lib/sourceParams')(params, app, schema)
 
   // use existence of public folder to determine first run
   if (!fsr.fileExists(params.publicFolder) && params.logging.methods.info) {


### PR DESCRIPTION
Users can pass in a schema. Any recognized Roosevelt variables within the rooseveltConfig section will override the default command line flags and environment variables. Closes #746 