### PR TITLE
Allowlist directory in client views

### DIFF
--- a/lib/viewsBundler.js
+++ b/lib/viewsBundler.js
@@ -53,7 +53,7 @@ module.exports = app => {
 
       try {
         if (fse.lstatSync(fileNameAndPath).isDirectory()) {
-          exposeDirectory(fileNameAndPath, 'allowlist')
+          exposeDirectory(fileNameAndPath, bundleName, 'allowlist')
         } else {
           contents = fse.readFileSync(fileNameAndPath, 'utf8').trim()
           filesCache.push(fileNameAndPath)
@@ -79,7 +79,7 @@ module.exports = app => {
   }
 
   if (exposeAll) {
-    exposeDirectory(viewsPath, 'exposeAll')
+    exposeDirectory(viewsPath, defaultBundle, 'exposeAll')
   }
 
   // Loop through each bundle, preprocess it, and save it to the specified location on the filesystem
@@ -89,7 +89,7 @@ module.exports = app => {
 
   /* ======== Internal Functions ======== */
 
-  function parseTemplateComment (templateComment, contents, defaultBundle, locationMethod) {
+  function parseTemplateComment (templateComment, contents, bundleName, locationMethod) {
     let bundleLocation
 
     if (templateComment.includes('roosevelt-blocklist')) {
@@ -103,7 +103,7 @@ module.exports = app => {
       regex.lastIndex = 0
     } else {
       // Otherwise, save it to a default bundle
-      bundleLocation = defaultBundle
+      bundleLocation = bundleName
     }
 
     return [bundleLocation, contents]
@@ -168,7 +168,7 @@ module.exports = app => {
   }
 
   // Returns an array of all valid file paths in the given directory.
-  function exposeDirectory (directory, locationMethod) {
+  function exposeDirectory (directory, bundleName, locationMethod) {
     // Use klaw to find all files in the given path except ones that are part of the blocklist param of the clientViews property in the Roosevelt config
     const blocklistPaths = blocklist.map(blocklistItem => path.join(viewsPath, blocklistItem))
     const allFilePaths = klaw(directory, { filter: item => !blocklistPaths.includes(item.path), nodir: true }).map(file => file.path)
@@ -196,7 +196,7 @@ module.exports = app => {
       templateComment = contents.split('\n')[0]
 
       try {
-        [bundleLocation, contents] = parseTemplateComment(templateComment, contents, defaultBundle, locationMethod)
+        [bundleLocation, contents] = parseTemplateComment(templateComment, contents, bundleName, locationMethod)
       } catch (error) {
         // Error is thrown when template contains <!-- roosevelt-blocklist -->. Skip this template
         logger.error(error)

--- a/lib/viewsBundler.js
+++ b/lib/viewsBundler.js
@@ -55,8 +55,8 @@ module.exports = app => {
         if (fse.lstatSync(fileNameAndPath).isDirectory()) {
           exposeDirectory(fileNameAndPath, 'allowlist')
         } else {
-        contents = fse.readFileSync(fileNameAndPath, 'utf8').trim()
-        filesCache.push(fileNameAndPath)
+          contents = fse.readFileSync(fileNameAndPath, 'utf8').trim()
+          filesCache.push(fileNameAndPath)
         }
       } catch (error) {
         // File may not exist. Log such error
@@ -80,7 +80,7 @@ module.exports = app => {
 
   if (exposeAll) {
     exposeDirectory(viewsPath, 'exposeAll')
-      }
+  }
 
   // Loop through each bundle, preprocess it, and save it to the specified location on the filesystem
   for (const bundleFilename in outputBundles) {
@@ -100,6 +100,7 @@ module.exports = app => {
       contents = contents.split('\n').slice(1).join('\n')
 
       bundleLocation = regex.exec(templateComment)[1]
+      regex.lastIndex = 0
     } else {
       // Otherwise, save it to a default bundle
       bundleLocation = defaultBundle

--- a/lib/viewsBundler.js
+++ b/lib/viewsBundler.js
@@ -52,8 +52,12 @@ module.exports = app => {
       const fileNameAndPath = path.join(viewsPath, file)
 
       try {
+        if (fse.lstatSync(fileNameAndPath).isDirectory()) {
+          exposeDirectory(fileNameAndPath, 'allowlist')
+        } else {
         contents = fse.readFileSync(fileNameAndPath, 'utf8').trim()
         filesCache.push(fileNameAndPath)
+        }
       } catch (error) {
         // File may not exist. Log such error
         logger.error(error)
@@ -75,44 +79,8 @@ module.exports = app => {
   }
 
   if (exposeAll) {
-    // Use klaw to find all files in the views path except ones that are part of the blocklist param of in the clientViews property in the Roosevelt config
-    const blocklistPaths = blocklist.map(blocklistItem => path.join(viewsPath, blocklistItem))
-    const allFilePaths = klaw(viewsPath, { filter: item => !blocklistPaths.includes(item.path), nodir: true }).map(file => file.path)
-
-    const excludedFiles = gitignoreScanner(allFilePaths)
-    for (const filePath of allFilePaths) {
-      // exclude system files from being harvested
-      const parts = filePath.split('/')
-      const justFileName = parts[parts.length - 1]
-      if (excludedFiles.includes(justFileName)) {
-        continue
+    exposeDirectory(viewsPath, 'exposeAll')
       }
-
-      if (filesCache.includes(filePath)) {
-        logger.log('💭', 'file already exposed. continuing...'.bold)
-        continue
-      }
-
-      // The filePath object is the absolute path of the file. Delete the viewsPath portion from the filePath
-      fileName = removeBasePath(filePath, viewsPath)
-
-      contents = fse.readFileSync(filePath, 'utf8').trim()
-      filesCache.push(filePath)
-
-      templateComment = contents.split('\n')[0]
-
-      try {
-        [bundleLocation, contents] = parseTemplateComment(templateComment, contents, defaultBundle, 'exposeAll')
-      } catch (error) {
-        // Error is thrown when template contains <!-- roosevelt-blocklist -->. Skip this template
-        logger.error(error)
-        continue
-      }
-
-      // Add the template to the outputBundles object
-      storeContents(contents, bundleLocation, fileName)
-    }
-  }
 
   // Loop through each bundle, preprocess it, and save it to the specified location on the filesystem
   for (const bundleFilename in outputBundles) {
@@ -196,5 +164,46 @@ module.exports = app => {
     }
 
     return file
+  }
+
+  // Returns an array of all valid file paths in the given directory.
+  function exposeDirectory (directory, locationMethod) {
+    // Use klaw to find all files in the given path except ones that are part of the blocklist param of the clientViews property in the Roosevelt config
+    const blocklistPaths = blocklist.map(blocklistItem => path.join(viewsPath, blocklistItem))
+    const allFilePaths = klaw(directory, { filter: item => !blocklistPaths.includes(item.path), nodir: true }).map(file => file.path)
+
+    const excludedFiles = gitignoreScanner(allFilePaths)
+    for (const filePath of allFilePaths) {
+      // exclude system files from being harvested
+      const parts = filePath.split('/')
+      const justFileName = parts[parts.length - 1]
+      if (excludedFiles.includes(justFileName)) {
+        continue
+      }
+
+      if (filesCache.includes(filePath)) {
+        logger.log('💭', 'file already exposed. continuing...'.bold)
+        continue
+      }
+
+      // The filePath object is the absolute path of the file. Delete the viewsPath portion from the filePath
+      fileName = removeBasePath(filePath, viewsPath)
+
+      contents = fse.readFileSync(filePath, 'utf8').trim()
+      filesCache.push(filePath)
+
+      templateComment = contents.split('\n')[0]
+
+      try {
+        [bundleLocation, contents] = parseTemplateComment(templateComment, contents, defaultBundle, locationMethod)
+      } catch (error) {
+        // Error is thrown when template contains <!-- roosevelt-blocklist -->. Skip this template
+        logger.error(error)
+        continue
+      }
+
+      // Add the template to the outputBundles object
+      storeContents(contents, bundleLocation, fileName)
+    }
   }
 }

--- a/test/viewsBundler.js
+++ b/test/viewsBundler.js
@@ -757,7 +757,7 @@ describe('Views Bundler Tests', function () {
         const templateJSON = require(outputBundle.path)
         const templates = Object.keys(templateJSON)
 
-        assert.strictEqual(templates.length, 1)
+        assert.strictEqual(templates.length, 2)
 
         testApp.send('stop')
       }


### PR DESCRIPTION
Closes #951. If a user provides a directory name in the clientView allowlist config, all of the templates within that directory will be exposed.