### PR TITLE
0.19.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Roosevelt Changelog
 
-## Next version
+## 0.19.10
 
 - Added `roosevelt-router` feature to improve support for writing isomorphic code for SPAs.
 - Added `isomorphicControllers` config option that will permit Roosevelt to make a list of all your controller files that can be used client-side as well so they can be auto-loaded client-side too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Roosevelt Changelog
 
+## Next version
+
+- Put your changes here...
+
 ## 0.19.10
 
 - Added `roosevelt-router` feature to improve support for writing isomorphic code for SPAs.


### PR DESCRIPTION
- Added `roosevelt-router` feature to improve support for writing isomorphic code for SPAs.
- Added `isomorphicControllers` config option that will permit Roosevelt to make a list of all your controller files that can be used client-side as well so they can be auto-loaded client-side too.
- Altered `clientViews` such that the template list will lack file extensions if the file extension of the template matches the default view engine's file extension.
- Fixed confusing console warning.
- HTML validator frontend scripts moved to `<head>`.
- Various dependencies updated.