### PR TITLE
0.19.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 - Put your changes here...
 
+## 0.19.13
+
+- Added script to generate self-signed HTTPS certs:
+  - `npm run certs-generator`: Generates self-signed HTTPS certs for your app.
+    - Default shorthand:
+      - `npm run c`
+    - Script is short for: `node ./node_modules/roosevelt/lib/scripts/certsGenerator.js`
+- Some refactoring.
+- Various dependencies updated.
+
 ## 0.19.12
 
 - Various dependencies updated.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Roosevelt apps created with the app generator come with the following notable [n
     - `npm run prodproxy`
     - `npm run x`
   - Script is short for: `nodemon app.js --production-proxy`
+- `npm run certs-generator`: Generates self-signed HTTPS certs for your app.
+  - Default shorthand:
+    - `npm run c`
+  - Script is short for: `node ./node_modules/roosevelt/lib/scripts/certsGenerator.js`
 - `npm run config-audit`: Scans current `rooseveltConfig` and `scripts` in `package.json` and warns about any parameters or npm scripts that don't match the current Roosevelt API:
   - Default shorthand:
     - `npm run a`

--- a/defaultErrorPages/controllers/5xx.js
+++ b/defaultErrorPages/controllers/5xx.js
@@ -6,7 +6,7 @@ const errorPage = fs.readFileSync(path.join(__dirname, '../views/5xx.html'))
 module.exports = function (app, err, req, res) {
   const status = err.status || 500
   const model = {
-    status: status,
+    status,
     url: req.url,
     mainDomain: req.headers['x-forwarded-host'] || req.headers.host,
     appVersion: app.get('appVersion')

--- a/lib/defaults/scripts.json
+++ b/lib/defaults/scripts.json
@@ -27,8 +27,12 @@
     "value": "nodemon app.js --development-mode",
     "priority": "ignore"
   },
-  "certGen": {
-    "value": "node ./node_modules/roosevelt/lib/scripts/httpsSelfsigned.js",
+  "certs-generator": {
+    "value": "node ./node_modules/roosevelt/lib/scripts/certsGenerator.js",
+    "priority": "error"
+  },
+  "c": {
+    "value": "node ./node_modules/roosevelt/lib/scripts/certsGenerator.js",
     "priority": "error"
   },
   "config-audit": {

--- a/lib/roosevelt-router.js
+++ b/lib/roosevelt-router.js
@@ -96,7 +96,7 @@ module.exports = (params) => {
           e.preventDefault() // prevent page reload if there is a registered route for this form submission
           document.activeElement.disabled = true // disable button that was clicked so it can't be double clicked
           window.fetch(action, { // send fetch to the server
-            method: method, // with whatever method is defined in the form element
+            method, // with whatever method is defined in the form element
             headers: {
               'Content-Type': 'application/json' // tell the server it's an API request
             },

--- a/lib/scripts/certsGenerator.js
+++ b/lib/scripts/certsGenerator.js
@@ -1,12 +1,11 @@
-
 if (module.parent) {
   module.exports = {
-    certsGen: certsGen
+    certsGenerator
   }
 } else {
-  certsGen()
+  certsGenerator()
 }
-function certsGen (appDir) {
+function certsGenerator (appDir) {
   const selfsigned = require('selfsigned')
   const pem = selfsigned.generate(null, {
     keySize: 2048, // the size for the private key in bits (default: 1024)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.19.12",
+  "version": "0.19.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.19.12",
+      "version": "0.19.13",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "~1.5.0",
@@ -43,18 +43,18 @@
         "codecov": "~3.8.3",
         "eslint": "~8.19.0",
         "eslint-plugin-mocha": "~10.0.5",
-        "less": "~4.1.2",
+        "less": "~4.1.3",
         "mocha": "~10.0.0",
         "proxyquire": "~2.1.3",
         "sass": "~1.39.2",
         "sinon": "~14.0.0",
         "standard": "~17.0.0",
         "stylus": "~0.58.1",
-        "supertest": "~6.2.3",
+        "supertest": "~6.2.4",
         "teddy": "~0.5.10"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "funding": {
         "type": "individual",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.19.12",
+  "version": "0.19.13",
   "files": [
     "defaultErrorPages",
     "lib",
@@ -19,7 +19,7 @@
   "main": "roosevelt.js",
   "readmeFilename": "README.md",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "engineStrict": true,
   "dependencies": {
@@ -57,14 +57,14 @@
     "codecov": "~3.8.3",
     "eslint": "~8.19.0",
     "eslint-plugin-mocha": "~10.0.5",
-    "less": "~4.1.2",
+    "less": "~4.1.3",
     "mocha": "~10.0.0",
     "proxyquire": "~2.1.3",
     "sass": "~1.39.2",
     "sinon": "~14.0.0",
     "standard": "~17.0.0",
     "stylus": "~0.58.1",
-    "supertest": "~6.2.3",
+    "supertest": "~6.2.4",
     "teddy": "~0.5.10"
   },
   "repository": {

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -517,11 +517,11 @@ module.exports = (params, schema) => {
   }
 
   return {
-    httpServer: httpServer,
-    httpsServer: httpsServer,
+    httpServer,
+    httpsServer,
     expressApp: app,
-    initServer: initServer,
-    startServer: startServer,
+    initServer,
+    startServer,
     stopServer: gracefulShutdown
   }
 }

--- a/test/cssCompiler.js
+++ b/test/cssCompiler.js
@@ -24,7 +24,7 @@ describe('css preprocessors', () => {
     htmlValidator: {
       enable: false
     },
-    appDir: appDir,
+    appDir,
     generateFolderStructure: true
   }
   const file1 = `

--- a/test/errorPages.js
+++ b/test/errorPages.js
@@ -34,7 +34,7 @@ describe('error pages', function () {
   it('should render the default 404 page if there is a request for an invalid route', function (done) {
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       viewEngine: [
         'html: teddy'
@@ -75,7 +75,7 @@ describe('error pages', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       errorPages: {
         notFound: '404test.js'
@@ -115,7 +115,7 @@ describe('error pages', function () {
   it('should render a custom 500 page if there is a request for a route that will respond with a server error and the 500 parameter is set', function (done) {
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       errorPages: {
         internalServerError: '500test.js'
@@ -155,7 +155,7 @@ describe('error pages', function () {
   it('should render the default 500 error page if an error has occured on the server', function (done) {
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}'
     }, options)
@@ -192,7 +192,7 @@ describe('error pages', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}',
       toobusy: {
@@ -239,7 +239,7 @@ describe('error pages', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       errorPages: {
         serviceUnavailable: '503test.js'
@@ -291,7 +291,7 @@ describe('error pages', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}'
     }, options)
@@ -354,7 +354,7 @@ describe('error pages', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}',
       shutdownTimeout: 7000
@@ -414,7 +414,7 @@ describe('error pages', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       https: {
         enable: true,
@@ -478,7 +478,7 @@ describe('error pages', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}'
     }, options)

--- a/test/fileGeneration.js
+++ b/test/fileGeneration.js
@@ -20,7 +20,7 @@ describe('file creation', () => {
 
     // spin up an app configured to make lots of folders
     const app = require('../roosevelt')({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       logging: {
         methods: {
@@ -61,7 +61,7 @@ describe('file creation', () => {
 
     // spin up an app
     const app = require('../roosevelt')({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: false,
       logging: {
         methods: {
@@ -103,7 +103,7 @@ describe('file creation', () => {
 
     // spin up an app
     const app = require('../roosevelt')({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       versionedPublic: true,
       logging: {

--- a/test/htmlMinify.js
+++ b/test/htmlMinify.js
@@ -11,7 +11,7 @@ const roosevelt = require('../roosevelt')
 describe('HTML Minification Tests', function () {
   const appDir = path.join(__dirname, 'app/htmlMinifier')
   const appConfig = {
-    appDir: appDir,
+    appDir,
     port: 41002,
     logging: {
       methods: {
@@ -63,7 +63,7 @@ describe('HTML Minification Tests', function () {
     // initialize test app
     app = roosevelt({
       ...appConfig,
-      onServerStart: onServerStart
+      onServerStart
     })
 
     app.startServer()
@@ -88,7 +88,7 @@ describe('HTML Minification Tests', function () {
     // initialize test app
     app = roosevelt({
       ...appConfig,
-      onServerStart: onServerStart
+      onServerStart
     })
 
     app.startServer()
@@ -117,7 +117,7 @@ describe('HTML Minification Tests', function () {
     // initialize test app
     app = roosevelt({
       ...config,
-      onServerStart: onServerStart
+      onServerStart
     })
 
     app.startServer()
@@ -146,7 +146,7 @@ describe('HTML Minification Tests', function () {
     // initialize test app
     app = roosevelt({
       ...config,
-      onServerStart: onServerStart
+      onServerStart
     })
 
     app.startServer()
@@ -175,7 +175,7 @@ describe('HTML Minification Tests', function () {
     // initialize test app
     app = roosevelt({
       ...config,
-      onServerStart: onServerStart
+      onServerStart
     })
 
     app.startServer()
@@ -220,7 +220,7 @@ describe('HTML Minification Tests', function () {
     // initialize test app
     app = roosevelt({
       ...config,
-      onServerStart: onServerStart
+      onServerStart
     })
 
     app.startServer()

--- a/test/httpsOptions.js
+++ b/test/httpsOptions.js
@@ -55,7 +55,7 @@ describe('HTTPS Server Options Tests', function () {
   })
 
   it('should create a https server when https.enable is set to true', function () {
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertion
     assert(stubHttpsServer.called, 'https.Server was not called')
@@ -65,7 +65,7 @@ describe('HTTPS Server Options Tests', function () {
     // change config
     config.https.force = false
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertion
     assert(stubHttpServer.called, 'http.Server was not called')
@@ -77,7 +77,7 @@ describe('HTTPS Server Options Tests', function () {
     config.https.force = true
     config.https.enable = false
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertion
     assert(stubHttpServer.called, 'http.Server was not called')
@@ -90,7 +90,7 @@ describe('HTTPS Server Options Tests', function () {
     // change config
     config.https.force = true
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertion
     assert(stubHttpServer.notCalled, 'http.Server called despite force flag')
@@ -99,7 +99,7 @@ describe('HTTPS Server Options Tests', function () {
   it('should start a https server using the given p12 file and passphrase if the p12Path param is set to a file path string and the passphrase is set', function () {
     const p12text = fs.readFileSync(path.join(appDir, '../.././util/certs/test.p12'), 'utf8')
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertions
     assert(typeof stubHttpsServer.args[0][0].cert === 'undefined', 'https.Server had cert when using p12')
@@ -112,7 +112,7 @@ describe('HTTPS Server Options Tests', function () {
   it('should start a https server using the given p12 buffer and passphrase if the p12.p12Path param is set to a PKCS#12 formatted buffer and passphrase is set', function () {
     const p12text = fs.readFileSync(path.join(appDir, '../.././util/certs/test.p12'), 'utf8')
     config.https.authInfoPath.p12.p12Path = p12text
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertions
     assert(typeof stubHttpsServer.args[0][0].cert === 'undefined', 'https.Server had cert when using p12')
@@ -129,7 +129,7 @@ describe('HTTPS Server Options Tests', function () {
     // change config - unset p12Path
     config.https.authInfoPath.p12.p12Path = ''
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertions
     assert(stubHttpsServer.args[0][0].key.equals(keytext), 'https.Server key file did not match supplied')
@@ -145,7 +145,7 @@ describe('HTTPS Server Options Tests', function () {
     // change config - change key to a string
     config.https.authInfoPath.authCertAndKey.key = fs.readFileSync(path.join(appDir, '../.././util/certs/test.req.key'))
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertions
     assert(stubHttpsServer.args[0][0].key.equals(keytext), 'https.Server key file did not match supplied')
@@ -161,7 +161,7 @@ describe('HTTPS Server Options Tests', function () {
     // change config - change cert to a  string
     config.https.authInfoPath.authCertAndKey.cert = fs.readFileSync(path.join(appDir, '../.././util/certs/test.req.crt'))
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertions
     assert(stubHttpsServer.args[0][0].key.equals(keytext), 'https.Server key file did not match supplied')
@@ -173,7 +173,7 @@ describe('HTTPS Server Options Tests', function () {
   it('should start a https server using the certificate authority certificate from a file if the caCert param is set with a file path', function () {
     const catext = fs.readFileSync(path.join(appDir, '../.././util/certs/ca.crt'))
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertion
     assert(stubHttpsServer.args[0][0].ca.equals(catext), 'https.Server CA did not match supplied CA')
@@ -187,7 +187,7 @@ describe('HTTPS Server Options Tests', function () {
     // change config
     config.https.caCert = ['test/util/certs/ca.crt', 'test/util/certs/ca-2.crt']
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertions
     assert(stubHttpsServer.args[0][0].ca[0].equals(ca1), 'https.Server CA (1) did not match supplied CA')
@@ -199,7 +199,7 @@ describe('HTTPS Server Options Tests', function () {
     // change config
     config.https.caCert = fs.readFileSync(path.join(appDir, '../.././util/certs/ca.crt'), 'UTF8')
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertion
     assert.strictEqual(stubHttpsServer.args[0][0].ca, config.https.caCert, 'https.Server CA did not match supplied CA')
@@ -213,7 +213,7 @@ describe('HTTPS Server Options Tests', function () {
     // change config
     config.https.caCert = [ca1, ca2]
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertions
     assert(stubHttpsServer.args[0][0].ca[0].equals(ca1), 'https.Server CA (1) did not match supplied CA')
@@ -228,7 +228,7 @@ describe('HTTPS Server Options Tests', function () {
     // change config
     config.https.caCert = [ca1, path.join(appDir, '../.././util/certs/ca-2.crt')]
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertions
     assert(stubHttpsServer.args[0][0].ca[0].equals(ca1), 'https.Server CA (1) did not match supplied CA')
@@ -240,7 +240,7 @@ describe('HTTPS Server Options Tests', function () {
     // change config
     config.https.caCert = 42
 
-    app({ appDir: appDir, ...config })
+    app({ appDir, ...config })
 
     // test assertions
     assert(stubHttpsServer.called, 'https.Server was not called')

--- a/test/multipart.js
+++ b/test/multipart.js
@@ -36,7 +36,7 @@ describe('multipart/formidable', () => {
 
     // spin up the roosevelt app
     roosevelt({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       port: 40003,
       logging: {

--- a/test/paramFunctions.js
+++ b/test/paramFunctions.js
@@ -41,7 +41,7 @@ describe('Parameter Function Tests', function () {
 
     // generate the app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerInit: '(app) => {process.send("something")}'
     }, options)
@@ -73,7 +73,7 @@ describe('Parameter Function Tests', function () {
 
     // generate the app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onAppExit: '(app) => {process.send("the big exit")}'
     }, options)
@@ -106,7 +106,7 @@ describe('Parameter Function Tests', function () {
 
     // generate the app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onReqStart: '(req, res, next) => {console.log("body: " + JSON.stringify(req.body)); next()}',
       onServerStart: '(app) => {process.send(app.get("params"))}'
@@ -151,7 +151,7 @@ describe('Parameter Function Tests', function () {
 
     // generate the app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onReqBeforeRoute: '(req, res, next) => {console.log("body: " + JSON.stringify(req.body)); next()}',
       onServerStart: '(app) => {process.send(app.get("params"))}'
@@ -196,7 +196,7 @@ describe('Parameter Function Tests', function () {
 
     // generate the app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onReqAfterRoute: '(req, res) => {console.log("Testing after: " + res.Testing)}',
       onServerStart: '(app) => {process.send(app.get("params"))}'
@@ -244,7 +244,7 @@ describe('Parameter Function Tests', function () {
 
     // create the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}'
     }, options)
@@ -280,7 +280,7 @@ describe('Parameter Function Tests', function () {
 
     // create the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}',
       errorPages: {
@@ -325,7 +325,7 @@ describe('Parameter Function Tests', function () {
 
     // create the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("routes"))}',
       checkDependencies: false

--- a/test/publicFolder.js
+++ b/test/publicFolder.js
@@ -42,7 +42,7 @@ describe('Public Folder Tests', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}',
       favicon: 'images/faviconTest.ico'
@@ -92,7 +92,7 @@ describe('Public Folder Tests', function () {
   it('should allow for no favicon with a null paramter', function (done) {
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}',
       favicon: null
@@ -135,7 +135,7 @@ describe('Public Folder Tests', function () {
     let nonExistentWarningBool = false
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}',
       favicon: 'images/nothingHere.ico'
@@ -187,7 +187,7 @@ describe('Public Folder Tests', function () {
 
     // generate the app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}',
       versionedPublic: true

--- a/test/rooseveltTest.js
+++ b/test/rooseveltTest.js
@@ -68,7 +68,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}',
       onServerInit: '(app) => {console.log("Server initialized")}'
@@ -107,7 +107,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerInit: '(app) => {console.log("Server initialized")}'
     }, sOptions)
@@ -143,7 +143,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true
     }, sOptions)
 
@@ -183,7 +183,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true
     }, sOptions)
 
@@ -226,7 +226,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {console.log("server started")}'
     }, sOptions)
@@ -260,7 +260,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {console.log("server started")}'
     }, sOptions)
@@ -295,7 +295,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {console.log("server started")}'
     }, sOptions)
@@ -333,7 +333,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {console.log("server started " + process.pid)}'
     }, sOptions)
@@ -373,7 +373,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}'
     }, sOptions)
@@ -415,7 +415,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}'
     }, sOptions)
@@ -456,7 +456,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate a app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}'
     }, sOptions)
@@ -489,7 +489,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate a app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       localhostOnly: true,
       onServerStart: '(app) => {process.send(app.get("params"))}'
@@ -526,7 +526,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: 'something'
     }, sOptions)
@@ -559,7 +559,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate a app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       localhostOnly: true,
       https: {
@@ -611,7 +611,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}'
     }, sOptions)
@@ -667,7 +667,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       mode: 'development',
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}'
@@ -723,7 +723,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       mode: 'development',
       onServerStart: '(app) => {process.send(app.get("params"))}',
@@ -763,7 +763,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       onServerStart: '(app) => {process.send(app.get("params"))}'
     }, sOptions)
@@ -810,7 +810,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true
     }, sOptions)
 
@@ -844,7 +844,7 @@ describe('Roosevelt.js Tests', function () {
 
     // generate the app.js file
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       https: {
         enable: true,

--- a/test/routing.js
+++ b/test/routing.js
@@ -9,7 +9,7 @@ const roosevelt = require('../roosevelt')
 describe('routing', () => {
   const appDir = path.join(__dirname, 'app/routesTest')
   const appConfig = {
-    appDir: appDir,
+    appDir,
     mode: 'production',
     generateFolderStructure: true,
     logging: {

--- a/test/sourceParams.js
+++ b/test/sourceParams.js
@@ -62,7 +62,7 @@ describe('sourceParams', () => {
 
       // initialize roosevelt
       const app = require('../roosevelt')({
-        appDir: appDir
+        appDir
       })
 
       const appConfig = app.expressApp.get('params')
@@ -136,7 +136,7 @@ describe('sourceParams', () => {
 
       // initialize roosevelt
       const app = require('../roosevelt')({
-        appDir: appDir
+        appDir
       })
 
       const appConfig = app.expressApp.get('params')

--- a/test/viewEngine.js
+++ b/test/viewEngine.js
@@ -34,7 +34,7 @@ describe('view engines', function () {
   it('should render the teddy test page', function (done) {
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       viewEngine: [
         'html: teddy'
@@ -76,7 +76,7 @@ describe('view engines', function () {
   it('should be able to handle multiple viewEngines', function (done) {
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       viewEngine: [
         'html: teddy',
@@ -103,7 +103,7 @@ describe('view engines', function () {
   it('should be able to use view engines that are functions and do not have an __express function', function (done) {
     // generate the test app
     generateTestApp({
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       viewEngine: [
         'jcs: ../test/util/jcsTemplate'
@@ -143,7 +143,7 @@ describe('view engines', function () {
     // generate the test app
     generateTestApp({
       generateFolderStructure: true,
-      appDir: appDir,
+      appDir,
       viewEngine: [
         'html: teddy: blah'
       ],
@@ -178,7 +178,7 @@ describe('view engines', function () {
     // generate the test app
     generateTestApp({
       generateFolderStructure: true,
-      appDir: appDir,
+      appDir,
       viewEngine: [
         'html: teddyza'
       ],
@@ -211,7 +211,7 @@ describe('view engines', function () {
     // generate the test app
     generateTestApp({
       generateFolderStructure: true,
-      appDir: appDir,
+      appDir,
       viewEngine: 'html: teddy',
       onServerStart: '(app) => {process.send(app.get("params"))}'
     }, options)

--- a/test/webpack.js
+++ b/test/webpack.js
@@ -87,7 +87,7 @@ describe('webpack', () => {
         }
       },
       mode: 'production',
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       js: {
         sourceDir: 'js',
@@ -118,7 +118,7 @@ describe('webpack', () => {
       htmlValidator: {
         enable: false
       },
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       js: {
         sourceDir: 'js',
@@ -146,7 +146,7 @@ describe('webpack', () => {
         }
       },
       mode: 'production',
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       js: {
         sourceDir: 'js',
@@ -184,7 +184,7 @@ describe('webpack', () => {
         }
       },
       mode: 'development',
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       htmlValidator: {
         enable: false
@@ -225,7 +225,7 @@ describe('webpack', () => {
         }
       },
       mode: 'development',
-      appDir: appDir,
+      appDir,
       generateFolderStructure: true,
       htmlValidator: {
         enable: false


### PR DESCRIPTION
- Added script to generate self-signed HTTPS certs:
  - `npm run certs-generator`: Generates self-signed HTTPS certs for your app.
    - Default shorthand:
      - `npm run c`
    - Script is short for: `node ./node_modules/roosevelt/lib/scripts/certsGenerator.js`
- Some refactoring.
- Various dependencies updated.