### PR TITLE
0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ## 0.20.0
 
-- Renamed `generateFolderStructure` to `makeBuildArtifacts`.
+- Breaking: Renamed `generateFolderStructure` to `makeBuildArtifacts`.
+- Various dependencies updated.
+  - Breaking: Among them, `formidable` was updated which is a breaking change for any app that takes file uploads as [property names in req.files have been renamed](https://github.com/node-formidable/formidable/blob/master/CHANGELOG.md#200), most notably `file.path` is now `file.filepath` and `file.name` is now `file.originalname`.
 - Removed `checkDependencies`.
 
 ## 0.19.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Next version
 
+- Put your changes here...
+
+## 0.21.0
+
+- Breaking: `htmlMinifier` param renamed and expanded to `html`. You will need to update your Roosevelt config.
+  - Added feature `html.sourcePath`, `html.models`, and `html.output` which lets you generate static HTML pages from the your statics directory by compiling them with a view engine and depositing the output to the public folder at start time.
+- Fixed issue with `symlinks` that would cause symlinking to a file rather than a directory to fail in Windows.
 - Some error message copyediting.
+- Some minor refactoring and documentation fixes.
+- Various dependencies updated.
 
 ## 0.20.1
 

--- a/README.md
+++ b/README.md
@@ -534,15 +534,15 @@ Resolves to:
 
 - `viewEngine`: What templating engine to use, formatted as *[String]* `"fileExtension: nodeModule"`.
 
-- Default: *[String]* `"none"`.
+  - Default: *[String]* `"none"`.
 
-- Will be set to `"html: teddy"` in apps generated with [generator-roosevelt](https://github.com/rooseveltframework/generator-roosevelt).
+  - Will be set to `"html: teddy"` in apps generated with [generator-roosevelt](https://github.com/rooseveltframework/generator-roosevelt).
 
-- Also by default when using the generator, the module [teddy](https://github.com/rooseveltframework/teddy) is marked as a dependency in `package.json`.
+  - Also by default when using the generator, the module [teddy](https://github.com/rooseveltframework/teddy) is marked as a dependency in `package.json`.
 
-- To use multiple templating systems, supply an array of engines to use in the same string format. Each engine you use must also be marked as a dependency in your app's `package.json`. Whichever engine you supply first with this parameter will be considered the default.
+  - To use multiple templating systems, supply an array of engines to use in the same string format. Each engine you use must also be marked as a dependency in your app's `package.json`. Whichever engine you supply first with this parameter will be considered the default.
 
-- Example configuration using multiple templating systems: *[Object]*
+  - Example configuration using multiple templating systems: *[Object]*
 
       ```json
       {
@@ -588,30 +588,56 @@ Resolves to:
 
   - Default: *[String]* `"statics"`.
 
-- `htmlMinifier`: How you want Roosevelt to minify your HTML:
+- `html`: How you want Roosevelt to handle HTML:
 
-  - `enable`: *[Boolean]* Whether or not to minify HTML.
+  - `sourcePath`: Subdirectory within `staticsRoot` where your static HTML files are located. By default this folder will not be made public, but is instead meant to store unminified / unprocessed HTML template source files which will be rendered, minified, and written to the `public` folder when the app is started.
 
-      - Note: Can also be disabled by the `minify` param.
+  - `models`: Data to pass to templates by file path / file name.
+    - Example:
+      ```json
+      {
+        "models": {
+          "index.html": {
+            "some": "data"
+          },
+          "subdirectory/otherFile.html": {
+            "someOther": "data"
+          }
+        }
+      }
+      ```
 
-  - Note: Minification is automatically disabled in development mode.
+  - `output`: Subdirectory within `publicFolder` where parsed and minified HTML files will be written to.
 
-  - `exceptionRoutes`: *[Array]* List of controller routes that will skip minification entirely. Set to `false` to minify all URLs.
+  - `minifier`: How you want Roosevelt to minify your HTML:
 
-  - `options`: *[Object]* Parameters to supply to [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference)'s API.
+    - `enable`: *[Boolean]* Whether or not to minify HTML.
+
+        - Note: Can also be disabled by the `minify` param.
+
+    - Note: Minification is automatically disabled in development mode.
+
+    - `exceptionRoutes`: *[Array]* List of controller routes that will skip minification entirely. Set to `false` to minify all URLs.
+
+    - `options`: *[Object]* Parameters to supply to [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference)'s API.
 
   - Default: *[Object]*
 
       ```json
       {
-        "enable": true,
-        "exceptionRoutes": false,
-        "options": {
-          "removeComments": true,
-          "collapseWhitespace": true,
-          "collapseBooleanAttributes": true,
-          "removeAttributeQuotes": true,
-          "removeEmptyAttributes": true
+        "sourcePath": "pages",
+        "models": {}
+        "output": "",
+        "minifier": {
+          "enable": true,
+          "exceptionRoutes": false,
+          "options": {
+            "removeComments": true,
+            "collapseWhitespace": true,
+            "collapseBooleanAttributes": true,
+            "removeAttributeQuotes": true,
+            "removeEmptyAttributes": true
+          }
         }
       }
       ```
@@ -635,60 +661,60 @@ Resolves to:
   - `minifier`: *[Object]* Params pertaining to CSS minifcation.
 
     - `enable`: *[Boolean]* Whether or not to minify CSS.
-- Note: Can also be disabled by the `minify` param.
+  - Note: Can also be disabled by the `minify` param.
 
-- `options`: *[Object]* Parameters to pass to the CSS minifier [clean-css](https://www.npmjs.com/package/clean-css), a list of which can be found in the [clean-css docs](https://github.com/jakubpawlowicz/clean-css#constructor-options).
+  - `options`: *[Object]* Parameters to pass to the CSS minifier [clean-css](https://www.npmjs.com/package/clean-css), a list of which can be found in the [clean-css docs](https://github.com/jakubpawlowicz/clean-css#constructor-options).
 
-- `allowlist`: Array of CSS files to allowlist for compiling. Leave undefined to compile all files. Supply a `:` character after each file name to delimit an alternate file path and/or file name for the minified file.
+  - `allowlist`: Array of CSS files to allowlist for compiling. Leave undefined to compile all files. Supply a `:` character after each file name to delimit an alternate file path and/or file name for the minified file.
 
-  - Example array member: *[String]* `example.less:example.min.css` (compiles `example.less` into `example.min.css`).
+    - Example array member: *[String]* `example.less:example.min.css` (compiles `example.less` into `example.min.css`).
 
-- `output`: Subdirectory within `publicFolder` where compiled CSS files will be written to.
+  - `output`: Subdirectory within `publicFolder` where compiled CSS files will be written to.
 
-- `versionFile`: If enabled, Roosevelt will create a CSS file which declares a CSS variable containing your app's version number from `package.json`. Enable this option by supplying an object with the member variables `fileName` and `varName`. Versioning your static files is useful for resetting your users' browser cache when you release a new version of your app.
+  - `versionFile`: If enabled, Roosevelt will create a CSS file which declares a CSS variable containing your app's version number from `package.json`. Enable this option by supplying an object with the member variables `fileName` and `varName`. Versioning your static files is useful for resetting your users' browser cache when you release a new version of your app.
 
-  - Default: `null`.
+    - Default: `null`.
 
-  - Example usage (with LESS): *[Object]*
+    - Example usage (with LESS): *[Object]*
+
+        ```json
+          {
+            "fileName": "_version.less",
+            "varName": "appVersion"
+          }
+        ```
+
+    - Assuming the default Roosevelt configuration otherwise, this will result in a file `statics/css/_version.less` with the following content:
+
+        ```less
+          /* do not edit; generated automatically by Roosevelt */ @appVersion: '0.1.0';
+        ```
+
+    - Some things to note:
+
+      - If there is already a file there with that name, this will overwrite it, so be careful!
+
+      - It's generally a good idea to add this file to `.gitignore`, since it is a build artifact.
+
+  - Default: *[Object]*
 
       ```json
         {
-          "fileName": "_version.less",
-          "varName": "appVersion"
+          "sourcePath": "css",
+          "compiler": {
+            "enable" : false,
+            "module": "less",
+            "options": {}
+          },
+          "minifier": {
+            "enable": true,
+            "options": {}
+          },
+          "allowlist": null,
+          "output": "css",
+          "versionFile": null
         }
       ```
-
-  - Assuming the default Roosevelt configuration otherwise, this will result in a file `statics/css/_version.less` with the following content:
-
-      ```less
-        /* do not edit; generated automatically by Roosevelt */ @appVersion: '0.1.0';
-      ```
-
-  - Some things to note:
-
-    - If there is already a file there with that name, this will overwrite it, so be careful!
-
-    - It's generally a good idea to add this file to `.gitignore`, since it is a build artifact.
-
-- Default: *[Object]*
-
-    ```json
-      {
-        "sourcePath": "css",
-        "compiler": {
-          "enable" : false,
-          "module": "less",
-          "options": {}
-        },
-        "minifier": {
-          "enable": true,
-          "options": {}
-        },
-        "allowlist": null,
-        "output": "css",
-        "versionFile": null
-      }
-    ```
 
 - `js`: *[Object]* How you want Roosevelt to handle module bundling and minifying your frontend JS:
 
@@ -848,7 +874,7 @@ Resolves to:
 
   - `minifyOptions`: *[Object]* Parameters to supply to [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference)'s API.
 
-    - Uses the params you set in `htmlMinifier.options` if empty.
+    - Uses the params you set in `html.minifier.options` if empty.
 
   - Default: *[Object]*
 
@@ -1181,8 +1207,10 @@ Roosevelt supplies several variables to Express that you may find handy. Access 
 | `controllersPath`                    | Full path on the file system to where your app's controllers folder is located. |
 | `staticsRoot`                        | Full path on the file system to where your app's statics folder is located. |
 | `publicFolder`                       | Full path on the file system to where your app's public folder is located. |
+| `htmlPath`                           | Full path on the file system to where your app's HTML static page source files are located. |
 | `cssPath`                            | Full path on the file system to where your app's CSS source files are located. |
 | `jsPath`                             | Full path on the file system to where your app's JS source files are located. |
+| `htmlRenderedOutput`                 | Full path on the file system to where your app's rendered and minified staic HTML files are located. |
 | `cssCompiledOutput`                  | Full path on the file system to where your app's minified CSS files are located. |
 | `clientViewsBundledOutput`           | Full path on the file system to where your app's client-exposed views folder is located. |
 | `env`                                | Either `development` or `production`.                        |

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -66,14 +66,19 @@
   },
   "routePrefix": null,
   "staticsRoot": "statics",
-  "htmlMinifier": {
-    "enable": true,
-    "exceptionRoutes": false,
-    "options": {
-      "collapseWhitespace": true,
-      "collapseBooleanAttributes": true,
-      "removeAttributeQuotes": true,
-      "removeEmptyAttributes": true
+  "html": {
+    "sourcePath": "pages",
+    "models": {},
+    "output": "",
+    "minifier": {
+      "enable": true,
+      "exceptionRoutes": false,
+      "options": {
+        "collapseWhitespace": true,
+        "collapseBooleanAttributes": true,
+        "removeAttributeQuotes": true,
+        "removeEmptyAttributes": true
+      }
     }
   },
   "css": {

--- a/lib/generateSymlinks.js
+++ b/lib/generateSymlinks.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra')
 const path = require('path')
+const process = require('process')
 
 module.exports = app => {
   const params = app.get('params')
@@ -27,10 +28,10 @@ module.exports = app => {
             logger.error(`Symlink destination "${dest}" is already a file that exists. Skipping symlink creation.`)
           }
         } else {
-          if (fs.lstatSync(source).isDirectory()) {
-            fs.ensureSymlinkSync(source, dest, 'junction')
+          if (process.platform === 'win32' && !fs.lstatSync(source).isDirectory()) {
+            fs.ensureLinkSync(source, dest)
           } else {
-            fs.ensureSymlinkSync(source, dest)
+            fs.ensureSymlinkSync(source, dest, 'junction')
           }
           logger.info('📁', `${appName} making new symlink `.cyan + `${dest}`.yellow + (' pointing to ').cyan + `${source}`.yellow)
         }

--- a/lib/generateSymlinks.js
+++ b/lib/generateSymlinks.js
@@ -6,10 +6,9 @@ module.exports = app => {
   const appName = app.get('appName')
   const fsr = require('./tools/fsr')(app)
   const logger = app.get('logger')
-  const publicDir = params.publicFolder
 
   // generate public and statics directories
-  fsr.ensureDirSync(publicDir)
+  fsr.ensureDirSync(params.publicFolder)
   fsr.ensureDirSync(params.staticsRoot)
 
   // process symlinks
@@ -28,7 +27,11 @@ module.exports = app => {
             logger.error(`Symlink destination "${dest}" is already a file that exists. Skipping symlink creation.`)
           }
         } else {
-          fs.ensureSymlinkSync(source, dest, 'junction')
+          if (fs.lstatSync(source).isDirectory()) {
+            fs.ensureSymlinkSync(source, dest, 'junction')
+          } else {
+            fs.ensureSymlinkSync(source, dest)
+          }
           logger.info('📁', `${appName} making new symlink `.cyan + `${dest}`.yellow + (' pointing to ').cyan + `${source}`.yellow)
         }
       } else {

--- a/lib/htmlMinifier.js
+++ b/lib/htmlMinifier.js
@@ -1,7 +1,7 @@
 // html minifier
 
 module.exports = function (app) {
-  const params = app.get('params').htmlMinifier
+  const params = app.get('params').html.minifier
   const options = params.options
   const minify = require('html-minifier').minify
 

--- a/lib/preprocessStaticPages.js
+++ b/lib/preprocessStaticPages.js
@@ -1,0 +1,97 @@
+// static page preprocessor
+
+require('@colors/colors')
+
+const fs = require('fs-extra')
+const path = require('path')
+const klawSync = require('klaw-sync')
+const gitignoreScanner = require('./tools/gitignoreScanner')
+
+module.exports = (app, callback) => {
+  const params = app.get('params')
+  const appName = app.get('appName')
+  const htmlPath = app.get('htmlPath')
+  const htmlRenderedOutput = app.get('htmlRenderedOutput')
+  const htmlMinifier = require('html-minifier').minify
+  const minifyOptions = app.get('params').html.minifier.options
+  const logger = app.get('logger')
+  const fsr = require('./tools/fsr')(app)
+  const promises = []
+  const gitignoreFiles = gitignoreScanner(path.join(app.get('appDir'), '.gitignore'))
+
+  // skip parsing static pages if feature is disabled or makeBuildArtifacts is false
+  if (!params.html.sourcePath || !params.makeBuildArtifacts) {
+    callback()
+    return
+  }
+
+  // generate html source/output directories
+  fsr.ensureDirSync(htmlPath)
+  fsr.ensureDirSync(htmlRenderedOutput)
+
+  const htmlFiles = klawSync(htmlPath)
+
+  // process each html file
+  for (let file of htmlFiles) {
+    // handle cases where file is an object provided by klaw
+    file = file.path || file
+
+    // filter out irrelevant files
+    if (file !== '.' && file !== '..' && !gitignoreFiles.includes(path.basename(file)) && !gitignoreFiles.includes(file) && !fs.lstatSync(file).isDirectory()) {
+      // generate a promise for each file
+      promises.push(
+        new Promise((resolve, reject) => {
+          (async () => {
+            let extension = file.split('.')
+            extension = extension[extension.length - 1]
+            const renderer = app.get('view: ' + extension)
+            if (!renderer) {
+              logger.error(`${appName} failed to parse ${file}. There is no view engine for file type "${extension}" registered with the app.`)
+              resolve()
+            } else {
+              try {
+                const modelData = app.get('htmlModels')[path.normalize(file.replace(app.get('htmlPath') + '/', ''))]
+                const model = modelData || {}
+                let newHtml = renderer(file, model)
+
+                // minify the html if minification is enabled
+                if (params.minify && params.html.minifier.enable) {
+                  newHtml = htmlMinifier(newHtml, minifyOptions)
+                }
+
+                // construct destination for rendered html
+                const { name, dir } = path.parse(file)
+                let content
+                const outpath = path.join(htmlRenderedOutput, dir.replace(htmlPath, ''), `${name}.html`)
+
+                // check if html file already exists
+                if (fsr.fileExists(outpath)) {
+                  content = fs.readFileSync(outpath, 'utf8')
+                }
+
+                // check existing file for matching content before writing
+                if (newHtml !== '' && (!content || content !== newHtml)) {
+                  fsr.writeFileSync(outpath, newHtml, ['📝', `${appName} writing new HTML file ${outpath}`.green])
+                }
+                resolve()
+              } catch (e) {
+                logger.error(`${appName} failed to parse ${file}. Please ensure that it is coded correctly.`)
+                logger.error(e)
+                reject(e)
+              }
+            }
+          })()
+        })
+      )
+    }
+  }
+
+  Promise.all(promises)
+    .then(() => {
+      callback()
+    })
+    .catch(err => {
+      logger.error(err)
+      callback()
+    })
+}

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -268,6 +268,50 @@ function configAudit (appDir) {
           }
           break
         }
+        case 'html': {
+          checkTypes(userParam, key, ['object'])
+          const htmlParam = userParam || {}
+          for (const htmlKey of Object.keys(htmlParam)) {
+            keyStack.push(htmlKey)
+            switch (htmlKey) {
+              case 'sourcePath':
+                checkTypes(htmlParam[htmlKey], htmlKey, ['string'])
+                break
+              case 'models':
+                checkTypes(htmlParam[htmlKey], htmlKey, ['object'])
+                break
+              case 'output':
+                checkTypes(htmlParam[htmlKey], htmlKey, ['string', 'null'])
+                break
+              case 'minifier': {
+                checkTypes(htmlParam[htmlKey], htmlKey, ['object'])
+                const htmlMinParam = htmlParam[htmlKey] || {}
+                for (const htmlMinKey of Object.keys(htmlMinParam)) {
+                  keyStack.push(htmlMinKey)
+                  switch (htmlMinKey) {
+                    case 'enable':
+                      checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['boolean'])
+                      break
+                    case 'exceptionRoutes':
+                      checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['array', 'boolean', 'string'])
+                      break
+                    case 'options':
+                      checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['object'])
+                      break
+                    default:
+                      foundExtra(['rooseveltConfig', ...keyStack])
+                  }
+                  keyStack.pop(htmlMinKey)
+                }
+                break
+              }
+              default:
+                foundExtra(['rooseveltConfig', ...keyStack])
+            }
+            keyStack.pop(htmlKey)
+          }
+          break
+        }
         case 'css': {
           checkTypes(userParam, key, ['object'])
           const cssParam = userParam || {}
@@ -378,28 +422,6 @@ function configAudit (appDir) {
                 foundExtra(['rooseveltConfig', ...keyStack])
             }
             keyStack.pop(reloadKey)
-          }
-          break
-        }
-        case 'htmlMinifier': {
-          checkTypes(userParam, key, ['object'])
-          const htmlMinParam = userParam || {}
-          for (const htmlMinKey of Object.keys(htmlMinParam)) {
-            keyStack.push(htmlMinKey)
-            switch (htmlMinKey) {
-              case 'enable':
-                checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['boolean'])
-                break
-              case 'exceptionRoutes':
-                checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['array', 'boolean', 'string'])
-                break
-              case 'options':
-                checkTypes(htmlMinParam[htmlMinKey], htmlMinKey, ['object'])
-                break
-              default:
-                foundExtra(['rooseveltConfig', ...keyStack])
-            }
-            keyStack.pop(htmlMinKey)
           }
           break
         }

--- a/lib/setExpressConfigs.js
+++ b/lib/setExpressConfigs.js
@@ -31,6 +31,7 @@ module.exports = function (app) {
       viewEngine = paramValue[1].trim()
       viewModule = prequire(viewEngine)
       app.set(viewEngine, viewModule)
+      app.set('view: ' + viewExt, (viewModule.__express ? viewModule.__express : viewModule))
       app.engine(viewExt, (viewModule.__express ? viewModule.__express : viewModule))
     } catch (e) {
       if (e.toString().includes('viewEngine')) {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -226,15 +226,26 @@ module.exports = (params, app, appSchema) => {
     staticsRoot: {
       default: defaults.staticsRoot
     },
-    htmlMinifier: {
-      enable: {
-        default: defaults.htmlMinifier.enable
+    html: {
+      sourcePath: {
+        default: defaults.html.sourcePath
       },
-      exceptionRoutes: {
-        default: defaults.htmlMinifier.exceptionRoutes
+      models: {
+        default: defaults.html.models
       },
-      options: {
-        default: defaults.htmlMinifier.options
+      output: {
+        default: defaults.html.output
+      },
+      minifier: {
+        enable: {
+          default: defaults.html.minifier.enable
+        },
+        exceptionRoutes: {
+          default: defaults.html.minifier.exceptionRoutes
+        },
+        options: {
+          default: defaults.html.minifier.options
+        }
       }
     },
     css: {
@@ -366,6 +377,8 @@ module.exports = (params, app, appSchema) => {
   params.staticsRoot = path.join(appDir, params.staticsRoot)
   params.unversionedPublic = path.join(appDir, params.publicFolder)
   params.publicFolder = path.join(params.unversionedPublic, params.versionedPublic ? pkg.version || '' : '')
+  params.html.sourcePath = path.join(params.staticsRoot, params.html.sourcePath)
+  params.html.output = path.join(params.publicFolder, params.html.output)
   params.css.sourcePath = path.join(params.staticsRoot, params.css.sourcePath)
   params.css.output = path.join(params.publicFolder, params.css.output)
   params.js.sourcePath = path.join(params.staticsRoot, params.js.sourcePath)
@@ -509,8 +522,11 @@ module.exports = (params, app, appSchema) => {
 
     // map statics paths
     app.set('staticsRoot', params.staticsRoot)
+    app.set('htmlPath', params.html.sourcePath)
+    app.set('htmlModels', params.html.models)
     app.set('cssPath', params.css.sourcePath)
     app.set('jsPath', params.js.sourcePath)
+    app.set('htmlRenderedOutput', params.html.output)
     app.set('cssCompiledOutput', params.css.output)
     app.set('clientViewsBundledOutput', params.clientViews.output)
     app.set('isomorphicControllersListOutput', params.isomorphicControllers.output)

--- a/lib/viewsBundler.js
+++ b/lib/viewsBundler.js
@@ -29,9 +29,9 @@ module.exports = app => {
   let contents
   let bundleLocation
 
-  // If the clientViews minifyOptions is empty, default back to the htmlMinifier options
+  // If the clientViews minifyOptions is empty, default back to the html.minifier options
   if (Object.keys(minifyOptions).length === 0) {
-    minifyOptions = app.get('params').htmlMinifier.options
+    minifyOptions = app.get('params').html.minifier.options
   }
 
   // Loop through each bundle in the allowlist of the roosevelt configs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "~1.5.0",
@@ -40,7 +40,7 @@
       "devDependencies": {
         "c8": "~7.12.0",
         "codecov": "~3.8.3",
-        "eslint": "~8.20.0",
+        "eslint": "~8.21.0",
         "eslint-plugin-mocha": "~10.1.0",
         "less": "~4.1.3",
         "mocha": "~10.0.0",
@@ -254,9 +254,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
+      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -289,6 +289,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/@humanwhocodes/gitignore-to-minimatch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
+      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
@@ -355,6 +365,41 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@sidvind/better-ajv-errors": {
@@ -457,9 +502,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
-      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
+      "version": "18.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
+      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -816,6 +861,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/array.prototype.flat": {
@@ -1564,6 +1618,18 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1582,9 +1648,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.206",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.206.tgz",
-      "integrity": "sha512-h+Fadt1gIaQ06JaIiyqPsBjJ08fV5Q7md+V8bUvQW/9OvXfL2LRICTz2EcnnCP7QzrFTS6/27MRV6Bl9Yn97zA=="
+      "version": "1.4.208",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.208.tgz",
+      "integrity": "sha512-diMr4t69FigAGUk2KovP0bygEtN/9AkqEVkzjEp0cu+zFFbZMVvwACpTTfuj1mAmFR5kNoSW8wGKDFWIvmThiQ=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1708,9 +1774,9 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "hasInstallScript": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
@@ -1786,13 +1852,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
-      "integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
+      "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.0",
-        "@humanwhocodes/config-array": "^0.9.2",
+        "@humanwhocodes/config-array": "^0.10.4",
+        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -1802,14 +1869,17 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.2",
+        "espree": "^9.3.3",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
+        "globby": "^11.1.0",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -2298,16 +2368,19 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
+      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
       "dependencies": {
-        "acorn": "^8.7.1",
+        "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esprima": {
@@ -2529,6 +2602,34 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2560,6 +2661,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fecha": {
       "version": "4.2.3",
@@ -2937,10 +3047,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -4071,6 +4207,15 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/method-override": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/method-override/-/method-override-3.0.0.tgz",
@@ -4099,6 +4244,19 @@
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -4885,6 +5043,15 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5099,10 +5266,30 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/rambda": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.1.4.tgz",
-      "integrity": "sha512-bPK8sSiVHIC7CqdWga8R+hRi5hfc4hK6S01lZW4KrLwSNryQoKaCOJA9GNiF20J7Nbe1vejRfR37/ASQXFL5EA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.2.0.tgz",
+      "integrity": "sha512-xW2ZcQh+AtRHdIN0RUix+gAwyfAeMBZA6SnLSblw1+YRqUx+eV4Eppg/ayDdrvSs6KegZYHYtSF6+I86Z5Owqg==",
       "dev": true
     },
     "node_modules/randombytes": {
@@ -5392,6 +5579,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -5442,6 +5639,29 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/kethinov"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -5679,6 +5899,15 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/source-configs": {
       "version": "0.3.6",
@@ -7004,9 +7233,9 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
-      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
+      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -7030,6 +7259,12 @@
           "dev": true
         }
       }
+    },
+    "@humanwhocodes/gitignore-to-minimatch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
+      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+      "dev": true
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
@@ -7084,6 +7319,32 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
       }
     },
     "@sidvind/better-ajv-errors": {
@@ -7177,9 +7438,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
-      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
+      "version": "18.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
+      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -7479,6 +7740,12 @@
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
     },
     "array.prototype.flat": {
       "version": "1.3.0",
@@ -8039,6 +8306,15 @@
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
     },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -8054,9 +8330,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.4.206",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.206.tgz",
-      "integrity": "sha512-h+Fadt1gIaQ06JaIiyqPsBjJ08fV5Q7md+V8bUvQW/9OvXfL2LRICTz2EcnnCP7QzrFTS6/27MRV6Bl9Yn97zA=="
+      "version": "1.4.208",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.208.tgz",
+      "integrity": "sha512-diMr4t69FigAGUk2KovP0bygEtN/9AkqEVkzjEp0cu+zFFbZMVvwACpTTfuj1mAmFR5kNoSW8wGKDFWIvmThiQ=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -8159,9 +8435,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.61",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
-      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "requires": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -8224,13 +8500,14 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
-      "integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
+      "integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.0",
-        "@humanwhocodes/config-array": "^0.9.2",
+        "@humanwhocodes/config-array": "^0.10.4",
+        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -8240,14 +8517,17 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.2",
+        "espree": "^9.3.3",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
+        "globby": "^11.1.0",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -8593,11 +8873,11 @@
       }
     },
     "espree": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
-      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
+      "integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
       "requires": {
-        "acorn": "^8.7.1",
+        "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       }
@@ -8766,6 +9046,30 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -8798,6 +9102,15 @@
           "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
           "dev": true
         }
+      }
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
       }
     },
     "fecha": {
@@ -9074,10 +9387,30 @@
         "type-fest": "^0.20.2"
       }
     },
+    "globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
     },
     "has": {
       "version": "1.0.3",
@@ -9907,6 +10240,12 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "method-override": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/method-override/-/method-override-3.0.0.tgz",
@@ -9932,6 +10271,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
     },
     "mime": {
       "version": "1.6.0",
@@ -10528,6 +10877,12 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -10689,10 +11044,16 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
     "rambda": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.1.4.tgz",
-      "integrity": "sha512-bPK8sSiVHIC7CqdWga8R+hRi5hfc4hK6S01lZW4KrLwSNryQoKaCOJA9GNiF20J7Nbe1vejRfR37/ASQXFL5EA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.2.0.tgz",
+      "integrity": "sha512-xW2ZcQh+AtRHdIN0RUix+gAwyfAeMBZA6SnLSblw1+YRqUx+eV4Eppg/ayDdrvSs6KegZYHYtSF6+I86Z5Owqg==",
       "dev": true
     },
     "randombytes": {
@@ -10914,6 +11275,12 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -10947,6 +11314,15 @@
         "@colors/colors": "~1.5.0",
         "node-emoji": "~1.11.0",
         "winston": "~3.6.0"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "safe-buffer": {
@@ -11143,6 +11519,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "source-configs": {
       "version": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.20.1",
+  "version": "0.21.0",
   "files": [
     "defaultErrorPages",
     "lib",
@@ -54,7 +54,7 @@
   "devDependencies": {
     "c8": "~7.12.0",
     "codecov": "~3.8.3",
-    "eslint": "~8.20.0",
+    "eslint": "~8.21.0",
     "eslint-plugin-mocha": "~10.1.0",
     "less": "~4.1.3",
     "mocha": "~10.0.0",

--- a/test/configAuditor.js
+++ b/test/configAuditor.js
@@ -72,7 +72,6 @@ describe('config auditor', () => {
     pkgJson.rooseveltConfig.css.extraParam = true
     pkgJson.rooseveltConfig.errorPages.extraParam = true
     pkgJson.rooseveltConfig.frontendReload.extraParam = true
-    pkgJson.rooseveltConfig.htmlMinifier.extraParam = true
     pkgJson.rooseveltConfig.htmlValidator.extraParam = true
     pkgJson.rooseveltConfig.logging.extraParam = true
     pkgJson.rooseveltConfig.js.extraParam = true
@@ -93,7 +92,6 @@ describe('config auditor', () => {
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.css,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.errorPages,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.frontendReload,'))
-    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlMinifier,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.logging,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js,'))
@@ -139,7 +137,6 @@ describe('config auditor', () => {
     configFile.css.extraParam = true
     configFile.errorPages.extraParam = true
     configFile.frontendReload.extraParam = true
-    configFile.htmlMinifier.extraParam = true
     configFile.htmlValidator.extraParam = true
     configFile.logging.extraParam = true
     configFile.js.extraParam = true
@@ -160,7 +157,6 @@ describe('config auditor', () => {
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.css,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.errorPages,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.frontendReload,'))
-    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlMinifier,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.logging,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js,'))

--- a/test/frontendReload.js
+++ b/test/frontendReload.js
@@ -160,7 +160,7 @@ describe('frontend reload', () => {
     assert(res.text.includes('<script src=\'/reloadHttp/reload.js\'></script>'))
   })
 
-  it('should no start reload in prod mode', async () => {
+  it('should not start reload in prod mode', async () => {
     // configure and start roosevelt
     const app = await startRoosevelt({
       ...config,
@@ -179,7 +179,7 @@ describe('frontend reload', () => {
     assert(app.get('reloadHttpServer') === undefined)
   })
 
-  it('should no start reload when disabled', async () => {
+  it('should not start reload when disabled', async () => {
     // configure and start roosevelt
     const app = await startRoosevelt({
       ...config,

--- a/test/htmlMinify.js
+++ b/test/htmlMinify.js
@@ -24,15 +24,17 @@ describe('HTML Minification Tests', function () {
     makeBuildArtifacts: true,
     viewEngine: 'html:teddy',
     hostPublic: false, // this line gives us free coverage of an unrelated warning
-    htmlMinifier: {
-      enable: true,
-      exceptionRoutes: false,
-      options: {
-        removeComments: true,
-        collapseWhitespace: true,
-        collapseBooleanAttributes: true,
-        removeAttributeQuotes: true,
-        removeEmptyAttributes: true
+    html: {
+      minifier: {
+        enable: true,
+        exceptionRoutes: false,
+        options: {
+          removeComments: true,
+          collapseWhitespace: true,
+          collapseBooleanAttributes: true,
+          removeAttributeQuotes: true,
+          removeEmptyAttributes: true
+        }
       }
     }
   }
@@ -76,7 +78,7 @@ describe('HTML Minification Tests', function () {
           if (err) {
             assert.fail(err.message)
           } else {
-            const testMinify = minify(res.text, appConfig.htmlMinifier.options)
+            const testMinify = minify(res.text, appConfig.html.minifier.options)
             assert.strictEqual(testMinify, res.text)
           }
           done()
@@ -101,7 +103,7 @@ describe('HTML Minification Tests', function () {
           if (err) {
             assert.fail(err.message)
           } else {
-            const testMinify = minify(res.text, appConfig.htmlMinifier.options)
+            const testMinify = minify(res.text, appConfig.html.minifier.options)
             assert.strictEqual(testMinify, res.text)
           }
           done()
@@ -109,10 +111,10 @@ describe('HTML Minification Tests', function () {
     }
   })
 
-  it('should not minify HTML when "htmlMinifier.enable" param is set to false', function (done) {
+  it('should not minify HTML when "html.minifier.enable" param is set to false', function (done) {
     // copy root config and disable HTML minifier
     const config = JSON.parse(JSON.stringify(appConfig))
-    config.htmlMinifier.enable = false
+    config.html.minifier.enable = false
 
     // initialize test app
     app = roosevelt({
@@ -130,7 +132,7 @@ describe('HTML Minification Tests', function () {
           if (err) {
             assert.fail(err.message)
           } else {
-            const testMinify = minify(res.text, config.htmlMinifier.options)
+            const testMinify = minify(res.text, config.html.minifier.options)
             assert.notStrictEqual(testMinify, res.text)
           }
           done()
@@ -159,7 +161,7 @@ describe('HTML Minification Tests', function () {
           if (err) {
             assert.fail(err.message)
           } else {
-            const testMinify = minify(res.text, config.htmlMinifier.options)
+            const testMinify = minify(res.text, config.html.minifier.options)
             assert.notStrictEqual(testMinify, res.text)
           }
           done()
@@ -170,7 +172,7 @@ describe('HTML Minification Tests', function () {
   it('should not minify HTML when requesting exceptionRoutes (string format)', function (done) {
     // copy root config and set exceptionRoutes as string
     const config = JSON.parse(JSON.stringify(appConfig))
-    config.htmlMinifier.exceptionRoutes = '/minify'
+    config.html.minifier.exceptionRoutes = '/minify'
 
     // initialize test app
     app = roosevelt({
@@ -188,7 +190,7 @@ describe('HTML Minification Tests', function () {
           if (err) {
             assert.fail(err.message)
           } else {
-            const testMinify = minify(res.text, config.htmlMinifier.options)
+            const testMinify = minify(res.text, config.html.minifier.options)
             assert.notStrictEqual(testMinify, res.text)
 
             // ensure minification is only disabled on the exceptionRoutes by testing another URL
@@ -204,7 +206,7 @@ describe('HTML Minification Tests', function () {
           if (err) {
             assert.fail(err.message)
           } else {
-            const testMinify = minify(res.text, config.htmlMinifier.options)
+            const testMinify = minify(res.text, config.html.minifier.options)
             assert.strictEqual(testMinify, res.text)
           }
           done()
@@ -215,7 +217,7 @@ describe('HTML Minification Tests', function () {
   it('should not minify HTML when requesting exceptionRoutes (array format)', function (done) {
     // copy root config and set exceptionRoutes as array
     const config = JSON.parse(JSON.stringify(appConfig))
-    config.htmlMinifier.exceptionRoutes = ['/minify']
+    config.html.minifier.exceptionRoutes = ['/minify']
 
     // initialize test app
     app = roosevelt({
@@ -233,7 +235,7 @@ describe('HTML Minification Tests', function () {
           if (err) {
             assert.fail(err.message)
           } else {
-            const testMinify = minify(res.text, config.htmlMinifier.options)
+            const testMinify = minify(res.text, config.html.minifier.options)
             assert.notStrictEqual(testMinify, res.text)
 
             // ensure minification is only disabled on the exceptionRoutes by testing another URL
@@ -249,7 +251,7 @@ describe('HTML Minification Tests', function () {
           if (err) {
             assert.fail(err.message)
           } else {
-            const testMinify = minify(res.text, config.htmlMinifier.options)
+            const testMinify = minify(res.text, config.html.minifier.options)
             assert.strictEqual(testMinify, res.text)
           }
           done()

--- a/test/sourceParams.js
+++ b/test/sourceParams.js
@@ -70,6 +70,8 @@ describe('sourceParams', () => {
       // do some param post-processing that matches what we expect from roosevelt
       pkg.rooseveltConfig.staticsRoot = path.join(appDir, pkg.rooseveltConfig.staticsRoot)
       pkg.rooseveltConfig.publicFolder = (path.join(appDir, pkg.rooseveltConfig.publicFolder))
+      pkg.rooseveltConfig.html.sourcePath = path.join(pkg.rooseveltConfig.staticsRoot, pkg.rooseveltConfig.html.sourcePath)
+      pkg.rooseveltConfig.html.output = path.join(pkg.rooseveltConfig.publicFolder, pkg.rooseveltConfig.html.output)
       pkg.rooseveltConfig.css.sourcePath = path.join(pkg.rooseveltConfig.staticsRoot, pkg.rooseveltConfig.css.sourcePath)
       pkg.rooseveltConfig.css.output = path.join(pkg.rooseveltConfig.publicFolder, pkg.rooseveltConfig.css.output)
       pkg.rooseveltConfig.js.sourcePath = path.join(pkg.rooseveltConfig.staticsRoot, pkg.rooseveltConfig.js.sourcePath)
@@ -102,6 +104,8 @@ describe('sourceParams', () => {
       // do some param post-processing that matches what we expect from roosevelt
       config.staticsRoot = path.join(config.appDir, config.staticsRoot)
       config.publicFolder = (path.join(config.appDir, config.publicFolder))
+      config.html.sourcePath = path.join(config.staticsRoot, config.html.sourcePath)
+      config.html.output = path.join(config.publicFolder, config.html.output)
       config.css.sourcePath = path.join(config.staticsRoot, config.css.sourcePath)
       config.css.output = path.join(config.publicFolder, config.css.output)
       config.js.sourcePath = path.join(config.staticsRoot, config.js.sourcePath)
@@ -144,6 +148,8 @@ describe('sourceParams', () => {
       // do some param post-processing that matches what we expect from roosevelt
       configJson.staticsRoot = path.join(appDir, configJson.staticsRoot)
       configJson.publicFolder = (path.join(appDir, configJson.publicFolder))
+      configJson.html.sourcePath = path.join(configJson.staticsRoot, configJson.html.sourcePath)
+      configJson.html.output = path.join(configJson.publicFolder, configJson.html.output)
       configJson.css.sourcePath = path.join(configJson.staticsRoot, configJson.css.sourcePath)
       configJson.css.output = path.join(configJson.publicFolder, configJson.css.output)
       configJson.js.sourcePath = path.join(configJson.staticsRoot, configJson.js.sourcePath)

--- a/test/util/sampleConfig.json
+++ b/test/util/sampleConfig.json
@@ -71,10 +71,15 @@
     "serviceUnavailable": "value"
   },
   "staticsRoot": "value",
-  "htmlMinifier": {
-    "enable": "value",
-    "exceptionRoutes": "value",
-    "options": "value"
+  "html": {
+    "sourcePath": "pages",
+    "models": {},
+    "output": "",
+    "minifier": {
+      "enable": "value",
+      "exceptionRoutes": "value",
+      "options": "value"
+    }
   },
   "css": {
     "sourcePath": "value",


### PR DESCRIPTION
- Breaking: `htmlMinifier` param renamed and expanded to `html`. You will need to update your Roosevelt config.
  - Added feature `html.sourcePath`, `html.models`, and `html.output` which lets you generate static HTML pages from the your statics directory by compiling them with a view engine and depositing the output to the public folder at start time.
- Fixed issue with `symlinks` that would cause symlinking to a file rather than a directory to fail in Windows.
- Some error message copyediting.
- Some minor refactoring and documentation fixes.
- Various dependencies updated.