### PR TITLE
0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Put your changes here...
 
+## 0.21.2
+
+- Fixed bug where the config auditor would complain about the `makeBuildArtifacts` param being set to string.
+- Various dependencies updated.
+
 ## 0.21.1
 
 - Static site generator can now be supplied models by file instead of by configuration. If model data is not supplied by configuration, Roosevelt will try to automatically load a model from a JS file with the same name alongside the template if it exists instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 0.21.2
 
 - Fixed bug where the config auditor would complain about the `makeBuildArtifacts` param being set to string.
+- Static site generator will now run the HTML validator against rendered templates in dev mode only.
 - Various dependencies updated.
 
 ## 0.21.1

--- a/README.md
+++ b/README.md
@@ -767,48 +767,48 @@ Resolves to:
           ]
           ```
 
-          - Webpack bundle example declaring one bundle only used in `dev` mode:
+        - Webpack bundle example declaring one bundle only used in `dev` mode:
 
-              ```json
-              [
-                {
-                  "env": "dev",
-                  "config": {
-                    "entry": "${js.sourcePath}/main.js",
-                    "output": {
-                      "path": "${publicFolder}/js",
-                      "filename": "bundle.js"
-                    }
+            ```json
+            [
+              {
+                "env": "dev",
+                "config": {
+                  "entry": "${js.sourcePath}/main.js",
+                  "output": {
+                    "path": "${publicFolder}/js",
+                    "filename": "bundle.js"
                   }
                 }
-              ]
-              ```
+              }
+            ]
+            ```
 
-          - Webpack bundle example declaring multiple bundles:
+        - Webpack bundle example declaring multiple bundles:
 
-              ```json
-              [
-                {
-                  "config": {
-                    "entry": "${js.sourcePath}/main.js",
-                    "output": {
-                      "path": "${publicFolder}/js",
-                      "filename": "bundle.js"
-                    }
+            ```json
+            [
+              {
+                "config": {
+                  "entry": "${js.sourcePath}/main.js",
+                  "output": {
+                    "path": "${publicFolder}/js",
+                    "filename": "bundle.js"
                   }
-                },
-                {
-                  "config": {
-                    "entry": "${js.sourcePath}/moreStuff.js",
-                    "output": {
-                      "path": "${publicFolder}/js",
-                      "filename": "bundle2.js"
-                    }
+                }
+              },
+              {
+                "config": {
+                  "entry": "${js.sourcePath}/moreStuff.js",
+                  "output": {
+                    "path": "${publicFolder}/js",
+                    "filename": "bundle2.js"
                   }
-                },
-                etc...
-              ]
-              ```
+                }
+              },
+              etc...
+            ]
+            ```
 
   - Default: *[Object]*
 

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -165,7 +165,7 @@ function configAudit (appDir) {
           checkTypes(userParam, key, ['null', 'string'])
           break
         case 'makeBuildArtifacts':
-          checkTypes(userParam, key, ['boolean'])
+          checkTypes(userParam, key, ['boolean', 'string'])
           break
         case 'https': {
           checkTypes(userParam, key, ['boolean', 'object'])

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -438,11 +438,6 @@ module.exports = (params, app, appSchema) => {
   // configure logger with params
   const logger = new Logger(params.logging)
 
-  // if we're using Roosevelt as a static site generator, then we're always in dev mode
-  if (params.makeBuildArtifacts === 'staticsOnly') {
-    params.mode = 'development'
-  }
-
   // set mode specific overrides
   if (params.mode === 'production' || params.mode === 'production-proxy') {
     process.env.NODE_ENV = 'production'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "~1.5.0",
@@ -501,9 +501,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
+      "version": "18.6.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
+      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw=="
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -1647,9 +1647,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.211",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
-      "integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A=="
+      "version": "1.4.212",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.212.tgz",
+      "integrity": "sha512-LjQUg1SpLj2GfyaPDVBUHdhmlDU1vDB4f0mJWSGkISoXQrn5/lH3ECPCuo2Bkvf6Y30wO+b69te+rZK/llZmjg=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2579,9 +2579,9 @@
       }
     },
     "node_modules/ext/node_modules/type": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.1.tgz",
-      "integrity": "sha512-rLp+w60+leZDK0J0r1Q+ZVAEoRjBs/qxEeHhfizjG9dHfv0cpfWDPI8U/qiNPQdEw5Tlb+yOo54jnFQw8yGOZA=="
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3892,13 +3892,13 @@
       }
     },
     "node_modules/jsx-ast-utils": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
-      "integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.5",
-        "object.assign": "^4.1.2"
+        "object.assign": "^4.1.3"
       },
       "engines": {
         "node": ">=4.0"
@@ -4704,14 +4704,14 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -7424,9 +7424,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
+      "version": "18.6.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
+      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -8316,9 +8316,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.4.211",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
-      "integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A=="
+      "version": "1.4.212",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.212.tgz",
+      "integrity": "sha512-LjQUg1SpLj2GfyaPDVBUHdhmlDU1vDB4f0mJWSGkISoXQrn5/lH3ECPCuo2Bkvf6Y30wO+b69te+rZK/llZmjg=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -9009,9 +9009,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.7.1.tgz",
-          "integrity": "sha512-rLp+w60+leZDK0J0r1Q+ZVAEoRjBs/qxEeHhfizjG9dHfv0cpfWDPI8U/qiNPQdEw5Tlb+yOo54jnFQw8yGOZA=="
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
         }
       }
     },
@@ -9970,13 +9970,13 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
-      "integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.5",
-        "object.assign": "^4.1.2"
+        "object.assign": "^4.1.3"
       }
     },
     "just-extend": {
@@ -10615,14 +10615,14 @@
       "dev": true
     },
     "object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.21.1",
+  "version": "0.21.2",
   "files": [
     "defaultErrorPages",
     "lib",


### PR DESCRIPTION
- Fixed bug where the config auditor would complain about the `makeBuildArtifacts` param being set to string.
- Static site generator will now run the HTML validator against rendered templates in dev mode only.
- Various dependencies updated.