### PR TITLE
Ensure manual file path processing is OS agnostic

### DIFF
--- a/lib/isomorphicControllersFinder.js
+++ b/lib/isomorphicControllersFinder.js
@@ -16,7 +16,7 @@ module.exports = app => {
     for (const filePath of allFilePaths) {
       const contents = fse.readFileSync(filePath.path, 'utf8')
       if (contents.includes('.isoRequire(')) {
-        fileData += '  require(\'' + filePath.path.replace(app.get('params').appDir + '/', '') + '\')(router)\n'
+        fileData += '  require(\'' + filePath.path.replace(app.get('params').appDir + path.sep, '') + '\')(router)\n'
       }
     }
     fileData += '}'

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -262,7 +262,7 @@ module.exports = (app, callback) => {
               }
             }
             try {
-              const baseFile = file.replace(app.get('params').css.sourcePath + '/', '')
+              const baseFile = file.replace(app.get('params').css.sourcePath + path.sep, '')
               if ((allowlist && allowlist.length > 0 && !wildcardMatch(baseFile, allowlist) && !wildcardMatch(baseFile + ':' + altdest, allowlist))) {
                 // skip this file if it's not on the allowlist
                 // but only if an allowlist exists

--- a/lib/preprocessStaticPages.js
+++ b/lib/preprocessStaticPages.js
@@ -53,7 +53,7 @@ module.exports = (app, callback) => {
         new Promise((resolve, reject) => {
           (async () => {
             try {
-              const baseFile = file.replace(app.get('params').html.sourcePath + '/', '')
+              const baseFile = file.replace(app.get('params').html.sourcePath + path.sep, '')
               if ((allowlist && allowlist.length > 0 && !wildcardMatch(baseFile, allowlist)) || (blocklist && blocklist.length > 0 && wildcardMatch(baseFile, blocklist))) {
                 // skip this file if it's not on the allowlist
                 // but only if an allowlist exists
@@ -78,7 +78,7 @@ module.exports = (app, callback) => {
               if (!fsr.fileExists(modelFile)) {
                 modelFile = file.slice(0, file.length - extension.length) + 'json'
               }
-              modelData = app.get('htmlModels')[path.normalize(file.replace(app.get('htmlPath') + '/', ''))]
+              modelData = app.get('htmlModels')[path.normalize(file.replace(app.get('htmlPath') + path.sep, ''))]
               if (!modelData && fsr.fileExists(modelFile)) {
                 modelData = require(modelFile)
                 if (typeof modelData === 'function') {


### PR DESCRIPTION
This fixes some bugs in windows specifically, most notably the CSS preprocessor which would break on windows when using the default configuration in a newly generated app.