### PR TITLE
0.21.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next version
 
+- Put your changes here...
+
+## 0.21.9
+
+- Fixed frontend reload when https is enabled with self-signed certs.
 - Removed parent-require dependency.
 - Added new `dev_sync.sh` to make writing code for Roosevelt easier. See instructions on how to use it in the README.
 - Various dependencies updated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.21.8",
+      "version": "0.21.9",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.5.0",
@@ -1284,9 +1284,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001485",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001485.tgz",
-      "integrity": "sha512-8aUpZ7sjhlOyiNsg+pgcrTTPUXKh+rg544QYHSvQErljVEKJzvkYkCR/hUFeeVoEfTToUtY9cUKNRC7+c45YkA==",
+      "version": "1.0.30001486",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
+      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6871,9 +6871,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
-      "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
+      "version": "5.17.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.2.tgz",
+      "integrity": "sha512-1D1aGbOF1Mnayq5PvfMc0amAR1y5Z1nrZaGCvI5xsdEfZEVte8okonk02OiaK5fw5hG1GWuuVsakOnpZW8y25A==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.21.8",
+  "version": "0.21.9",
   "files": [
     "defaultErrorPages",
     "lib",

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -477,7 +477,7 @@ module.exports = (params, schema) => {
     } else {
       config.route = '/reloadHttps'
       config.port = params.frontendReload.httpsPort
-      config.forceWss = true
+      config.forceWss = false // lets this work in self-signed cert situations
       config.https = reloadHttpsOptions
     }
 


### PR DESCRIPTION
- Fixed frontend reload when https is enabled with self-signed certs.
- Removed parent-require dependency.
- Added new `dev_sync.sh` to make writing code for Roosevelt easier. See instructions on how to use it in the README.
- Various dependencies updated.