### PR TITLE
Error handling for configuration typos 

### DIFF
--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -566,12 +566,9 @@ module.exports = (params, app, appSchema) => {
 
     for (let id = 0; id < contentArray.length; id++) {
       if (contentArray[id].includes(',')) {
-        // console.log('contains ,')
         extract = contentArray[id].split(',')
       } else {
-        // console.log('contains NO ,')
         extract = (contentArray[id].match(/\${(.*)}/g))
-        // extract = extract.match(/\${(.*)}/).pop()
       }
 
       if (extract.length > 1) {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -7,13 +7,14 @@ const Logger = require('roosevelt-logger')
 const sourceConfigs = require('source-configs')
 const defaults = require('./defaults/config')
 const template = require('es6-template-strings')
+const paramListArray = []
 let pkg
 let pkgConfig
 let configFile
 
 module.exports = (params, app, appSchema) => {
   const appDir = params.appDir
-  const fsr = require('./tools/fsr')()
+  // const fsr = require('./tools/fsr')()
 
   // determine if app has a package.json
   try {
@@ -28,6 +29,10 @@ module.exports = (params, app, appSchema) => {
   // determine if app has a config file
   try {
     configFile = require(path.join(appDir, 'rooseveltConfig.json'))
+    // console.log('*** configFile')
+    // console.log(configFile)
+    // console.log('*** OBJECT VALUES')
+    // console.log(Object.values(configFile))
   } catch (err) {
     if (err.name === 'SyntaxError') {
       console.error(err)
@@ -386,13 +391,19 @@ module.exports = (params, app, appSchema) => {
     }
   }
 
+  // console.log('*** schema:')
+  // console.log(schema)
+  // console.log('*** appSchema:')
+  // console.log(appSchema.rooseveltConfig)
+
   // If a schema is passed in, update any necessary command line flags and environment variables
   if (appSchema !== undefined && appSchema.rooseveltConfig !== undefined) {
     updateFlagsAndEnvVars(schema, appSchema.rooseveltConfig)
   }
 
   params = sourceConfigs(schema, config)
-
+  // console.log('*** params')
+  // console.log(params.js.webpack)
   // resolve path params
   params.staticsRoot = path.join(appDir, params.staticsRoot)
   params.unversionedPublic = path.join(appDir, params.publicFolder)
@@ -409,6 +420,26 @@ module.exports = (params, app, appSchema) => {
   // configure logger with params
   const logger = new Logger(params.logging)
 
+  // const fs = require('fs')
+  // const path = require('path')
+  // const directory = './'
+  // use readdir method to read the files of the direcoty
+
+  // fs.readdir(directory, (err, files) => {
+  //   console.log('*** files ')
+  //   console.log(files)
+  //   files.forEach(file => {
+  //     // get the details of the file
+  //     const fileDetails = fs.lstatSync(path.resolve(directory, file));
+  //     // check if the file is directory
+  //     if (fileDetails.isDirectory()) {
+  //       console.log('Directory: ' + file)
+  //     } else {
+  //       console.log('File: ' + file)
+  //     }
+  //   })
+  // })
+
   // scan for variables in params and resolve them
   ;(function paramVariables (paramSet, paramSource) {
     paramSource = paramSource || params
@@ -417,6 +448,9 @@ module.exports = (params, app, appSchema) => {
     if (paramSet === Object(paramSet)) {
       for (const paramKey in paramSet) {
         const param = paramSet[paramKey]
+
+        // console.log('*** param:')
+        // console.log(param)
 
         // recurse if param value is an object (but not a function)
         if (param === Object(param) && typeof param !== 'function') {
@@ -430,11 +464,14 @@ module.exports = (params, app, appSchema) => {
             sourceParam = path.normalize(sourceParam)
           }
 
-          // check if param exist in the directory
-          // if not, run error for none existent variable
-          if (!fsr.fileExists(sourceParam)) {
-            logger.warn(`WARNING: Config variable ${param} does not exist.`)
+          function getSubstring (str, start, end) {
+            const char2 = str.lastIndexOf(end)
+            const char1 = str.indexOf(start) + 1
+            return str.substring(char1, char2)
           }
+
+          const paramSubstring = getSubstring(param, '{', '}')
+          paramListArray.push(paramSubstring)
 
           // convert number strings into numbers
           if (!isNaN(sourceParam) && !isNaN(parseFloat(sourceParam))) {
@@ -464,6 +501,35 @@ module.exports = (params, app, appSchema) => {
       paramVariables(params)
     }
   })(params)
+
+  const firstDirectoryArray = []
+  const secondDirectoryArray = []
+
+  for (const i in params) {
+    firstDirectoryArray.push(i)
+  }
+
+  for (const id of paramListArray) {
+    if (id.includes('.')) {
+      const firstDirectory = id.split('.')[0]
+      const secondDirectory = id.split('.')[1]
+
+      if (firstDirectoryArray.includes(firstDirectory)) {
+        for (const i in params[firstDirectory]) {
+          secondDirectoryArray.push(i)
+          if (!secondDirectoryArray.includes(secondDirectory)) {
+            logger.warn(`Config variable ${secondDirectory} does not exist.`)
+          }
+        }
+      } else {
+        logger.warn(`Config variable ${firstDirectory} does not exist.`)
+      }
+    } else {
+      if (!firstDirectoryArray.includes(id)) {
+        logger.warn(`Config variable ${id} does not exist.`)
+      }
+    }
+  }
 
   // set mode specific overrides
   if (params.mode === 'production' || params.mode === 'production-proxy') {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -477,6 +477,7 @@ module.exports = (params, app, appSchema) => {
     firstDirectoryArray.push(i)
   }
 
+  // checks if environment variable exist
   for (const id of paramListArray) {
     if (id.includes('.')) {
       const firstDirectory = id.split('.')[0]

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -7,10 +7,10 @@ const Logger = require('roosevelt-logger')
 const sourceConfigs = require('source-configs')
 const defaults = require('./defaults/config')
 const template = require('es6-template-strings')
-const fs = require('fs')
 let pkg
 let pkgConfig
 let configFile
+const contentArray = []
 
 module.exports = (params, app, appSchema) => {
   const appDir = params.appDir
@@ -419,6 +419,9 @@ module.exports = (params, app, appSchema) => {
         if (param === Object(param) && typeof param !== 'function') {
           paramVariables(param, paramSource[paramKey])
         } else if (typeof param === 'string' && /\${.*}/.test(param)) {
+          // pushes all  littoral variables into an array
+          contentArray.push(param)
+
           // run param through template parser
           let sourceParam = template(param, params, { partial: true })
 
@@ -552,38 +555,17 @@ module.exports = (params, app, appSchema) => {
     app.set('publicFolder', params.unversionedPublic)
   }
 
-  // gets config content as a string
-  const scriptContent = fs.readFileSync(path.join(appDir, 'rooseveltConfig.json')).toString('utf8')
-
-  // get all littoral variables from string
-  const pattern = (/\${(.*)}/g)
-  const contentArray = scriptContent.match(pattern)
+  // get all littoral variables from string and checks if they are true
   checkLittoralVariableTypo(contentArray)
 
   // check to see if littoral variables exist
   function checkLittoralVariableTypo (contentArray) {
     let extract
-    const extractList = []
 
-    // pushes all littoral variable into an array, if row contains more then 1  littoral variable, it separates them
-    for (let id = 0; id < contentArray.length; id++) {
-      if (contentArray[id].includes(',')) {
-        extract = contentArray[id].split(',')
-      } else {
-        extract = (contentArray[id].match(/\${(.*)}/g))
-      }
-
-      if (extract.length > 1) {
-        for (let i = 0; i < extract.length; i++) {
-          extractList.push(extract[i].match(/\${(.*)}/g))
-        }
-      } else {
-        extractList.push(extract)
-      }
-    }
     // goes through all  littoral variables and checks if it excist
-    for (const row in extractList) {
-      extract = extractList[row][0].match(/\${(.*)}/).pop()
+    for (const row in contentArray) {
+      extract = contentArray[row].match(/\${(.*)}/).pop()
+
       const ex = objectByDotNotation(params, extract)
       if (!ex) {
         logger.warn(`Config variable ${extract} does not exist.`)

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -29,10 +29,6 @@ module.exports = (params, app, appSchema) => {
   // determine if app has a config file
   try {
     configFile = require(path.join(appDir, 'rooseveltConfig.json'))
-    // console.log('*** configFile')
-    // console.log(configFile)
-    // console.log('*** OBJECT VALUES')
-    // console.log(Object.values(configFile))
   } catch (err) {
     if (err.name === 'SyntaxError') {
       console.error(err)
@@ -391,19 +387,13 @@ module.exports = (params, app, appSchema) => {
     }
   }
 
-  // console.log('*** schema:')
-  // console.log(schema)
-  // console.log('*** appSchema:')
-  // console.log(appSchema.rooseveltConfig)
-
   // If a schema is passed in, update any necessary command line flags and environment variables
   if (appSchema !== undefined && appSchema.rooseveltConfig !== undefined) {
     updateFlagsAndEnvVars(schema, appSchema.rooseveltConfig)
   }
 
   params = sourceConfigs(schema, config)
-  // console.log('*** params')
-  // console.log(params.js.webpack)
+
   // resolve path params
   params.staticsRoot = path.join(appDir, params.staticsRoot)
   params.unversionedPublic = path.join(appDir, params.publicFolder)
@@ -420,26 +410,6 @@ module.exports = (params, app, appSchema) => {
   // configure logger with params
   const logger = new Logger(params.logging)
 
-  // const fs = require('fs')
-  // const path = require('path')
-  // const directory = './'
-  // use readdir method to read the files of the direcoty
-
-  // fs.readdir(directory, (err, files) => {
-  //   console.log('*** files ')
-  //   console.log(files)
-  //   files.forEach(file => {
-  //     // get the details of the file
-  //     const fileDetails = fs.lstatSync(path.resolve(directory, file));
-  //     // check if the file is directory
-  //     if (fileDetails.isDirectory()) {
-  //       console.log('Directory: ' + file)
-  //     } else {
-  //       console.log('File: ' + file)
-  //     }
-  //   })
-  // })
-
   // scan for variables in params and resolve them
   ;(function paramVariables (paramSet, paramSource) {
     paramSource = paramSource || params
@@ -448,9 +418,6 @@ module.exports = (params, app, appSchema) => {
     if (paramSet === Object(paramSet)) {
       for (const paramKey in paramSet) {
         const param = paramSet[paramKey]
-
-        // console.log('*** param:')
-        // console.log(param)
 
         // recurse if param value is an object (but not a function)
         if (param === Object(param) && typeof param !== 'function') {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -7,14 +7,12 @@ const Logger = require('roosevelt-logger')
 const sourceConfigs = require('source-configs')
 const defaults = require('./defaults/config')
 const template = require('es6-template-strings')
-const paramListArray = []
 let pkg
 let pkgConfig
 let configFile
 
 module.exports = (params, app, appSchema) => {
   const appDir = params.appDir
-  // const fsr = require('./tools/fsr')()
 
   // determine if app has a package.json
   try {
@@ -406,12 +404,14 @@ module.exports = (params, app, appSchema) => {
   params.clientViews.output = path.join(params.publicFolder, params.clientViews.output)
   params.isomorphicControllers.output = path.join(params.publicFolder, params.isomorphicControllers.output)
 
-  let passes = 1
+  let passes = 3
+  // let counter = 1
 
   // scan for variables in params and resolve them
   ;(function paramVariables (paramSet, paramSource) {
     paramSource = paramSource || params
-
+    // console.log('*** paramSet 000:')
+    // console.log(paramSet)
     // iterate over param object
     if (paramSet === Object(paramSet)) {
       for (const paramKey in paramSet) {
@@ -429,20 +429,9 @@ module.exports = (params, app, appSchema) => {
             sourceParam = path.normalize(sourceParam)
           }
 
-          function getSubstring (str, start, end) {
-            const char2 = str.lastIndexOf(end)
-            const char1 = str.indexOf(start) + 1
-            return str.substring(char1, char2)
-          }
-
-          const paramSubstring = getSubstring(param, '{', '}')
-          paramListArray.push(paramSubstring)
-
           // convert number strings into numbers
           if (!isNaN(sourceParam) && !isNaN(parseFloat(sourceParam))) {
             sourceParam = parseInt(sourceParam)
-            // convert number strings into numbers
-            return
           }
 
           // convert string booleans into booleans
@@ -469,36 +458,6 @@ module.exports = (params, app, appSchema) => {
 
   // configure logger with params
   const logger = new Logger(params.logging)
-
-  const firstDirectoryArray = []
-  const secondDirectoryArray = []
-
-  for (const i in params) {
-    firstDirectoryArray.push(i)
-  }
-
-  // checks if environment variable exist
-  for (const id of paramListArray) {
-    if (id.includes('.')) {
-      const firstDirectory = id.split('.')[0]
-      const secondDirectory = id.split('.')[1]
-
-      if (firstDirectoryArray.includes(firstDirectory)) {
-        for (const i in params[firstDirectory]) {
-          secondDirectoryArray.push(i)
-          if (!secondDirectoryArray.includes(secondDirectory)) {
-            logger.warn(`Config variable ${id} does not exist.`)
-          }
-        }
-      } else {
-        logger.warn(`Config variable ${id} does not exist.`)
-      }
-    } else {
-      if (!firstDirectoryArray.includes(id)) {
-        logger.warn(`Config variable ${id} does not exist.`)
-      }
-    }
-  }
 
   // set mode specific overrides
   if (params.mode === 'production' || params.mode === 'production-proxy') {
@@ -595,6 +554,59 @@ module.exports = (params, app, appSchema) => {
     app.set('publicFolder', params.unversionedPublic)
   }
 
+  const fs = require('fs-extra')
+
+  // gets config content
+  const scriptContent = fs.readFileSync(path.join(appDir, 'rooseveltConfig.json')).toString('utf8')
+
+  // get letteral variable
+  const pattern = (/"\${(.*)}/gi)
+  const contentArray = scriptContent.match(pattern)
+
+  ;(function getLetteralVariable (contentArray) {
+    let extract
+    const extractList = []
+
+    for (let id = 0; id < contentArray.length; id++) {
+      if (contentArray[id].includes(',')) {
+        // console.log('contains ,')
+        extract = contentArray[id].split(',')
+      } else {
+        // console.log('contains NO ,')
+        extract = (contentArray[id].match(/\${(.*)}/g))
+        // extract = extract.match(/\${(.*)}/).pop()
+      }
+
+      if (extract.length > 1) {
+        for (let i = 0; i < extract.length; i++) {
+          extractList.push(extract[i].match(/\${(.*)}/g))
+        }
+      } else {
+        extractList.push(extract)
+      }
+    }
+
+    for (const row in extractList) {
+      extract = extractList[row][0].match(/\${(.*)}/).pop()
+      console.log(`*** extracted string: ${extract}`)
+      // console.log(extract)
+      if (extract.includes('.')) {
+        // let ex = objectByDotNotation(params, extract)
+
+        // if (ex.charAt(0) === '/') {
+        //   // console.log(ex.slice(1, 1))
+        //   // ex = ex.replace(/^\//, '')
+        //   console.log(typeof ex)
+        //   console.log(ex)
+        // }
+      } else {
+        if (!params[extract]) {
+          logger.warn(`Config variable ${extract} does not exist.`)
+        }
+      }
+    }
+  })(contentArray)
+
   return params
 }
 
@@ -607,5 +619,18 @@ function updateFlagsAndEnvVars (schema, params) {
     } else if (schema[key] !== undefined) {
       updateFlagsAndEnvVars(schema[key], params[key])
     }
+  }
+}
+
+function objectByDotNotation (obj, dotNotation, value) {
+  if (typeof dotNotation === 'string') {
+    return objectByDotNotation(obj, dotNotation.split('.'), value)
+  } else if (dotNotation.length === 1 && value !== undefined) {
+    obj[dotNotation[0]] = value
+    return obj[dotNotation[0]]
+  } else if (dotNotation.length === 0) {
+    return obj
+  } else {
+    return objectByDotNotation(obj[dotNotation[0]], dotNotation.slice(1), value)
   }
 }

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -10,7 +10,7 @@ const template = require('es6-template-strings')
 let pkg
 let pkgConfig
 let configFile
-const contentArray = []
+const configTemplateLiterals = []
 
 module.exports = (params, app, appSchema) => {
   const appDir = params.appDir
@@ -421,7 +421,7 @@ module.exports = (params, app, appSchema) => {
           paramVariables(param, paramSource[paramKey])
         } else if (typeof param === 'string' && /\${.*}/.test(param)) {
           // pushes all  littoral variables into an array
-          contentArray.push(param)
+          configTemplateLiterals.push(param)
 
           // run param through template parser
           let sourceParam = template(param, params, { partial: true })
@@ -448,6 +448,7 @@ module.exports = (params, app, appSchema) => {
           paramSource[paramKey] = sourceParam
         }
       }
+      return configTemplateLiterals
     }
 
     passes--
@@ -556,21 +557,15 @@ module.exports = (params, app, appSchema) => {
     app.set('publicFolder', params.unversionedPublic)
   }
 
-  // get all littoral variables from string and checks if they are true
-  checkLittoralVariableTypo(contentArray)
+  let extract
 
-  // check to see if littoral variables exist
-  function checkLittoralVariableTypo (contentArray) {
-    let extract
+  // goes through all  littoral variables and checks if it excist
+  for (const row in configTemplateLiterals) {
+    extract = configTemplateLiterals[row].match(/\${(.*)}/).pop()
 
-    // goes through all  littoral variables and checks if it excist
-    for (const row in contentArray) {
-      extract = contentArray[row].match(/\${(.*)}/).pop()
-
-      const ex = objectByDotNotation(params, extract)
-      if (!ex) {
-        logger.warn(`Config variable ${extract} does not exist.`)
-      }
+    const ex = getOrSetObjectByDotNotation(params, extract)
+    if (!ex) {
+      logger.warn(`Config variable ${extract} does not exist.`)
     }
   }
 
@@ -589,16 +584,24 @@ function updateFlagsAndEnvVars (schema, params) {
   }
 }
 
-// Recursively goes through an object using a dot notation string
-function objectByDotNotation (obj, dotNotation, value) {
+// gets or sets an object by dot notation, e.g. thing.nestedThing.furtherNestedThing: two arguments gets, three arguments sets
+function getOrSetObjectByDotNotation (obj, dotNotation, value) {
+  if (!dotNotation || typeof dotNotation === 'boolean' || typeof dotNotation === 'number') {
+    return dotNotation
+  }
   if (typeof dotNotation === 'string') {
-    return objectByDotNotation(obj, dotNotation.split('.'), value)
+    return getOrSetObjectByDotNotation(obj, dotNotation.split('.'), value)
   } else if (dotNotation.length === 1 && value !== undefined) {
     obj[dotNotation[0]] = value
     return obj[dotNotation[0]]
   } else if (dotNotation.length === 0) {
     return obj
+  } else if (dotNotation.length === 1) {
+    if (obj) {
+      return obj[dotNotation[0]]
+    }
+    return false
   } else {
-    return objectByDotNotation(obj[dotNotation[0]], dotNotation.slice(1), value)
+    return getOrSetObjectByDotNotation(obj[dotNotation[0]], dotNotation.slice(1), value)
   }
 }

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -482,10 +482,6 @@ module.exports = (params, app, appSchema) => {
       const firstDirectory = id.split('.')[0]
       const secondDirectory = id.split('.')[1]
 
-      if (id.indexOf('.') === 0) {
-        logger.warn(`Config variable ${id} does not exist.`)
-      }
-
       if (firstDirectoryArray.includes(firstDirectory)) {
         for (const i in params[firstDirectory]) {
           secondDirectoryArray.push(i)

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -420,7 +420,7 @@ module.exports = (params, app, appSchema) => {
         if (param === Object(param) && typeof param !== 'function') {
           paramVariables(param, paramSource[paramKey])
         } else if (typeof param === 'string' && /\${.*}/.test(param)) {
-          // pushes all  littoral variables into an array
+          // pushes all environment variables into an array
           configTemplateLiterals.push(param)
 
           // run param through template parser
@@ -559,7 +559,7 @@ module.exports = (params, app, appSchema) => {
 
   let extract
 
-  // goes through all  littoral variables and checks if it excist
+  // goes through all environment variables and checks if it excist
   for (const row in configTemplateLiterals) {
     extract = configTemplateLiterals[row].match(/\${(.*)}/).pop()
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -7,6 +7,7 @@ const Logger = require('roosevelt-logger')
 const sourceConfigs = require('source-configs')
 const defaults = require('./defaults/config')
 const template = require('es6-template-strings')
+const fs = require('fs-extra')
 let pkg
 let pkgConfig
 let configFile
@@ -554,16 +555,15 @@ module.exports = (params, app, appSchema) => {
     app.set('publicFolder', params.unversionedPublic)
   }
 
-  const fs = require('fs-extra')
-
-  // gets config content
+  // gets config content as a string
   const scriptContent = fs.readFileSync(path.join(appDir, 'rooseveltConfig.json')).toString('utf8')
 
-  // get letteral variable
+  // get all littoral variables from string
   const pattern = (/"\${(.*)}/gi)
   const contentArray = scriptContent.match(pattern)
 
-  ;(function getLetteralVariable (contentArray) {
+  // check to see if littoral variables exist
+  ;(function checkLittoralVariableTypo (contentArray) {
     let extract
     const extractList = []
 
@@ -586,19 +586,16 @@ module.exports = (params, app, appSchema) => {
       }
     }
 
+    // goes through all  littoral variables and removes the '${' and '}' chars
     for (const row in extractList) {
       extract = extractList[row][0].match(/\${(.*)}/).pop()
-      console.log(`*** extracted string: ${extract}`)
-      // console.log(extract)
-      if (extract.includes('.')) {
-        // let ex = objectByDotNotation(params, extract)
 
-        // if (ex.charAt(0) === '/') {
-        //   // console.log(ex.slice(1, 1))
-        //   // ex = ex.replace(/^\//, '')
-        //   console.log(typeof ex)
-        //   console.log(ex)
-        // }
+      // Check if  littoral variables is in dot notation or not, if it is run through if, if its not in  littoral variables run through else
+      if (extract.includes('.')) {
+        const ex = objectByDotNotation(params, extract)
+        if (!ex) {
+          logger.warn(`Config variable ${extract} does not exist.`)
+        }
       } else {
         if (!params[extract]) {
           logger.warn(`Config variable ${extract} does not exist.`)
@@ -622,6 +619,7 @@ function updateFlagsAndEnvVars (schema, params) {
   }
 }
 
+// Recursively goes through an object using a dot notation string
 function objectByDotNotation (obj, dotNotation, value) {
   if (typeof dotNotation === 'string') {
     return objectByDotNotation(obj, dotNotation.split('.'), value)

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -410,6 +410,7 @@ module.exports = (params, app, appSchema) => {
   // scan for variables in params and resolve them
   ;(function paramVariables (paramSet, paramSource) {
     paramSource = paramSource || params
+
     // iterate over param object
     if (paramSet === Object(paramSet)) {
       for (const paramKey in paramSet) {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -564,6 +564,7 @@ module.exports = (params, app, appSchema) => {
     let extract
     const extractList = []
 
+    // pushes all littoral variable into an array, if row contains more then 1  littoral variable, it separates them
     for (let id = 0; id < contentArray.length; id++) {
       if (contentArray[id].includes(',')) {
         extract = contentArray[id].split(',')

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -406,7 +406,7 @@ module.exports = (params, app, appSchema) => {
   params.clientViews.output = path.join(params.publicFolder, params.clientViews.output)
   params.isomorphicControllers.output = path.join(params.publicFolder, params.isomorphicControllers.output)
 
-  let passes = 3
+  let passes = 1
 
   // scan for variables in params and resolve them
   ;(function paramVariables (paramSet, paramSource) {
@@ -482,15 +482,19 @@ module.exports = (params, app, appSchema) => {
       const firstDirectory = id.split('.')[0]
       const secondDirectory = id.split('.')[1]
 
+      if (id.indexOf('.') === 0) {
+        logger.warn(`Config variable ${id} does not exist.`)
+      }
+
       if (firstDirectoryArray.includes(firstDirectory)) {
         for (const i in params[firstDirectory]) {
           secondDirectoryArray.push(i)
           if (!secondDirectoryArray.includes(secondDirectory)) {
-            logger.warn(`Config variable ${secondDirectory} does not exist.`)
+            logger.warn(`Config variable ${id} does not exist.`)
           }
         }
       } else {
-        logger.warn(`Config variable ${firstDirectory} does not exist.`)
+        logger.warn(`Config variable ${id} does not exist.`)
       }
     } else {
       if (!firstDirectoryArray.includes(id)) {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -407,8 +407,6 @@ module.exports = (params, app, appSchema) => {
   params.isomorphicControllers.output = path.join(params.publicFolder, params.isomorphicControllers.output)
 
   let passes = 3
-  // configure logger with params
-  const logger = new Logger(params.logging)
 
   // scan for variables in params and resolve them
   ;(function paramVariables (paramSet, paramSource) {
@@ -468,6 +466,8 @@ module.exports = (params, app, appSchema) => {
       paramVariables(params)
     }
   })(params)
+  // configure logger with params
+  const logger = new Logger(params.logging)
 
   const firstDirectoryArray = []
   const secondDirectoryArray = []

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -7,7 +7,7 @@ const Logger = require('roosevelt-logger')
 const sourceConfigs = require('source-configs')
 const defaults = require('./defaults/config')
 const template = require('es6-template-strings')
-const fs = require('fs-extra')
+const fs = require('fs')
 let pkg
 let pkgConfig
 let configFile
@@ -556,11 +556,12 @@ module.exports = (params, app, appSchema) => {
   const scriptContent = fs.readFileSync(path.join(appDir, 'rooseveltConfig.json')).toString('utf8')
 
   // get all littoral variables from string
-  const pattern = (/"\${(.*)}/gi)
+  const pattern = (/\${(.*)}/g)
   const contentArray = scriptContent.match(pattern)
+  checkLittoralVariableTypo(contentArray)
 
   // check to see if littoral variables exist
-  ;(function checkLittoralVariableTypo (contentArray) {
+  function checkLittoralVariableTypo (contentArray) {
     let extract
     const extractList = []
 
@@ -580,24 +581,15 @@ module.exports = (params, app, appSchema) => {
         extractList.push(extract)
       }
     }
-
-    // goes through all  littoral variables and removes the '${' and '}' chars
+    // goes through all  littoral variables and checks if it excist
     for (const row in extractList) {
       extract = extractList[row][0].match(/\${(.*)}/).pop()
-
-      // Check if  littoral variables is in dot notation or not, if it is run through if, if its not in  littoral variables run through else
-      if (extract.includes('.')) {
-        const ex = objectByDotNotation(params, extract)
-        if (!ex) {
-          logger.warn(`Config variable ${extract} does not exist.`)
-        }
-      } else {
-        if (!params[extract]) {
-          logger.warn(`Config variable ${extract} does not exist.`)
-        }
+      const ex = objectByDotNotation(params, extract)
+      if (!ex) {
+        logger.warn(`Config variable ${extract} does not exist.`)
       }
     }
-  })(contentArray)
+  }
 
   return params
 }

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -466,6 +466,7 @@ module.exports = (params, app, appSchema) => {
       paramVariables(params)
     }
   })(params)
+
   // configure logger with params
   const logger = new Logger(params.logging)
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -406,7 +406,7 @@ module.exports = (params, app, appSchema) => {
   params.clientViews.output = path.join(params.publicFolder, params.clientViews.output)
   params.isomorphicControllers.output = path.join(params.publicFolder, params.isomorphicControllers.output)
 
-  let passes = 1
+  let passes = 3
   // configure logger with params
   const logger = new Logger(params.logging)
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -13,6 +13,7 @@ let configFile
 
 module.exports = (params, app, appSchema) => {
   const appDir = params.appDir
+  const fsr = require('./tools/fsr')()
 
   // determine if app has a package.json
   try {
@@ -404,7 +405,9 @@ module.exports = (params, app, appSchema) => {
   params.clientViews.output = path.join(params.publicFolder, params.clientViews.output)
   params.isomorphicControllers.output = path.join(params.publicFolder, params.isomorphicControllers.output)
 
-  let passes = 3
+  let passes = 1
+  // configure logger with params
+  const logger = new Logger(params.logging)
 
   // scan for variables in params and resolve them
   ;(function paramVariables (paramSet, paramSource) {
@@ -427,9 +430,17 @@ module.exports = (params, app, appSchema) => {
             sourceParam = path.normalize(sourceParam)
           }
 
+          // check if param exist in the directory
+          // if not, run error for none existent variable
+          if (!fsr.fileExists(sourceParam)) {
+            logger.warn(`WARNING: Config variable ${param} does not exist.`)
+          }
+
           // convert number strings into numbers
           if (!isNaN(sourceParam) && !isNaN(parseFloat(sourceParam))) {
             sourceParam = parseInt(sourceParam)
+            // convert number strings into numbers
+            return
           }
 
           // convert string booleans into booleans
@@ -453,9 +464,6 @@ module.exports = (params, app, appSchema) => {
       paramVariables(params)
     }
   })(params)
-
-  // configure logger with params
-  const logger = new Logger(params.logging)
 
   // set mode specific overrides
   if (params.mode === 'production' || params.mode === 'production-proxy') {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -559,7 +559,7 @@ module.exports = (params, app, appSchema) => {
 
   let extract
 
-  // goes through all config variables and checks if it exist
+  // goes through all config variables and checks if it exists
   for (const row in configTemplateLiterals) {
     extract = configTemplateLiterals[row].match(/\${(.*)}/).pop()
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -406,13 +406,10 @@ module.exports = (params, app, appSchema) => {
   params.isomorphicControllers.output = path.join(params.publicFolder, params.isomorphicControllers.output)
 
   let passes = 3
-  // let counter = 1
 
   // scan for variables in params and resolve them
   ;(function paramVariables (paramSet, paramSource) {
     paramSource = paramSource || params
-    // console.log('*** paramSet 000:')
-    // console.log(paramSet)
     // iterate over param object
     if (paramSet === Object(paramSet)) {
       for (const paramKey in paramSet) {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -559,7 +559,7 @@ module.exports = (params, app, appSchema) => {
 
   let extract
 
-  // goes through all environment variables and checks if it excist
+  // goes through all config variables and checks if it exist
   for (const row in configTemplateLiterals) {
     extract = configTemplateLiterals[row].match(/\${(.*)}/).pop()
 

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -420,7 +420,7 @@ module.exports = (params, app, appSchema) => {
         if (param === Object(param) && typeof param !== 'function') {
           paramVariables(param, paramSource[paramKey])
         } else if (typeof param === 'string' && /\${.*}/.test(param)) {
-          // pushes all environment variables into an array
+          // pushes all config variables into an array for later checks
           configTemplateLiterals.push(param)
 
           // run param through template parser


### PR DESCRIPTION
You should now get a logger warning that states "Config variable ${envVariable} does not exist", when there is a configuration typo.

#888 