### PR TITLE
0.21.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 0.21.10
 
-- Added `--webpack=verbose` and `--wp=verbose-file` CLI flags to to make it easier to see verbose webpack errors. Available shorthands: `--wp` and `-w`.
+- Added `--webpack=verbose` and `--wp=verbose-file` CLI flags to make it easier to see verbose webpack errors. Available shorthands: `--wp` and `-w`.
 - Added detection of undefined template literal variables (e.g. via typo) in rooseveltConfig.
 - Added more helpful error if starting an app with broken symlinks.
 - Various dependencies updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - Put your changes here...
 
+## 0.21.10
+
+- Added `--webpack=verbose` and `--wp=verbose-file` CLI flags to to make it easier to see verbose webpack errors. Available shorthands: `--wp` and `-w`.
+- Added detection of undefined template literal variables (e.g. via typo) in rooseveltConfig.
+- Added more helpful error if starting an app with broken symlinks.
+- Various dependencies updated.
+
 ## 0.21.9
 
 - Fixed frontend reload when https is enabled with self-signed certs.

--- a/lib/generateSymlinks.js
+++ b/lib/generateSymlinks.js
@@ -36,7 +36,7 @@ module.exports = app => {
             }
             logger.info('📁', `${appName} making new symlink `.cyan + `${dest}`.yellow + (' pointing to ').cyan + `${source}`.yellow)
           } catch (e) {
-            logger.error('It appears your Roosevelt app has been moved/renamed. You may want to delete the `./public` folder to remove the broken symlinks.')
+            logger.error('It appears your Roosevelt app has been moved/renamed. You may want to delete the "./public" folder to remove the broken symlinks.')
           }
         }
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.21.9",
+  "version": "0.21.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.21.9",
+      "version": "0.21.10",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.5.0",
@@ -1279,9 +1279,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001492",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
-      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
+      "version": "1.0.30001494",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001494.tgz",
+      "integrity": "sha512-sY2B5Qyl46ZzfYDegrl8GBCzdawSLT4ThM9b9F+aDYUrAG2zCOyMbd2Tq34mS1g4ZKBfjRlzOohQMxx28x6wJg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1932,9 +1932,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.416",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.416.tgz",
-      "integrity": "sha512-AUYh0XDTb2vrj0rj82jb3P9hHSyzQNdTPYWZIhPdCOui7/vpme7+HTE07BE5jwuqg/34TZ8ktlRz6GImJ4IXjA=="
+      "version": "1.4.419",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.419.tgz",
+      "integrity": "sha512-jdie3RiEgygvDTyS2sgjq71B36q2cDSBfPlwzUyuOrfYTNoYWyBxxjGJV/HAu3A2hB0Y+HesvCVkVAFoCKwCSw=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3525,9 +3525,9 @@
       }
     },
     "node_modules/html-validate": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-7.18.0.tgz",
-      "integrity": "sha512-Ul8tPbrcpcV4XXx8aoWhx9ISRy0uCdhXyOz0MnnXt5IQ7sEyQFJJdY61Oysl8PKjE7JiR7SfLeyISPvQY8oS9Q==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-7.18.1.tgz",
+      "integrity": "sha512-K5jb0h/xAoeR8sJqyR0n/QaKL7rdT88sPCtN+Pvtyn5JUU+nidQe2gBB09WRzPTcQtPXBj4QxBUH5IA2tt8JQg==",
       "dependencies": {
         "@babel/code-frame": "^7.10.0",
         "@html-validate/stylish": "^4.0.1",
@@ -7022,9 +7022,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
       "dev": true
     },
     "node_modules/type": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.21.9",
+  "version": "0.21.10",
   "files": [
     "defaultErrorPages",
     "lib",


### PR DESCRIPTION
- Added `--webpack=verbose` and `--wp=verbose-file` CLI flags to to make it easier to see verbose webpack errors. Available shorthands: `--wp` and `-w`.
- Added detection of undefined template literal variables (e.g. via typo) in rooseveltConfig.
- Added more helpful error if starting an app with broken symlinks.
- Various dependencies updated.