### PR TITLE
0.21.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - Put your changes here...
 
+## 0.21.11
+
+- Added a new `--build` CLI flag that will instruct Roosevelt to just build the build artifacts but not start the server.
+- Added new `onStaticAssetsGenerated` event that is fired when the server finishes init but before the server starts.
+- Fixed an issue that would cause the server to start even when `makeBuildArtifacts` is set to `staticsOnly`. This has the side effect of causing `serverStart()` to revert to the behavior of `init()` if `makeBuildArtifacts` is set to `staticsOnly`.
+- Fixed a bug that would cause roosevelt-router to produce a false negative when detecting teddy.
+- Various dependencies updated.
+
 ## 0.21.10
 
 - Added `--webpack=verbose` and `--wp=verbose-file` CLI flags to make it easier to see verbose webpack errors. Available shorthands: `--wp` and `-w`.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ Roosevelt apps created with the app generator come with the following notable [n
   - Default shorthands:
     - `--dev`
     - `-d`
+- `node app.js --build`: Only runs the build scripts and doesn't start the app.
+  - Default shorthands:
+    - `-b`
 - `node app.js --webpack=verbose`: Enables webpack to print verbose errors to the console. 
   - Default shorthands:
     - `--wp=verbose`
@@ -979,6 +982,8 @@ require('roosevelt')({
 ### Event list
 
 - `onServerInit(app)`: Fired when the server begins starting, prior to any actions taken by Roosevelt. Note: some [Express variables exposed by Roosevelt](https://github.com/rooseveltframework/roosevelt#express-variables-exposed-by-roosevelt) are not available yet during this event.
+  - `app`: The [Express app](http://expressjs.com/api.html#express) created by Roosevelt.
+- `onStaticAssetsGenerated(app)`: Fired when the server finishes init but before the server starts.
   - `app`: The [Express app](http://expressjs.com/api.html#express) created by Roosevelt.
 - `onServerStart(app)`: Fired when the server starts.
   - `app`: The [Express app](http://expressjs.com/api.html#express) created by Roosevelt.

--- a/lib/roosevelt-router.js
+++ b/lib/roosevelt-router.js
@@ -33,7 +33,7 @@ module.exports = (params) => {
   if (!params.onLoad) {
     // use a teddy-specific template loader by default
     params.onLoad = function () {
-      if (this.templatingSystem.teddyConsole) { // check if teddy is loaded
+      if (params.templatingSystem.render && typeof params.templatingSystem.render === 'function' && params.templatingSystem.render('<if hello><p>{hello}</p></if>', { hello: 'world' }) === '<p>world</p>') { // check if teddy is loaded
         for (const key in templateBundle) {
           templatingSystem.setTemplate(key, templateBundle[key])
         }
@@ -47,7 +47,7 @@ module.exports = (params) => {
   }
   if (!params.renderMethod) {
     // use a teddy-specific render method by default
-    if (params.templatingSystem.teddyConsole) { // check if teddy is loaded
+    if (params.templatingSystem.render && typeof params.templatingSystem.render === 'function' && params.templatingSystem.render('<if hello><p>{hello}</p></if>', { hello: 'world' }) === '<p>world</p>') { // check if teddy is loaded
       // replaces entire body tag with the body tag of the new template
       // note: this does not handle partials. it assumes you want to replace the whole page minus the contents of the <head> tag
       params.renderMethod = function (template, model) {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -57,12 +57,15 @@ module.exports = (params, app, appSchema) => {
         params.mode = 'development'
       }
 
-      // handle webpack=verbose, --wp, -p cli flags
+      // handle --build and -b cli flags
+      if (flags.build || flags.b) {
+        params.makeBuildArtifacts = 'staticsOnly'
+      }
+
+      // handle --webpack, --wp, -w cli flags
       if (flags.webpack === 'verbose' || flags.wp === 'verbose' || flags.w === 'verbose') {
         params.js.webpack.verbose = true
       }
-
-      // handle verbose-file, --wf, -f cli flags
       if (flags.webpack === 'verbose-file' || flags.wp === 'verbose-file' || flags.w === 'verbose-file') {
         params.js.webpack.verbose = 'file'
       }
@@ -361,6 +364,9 @@ module.exports = (params, app, appSchema) => {
       }
     },
     onServerInit: {
+      default: {}
+    },
+    onStaticAssetsGenerated: {
       default: {}
     },
     onServerStart: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.21.10",
+  "version": "0.21.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.21.10",
+      "version": "0.21.11",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.5.0",
@@ -18,7 +18,7 @@
         "execa": "7.1.1",
         "express": "4.18.2",
         "express-html-validator": "0.2.1",
-        "formidable": "2.1.1",
+        "formidable": "2.1.2",
         "fs-extra": "11.1.1",
         "helmet": "7.0.0",
         "html-minifier": "4.0.0",
@@ -34,22 +34,22 @@
         "serve-favicon": "2.5.0",
         "source-configs": "0.3.6",
         "toobusy-js": "0.5.1",
-        "webpack": "5.85.0"
+        "webpack": "5.88.0"
       },
       "devDependencies": {
-        "c8": "7.14.0",
+        "c8": "8.0.0",
         "codecov": "3.8.3",
-        "eslint": "8.42.0",
+        "eslint": "8.43.0",
         "eslint-plugin-mocha": "10.1.0",
         "less": "4.1.3",
         "mocha": "10.2.0",
         "proxyquire": "2.1.3",
-        "sass": "1.62.1",
-        "sinon": "15.1.0",
+        "sass": "1.63.6",
+        "sinon": "15.2.0",
         "standard": "17.1.0",
         "stylus": "0.59.0",
         "supertest": "6.3.3",
-        "teddy": "0.6.1"
+        "teddy": "0.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -66,30 +66,30 @@
       "dev": true
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
-      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
+      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.22.3.tgz",
-      "integrity": "sha512-6bdmknScYKmt8I9VjsJuKKGr+TwUb555FTf6tT1P/ANlCjTHCiYLhiQ4X/O7J731w5NOqu8c1aYHEVuOwPz7jA==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.22.5.tgz",
+      "integrity": "sha512-TNPDN6aBFaUox2Lu+H/Y1dKKQgr4ucz/FGyCz67RVYLsBpVpUFf1dDngzg+Od8aqbrqwyztkaZjtWCZEUOT8zA==",
       "dev": true,
       "dependencies": {
         "core-js-pure": "^3.30.2",
@@ -287,18 +287,18 @@
       "dev": true
     },
     "node_modules/@eslint/js": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
-      "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
+      "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@html-validate/stylish": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-4.0.1.tgz",
-      "integrity": "sha512-BBZuKxYAbf9yddzn5eboV3LR9tF0KAJACkxH9+g0C9mhxIInPHtLhsXdDMyhRBY49Ls9TLjAuPKbuSUgLjclBA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-4.1.0.tgz",
+      "integrity": "sha512-f2MOKJ2HVdLxpOOg2jD6hjDTDJic3wpb8/UdDDIic5jTvgfMMPN3PoiNWlqDg/mCzLIj1b/p1hCRx4Kz5lbVjw==",
       "dependencies": {
         "kleur": "^4.0.0"
       },
@@ -533,9 +533,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.2.0.tgz",
-      "integrity": "sha512-OPwQlEdg40HAj5KNF8WW6q2KG4Z+cBCZb3m4ninfTZKaBmbIJodviQsDBoYMPHkOyJJMHnOJo5j2+LKDOhOACg==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.0.tgz",
-      "integrity": "sha512-nbq2mvc/tBrK9zQQuItvjJl++GTN5j06DaPtp3hZCpngmG6Q3xoyEmd0TwZI0gAy/G1X0zhGBbr2imsGFdFV0g==",
+      "version": "8.40.2",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
+      "integrity": "sha512-PRVjQ4Eh9z9pmmtaq8nTjZjQwKFk7YIHIud3lRoKRBgUQjgjRmoGxxGEPXQkF+lH7QkHJRNr5F4aBgYCW0lqpQ==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -617,9 +617,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
-      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ=="
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.2",
@@ -780,9 +780,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1158,9 +1158,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.21.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
-      "integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
+      "version": "4.21.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1176,8 +1176,8 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001489",
-        "electron-to-chromium": "^1.4.411",
+        "caniuse-lite": "^1.0.30001503",
+        "electron-to-chromium": "^1.4.431",
         "node-releases": "^2.0.12",
         "update-browserslist-db": "^1.0.11"
       },
@@ -1211,9 +1211,9 @@
       }
     },
     "node_modules/c8": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-7.14.0.tgz",
-      "integrity": "sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.0.tgz",
+      "integrity": "sha512-XHA5vSfCLglAc0Xt8eLBZMv19lgiBSjnb1FLAQgnwkuhJYEonpilhEB4Ea3jPAbm0FhD6VVJrc0z73jPe7JyGQ==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -1233,7 +1233,7 @@
         "c8": "bin/c8.js"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": ">=12"
       }
     },
     "node_modules/call-bind": {
@@ -1279,9 +1279,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001494",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001494.tgz",
-      "integrity": "sha512-sY2B5Qyl46ZzfYDegrl8GBCzdawSLT4ThM9b9F+aDYUrAG2zCOyMbd2Tq34mS1g4ZKBfjRlzOohQMxx28x6wJg==",
+      "version": "1.0.30001507",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001507.tgz",
+      "integrity": "sha512-SFpUDoSLCaE5XYL2jfqe9ova/pbQHEmbheDf5r4diNwbAgR3qxM9NQtfsiSscjqoya5K7kFcHPUQ+VsUkIJR4A==",
       "funding": [
         {
           "type": "opencollective",
@@ -1692,9 +1692,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.30.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.30.2.tgz",
-      "integrity": "sha512-p/npFUJXXBkCCTIlEGBdghofn00jWG6ZOtdoIXSJmAu2QBvN0IqpZXWweOytcwE6cfx8ZvVUy1vw8zxhe4Y2vg==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.31.0.tgz",
+      "integrity": "sha512-/AnE9Y4OsJZicCzIe97JP5XoPKQJfTuEG43aEVLFJGOJpyqELod+pE6LEl63DfG1Mp8wX97LDaDpy1GmLEUxlg==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -1932,9 +1932,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.419",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.419.tgz",
-      "integrity": "sha512-jdie3RiEgygvDTyS2sgjq71B36q2cDSBfPlwzUyuOrfYTNoYWyBxxjGJV/HAu3A2hB0Y+HesvCVkVAFoCKwCSw=="
+      "version": "1.4.440",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.440.tgz",
+      "integrity": "sha512-r6dCgNpRhPwiWlxbHzZQ/d9swfPaEJGi8ekqRBwQYaR3WmA5VkqQfBWSDDjuJU1ntO+W9tHx8OHV/96Q8e0dVw=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -1955,9 +1955,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.1.tgz",
-      "integrity": "sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -2049,9 +2049,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
-      "integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
+      "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA=="
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.0.1",
@@ -2172,15 +2172,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
-      "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
+      "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.42.0",
+        "@eslint/js": "8.43.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -3091,9 +3091,9 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
-      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
       "dependencies": {
         "dezalgo": "^1.0.4",
         "hexoid": "^1.0.0",
@@ -3248,9 +3248,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.6.tgz",
-      "integrity": "sha512-U/rnDpXJGF414QQQZv5uVsabTVxMSwzS5CH0p3DRCIV6ownl4f7PzGnkGmvlum2wB+9RlJWJZ6ACU1INnBqiPA==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.0.tgz",
+      "integrity": "sha512-AQ1/SB9HH0yCx1jXAT4vmCbTOPe5RQ+kCurjbel5xSCGhebumUv+GJZfa1rEqor3XIViqwSEmlkZCQD43RWrBg==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
@@ -3309,9 +3309,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.2.tgz",
+      "integrity": "sha512-PZOT9g5v2ojiTL7r1xF6plNHLtOeTpSlDI007As2NlA2aYBMfVom17yqa6QzhmDP8QOhn7LjHTg7DFCVSSa6yg==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6021,9 +6021,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
-      "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
+      "version": "1.63.6",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
+      "integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -6044,9 +6044,9 @@
       "dev": true
     },
     "node_modules/schema-utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
-      "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -6072,9 +6072,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6228,13 +6228,13 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sinon": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.1.0.tgz",
-      "integrity": "sha512-cS5FgpDdE9/zx7no8bxROHymSlPLZzq0ChbbLk1DrxBfc+eTeBK3y8nIL+nu/0QeYydhhbLIr7ecHJpywjQaoQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.2.0.tgz",
+      "integrity": "sha512-nPS85arNqwBXaIsFCkolHjGIkFo+Oxu9vbgmBJizLAhqe6P2o3Qmj3KCUoRkfhHtvgDhZdWD3risLHAUJ8npjw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
-        "@sinonjs/fake-timers": "^10.2.0",
+        "@sinonjs/fake-timers": "^10.3.0",
         "@sinonjs/samsam": "^8.0.0",
         "diff": "^5.1.0",
         "nise": "^5.1.4",
@@ -6731,21 +6731,6 @@
         }
       }
     },
-    "node_modules/superagent/node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
-      "dev": true,
-      "dependencies": {
-        "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
     "node_modules/superagent/node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -6826,9 +6811,9 @@
       }
     },
     "node_modules/teddy": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/teddy/-/teddy-0.6.1.tgz",
-      "integrity": "sha512-wJcDP01wtRVqzdiRTW+nHxollCswcAUS4WSLls6Wz6IgltlNGU9SvanfE1rwYVGprcDx306gTto+pd2iH817YQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/teddy/-/teddy-0.6.2.tgz",
+      "integrity": "sha512-0BEuYDILl9N9RXL5PqNXLTW2upgUK+HeCwE3KyBtRzv16w9yPjFIHtoCD/pm/GvfgD2qmLcrIPOHj8Hjdps6JQ==",
       "dev": true,
       "dependencies": {
         "cheerio": "1.0.0-rc.12",
@@ -6859,9 +6844,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.17.7",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.7.tgz",
-      "integrity": "sha512-/bi0Zm2C6VAexlGgLlVxA0P2lru/sdLyfCVaRMfKVo9nWxbmz7f/sD8VPybPeSUJaJcwmCJis9pBIhcVcG1QcQ==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.1.tgz",
+      "integrity": "sha512-j1n0Ao919h/Ai5r43VAnfV/7azUYW43GPxK7qSATzrsERfW7+y2QW9Cp9ufnRF5CQUWbnLSo7UJokSWCqg4tsQ==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -7256,9 +7241,9 @@
       "dev": true
     },
     "node_modules/webpack": {
-      "version": "5.85.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.85.0.tgz",
-      "integrity": "sha512-7gazTiYqwo5OSqwH1tigLDL2r3qDeP2dOKYgd+LlXpsUMqDTklg6tOghexqky0/+6QY38kb/R/uRPUleuL43zg==",
+      "version": "5.88.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.0.tgz",
+      "integrity": "sha512-O3jDhG5e44qIBSi/P6KpcCcH7HD+nYIHVBhdWFxcLOcIGN8zGo5nqF3BjyNCxIh4p1vFdNnreZv2h2KkoAw3lw==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -7269,7 +7254,7 @@
         "acorn-import-assertions": "^1.9.0",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.14.1",
+        "enhanced-resolve": "^5.15.0",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -7279,7 +7264,7 @@
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.1.2",
+        "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.3.7",
         "watchpack": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.21.10",
+  "version": "0.21.11",
   "files": [
     "defaultErrorPages",
     "lib",
@@ -32,7 +32,7 @@
     "execa": "7.1.1",
     "express": "4.18.2",
     "express-html-validator": "0.2.1",
-    "formidable": "2.1.1",
+    "formidable": "2.1.2",
     "fs-extra": "11.1.1",
     "helmet": "7.0.0",
     "html-minifier": "4.0.0",
@@ -48,22 +48,22 @@
     "serve-favicon": "2.5.0",
     "source-configs": "0.3.6",
     "toobusy-js": "0.5.1",
-    "webpack": "5.85.0"
+    "webpack": "5.88.0"
   },
   "devDependencies": {
-    "c8": "7.14.0",
+    "c8": "8.0.0",
     "codecov": "3.8.3",
-    "eslint": "8.42.0",
+    "eslint": "8.43.0",
     "eslint-plugin-mocha": "10.1.0",
     "less": "4.1.3",
     "mocha": "10.2.0",
     "proxyquire": "2.1.3",
-    "sass": "1.62.1",
-    "sinon": "15.1.0",
+    "sass": "1.63.6",
+    "sinon": "15.2.0",
     "standard": "17.1.0",
     "stylus": "0.59.0",
     "supertest": "6.3.3",
-    "teddy": "0.6.1"
+    "teddy": "0.6.2"
   },
   "repository": {
     "type": "git",

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -53,7 +53,7 @@ module.exports = (params, schema) => {
   const appEnv = app.get('env')
 
   if (params.makeBuildArtifacts === 'staticsOnly') {
-    logger.info('💭', `Building ${appName} static site...`.bold)
+    logger.info('💭', `Building ${appName} static site in ${appEnv} mode...`.bold)
   } else {
     logger.info('💭', `Starting ${appName} in ${appEnv} mode...`.bold)
   }
@@ -243,6 +243,10 @@ module.exports = (params, schema) => {
       // custom error page
       app = require('./lib/500ErrorPage.js')(app)
 
+      if (params.onStaticAssetsGenerated && typeof params.onStaticAssetsGenerated === 'function') {
+        params.onStaticAssetsGenerated(app)
+      }
+
       if (cb && typeof cb === 'function') {
         cb()
       }
@@ -374,13 +378,15 @@ module.exports = (params, schema) => {
     }
 
     function serverPush (server, serverPort, serverFormat) {
-      servers.push(server.listen(serverPort, (params.localhostOnly ? 'localhost' : null), startupCallback(serverFormat, serverPort)).on('error', (err) => {
-        logger.error(err)
-        if (err.message.includes('EADDRINUSE')) {
-          logger.error(`Another process is using port ${serverPort}. Either kill that process or change this app's port number.`.bold)
-        }
-        process.exit(1)
-      }))
+      if (params.makeBuildArtifacts !== 'staticsOnly') {
+        servers.push(server.listen(serverPort, (params.localhostOnly ? 'localhost' : null), startupCallback(serverFormat, serverPort)).on('error', (err) => {
+          logger.error(err)
+          if (err.message.includes('EADDRINUSE')) {
+            logger.error(`Another process is using port ${serverPort}. Either kill that process or change this app's port number.`.bold)
+          }
+          process.exit(1)
+        }))
+      }
     }
 
     const lock = {}

--- a/test/sourceParams.js
+++ b/test/sourceParams.js
@@ -27,6 +27,7 @@ describe('sourceParams', () => {
       'onReqBeforeRoute',
       'onReqStart',
       'onServerInit',
+      'onStaticAssetsGenerated',
       'onServerStart',
       'onAppExit',
       'routePrefix',


### PR DESCRIPTION
- Added a new `--build` CLI flag that will instruct Roosevelt to just build the build artifacts but not start the server.
- Added new `onStaticAssetsGenerated` event that is fired when the server finishes init but before the server starts.
- Fixed an issue that would cause the server to start even when `makeBuildArtifacts` is set to `staticsOnly`. This has the side effect of causing `serverStart()` to revert to the behavior of `init()` if `makeBuildArtifacts` is set to `staticsOnly`.
- Fixed a bug that would cause roosevelt-router to produce a false negative when detecting teddy.
- Various dependencies updated.