### PR TITLE
0.22.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Put your changes here...
 
+## 0.22.5
+
+- Certs generator will now run in production mode as well if `https` is enabled and if the files do not already exist. This behavior can be suppressed by setting `https.autoCert` to `false`.
+- Fixed README formatting typos.
+- Updated various dependencies.
+
 ## 0.22.4
 
 - Made it possible to set `expressSession` to `true` which will set a sane default config so you don't have to spell one out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 0.22.5
 
 - Certs generator will now run in production mode as well if `https` is enabled and if the files do not already exist. This behavior can be suppressed by setting `https.autoCert` to `false`.
+- Fixed bug that prevented the static site generator feature from working in dev mode when the HTML validator was enabled.
 - Fixed README formatting typos.
 - Updated various dependencies.
 

--- a/README.md
+++ b/README.md
@@ -431,9 +431,9 @@ Resolves to:
       - Default: *[Number]* `43733`.
   - `force`: Disallow unencrypted HTTP and route all traffic through HTTPS.
       - Default: *[Boolean]* `false`.
-    - `autoCert`: Will create self-signed HTTPS certificates in development mode as long as they don't already exist.
+  - `autoCert`: Will create self-signed HTTPS certificates in development mode as long as they don't already exist.
     - Default: *[Boolean]* `true`.
-    - `authInfoPath`: *[Object]* Specify either the paths where the server certificate files can be found or set the appropriate parameters to be a PKCS#12-formatted string or certificate or key strings.
+  - `authInfoPath`: *[Object]* Specify either the paths where the server certificate files can be found or set the appropriate parameters to be a PKCS#12-formatted string or certificate or key strings.
       - Default: *[Object]* `undefined`.
     - Object members:
         - `p12`: *[Object]* Parameter used when the server certificate/key is in PKCS#12 format.
@@ -448,14 +448,14 @@ Resolves to:
 
             - `key`: *[String]* Either the path to a PEM-encoded key file (e.g. .crt, .cer, etc.) or a PEM-encoded key string for the certificate given in `cert`.
               - Default: `undefined`.
-    - `passphrase`: *[String]* Shared passphrase used for a single private key and/or a P12.
+  - `passphrase`: *[String]* Shared passphrase used for a single private key and/or a P12.
     - Default: `undefined`.
-    - `requestCert`: *[Boolean]* Set whether to request a certificate from the client attempting to connect to the server to verify the client's identity.
-      - Default: `undefined`.
-    - `rejectUnauthorized`: *[Boolean]* Set whether to reject connections from clients that do no present a valid certificate to the server. (Ignored if `requestCert` is set to `false`.)
-      - Default:  `undefined`.
-    - `caCert`: *[String]* Either the path to a PEM-encoded Certificate Authority root certificate or certificate chain or a PEM-encoded Certificate Authority root certificate or certificate chain string. This certificate (chain) will be used to verify client certificates presented to the server. It is only needed if `requestCert` and `rejectUnauthorized` are both set to `true` and the client certificates are not signed by a Certificate Authority in the default publicly trusted list of CAs [curated by Mozilla](https://hg.mozilla.org/mozilla-central/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt).
-      - Default: `undefined`.
+  - `requestCert`: *[Boolean]* Set whether to request a certificate from the client attempting to connect to the server to verify the client's identity.
+    - Default: `undefined`.
+  - `rejectUnauthorized`: *[Boolean]* Set whether to reject connections from clients that do no present a valid certificate to the server. (Ignored if `requestCert` is set to `false`.)
+    - Default:  `undefined`.
+  - `caCert`: *[String]* Either the path to a PEM-encoded Certificate Authority root certificate or certificate chain or a PEM-encoded Certificate Authority root certificate or certificate chain string. This certificate (chain) will be used to verify client certificates presented to the server. It is only needed if `requestCert` and `rejectUnauthorized` are both set to `true` and the client certificates are not signed by a Certificate Authority in the default publicly trusted list of CAs [curated by Mozilla](https://hg.mozilla.org/mozilla-central/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt).
+    - Default: `undefined`.
 
 - `localhostOnly`: Listen only to requests coming from localhost in production mode. This is useful in environments where it is expected that HTTP requests to your app will be proxied through a more traditional web server like Apache or nginx. This setting is ignored in development mode.
 

--- a/README.md
+++ b/README.md
@@ -124,23 +124,23 @@ To do that:
 Create a Roosevelt app using one of the methods above, then set the `makeBuildArtifacts` param to the value of `'staticsOnly'` which will allow Roosevelt to create static files but skip the creation of the MVC directories:
 
   ```javascript
-require('roosevelt')({
-  makeBuildArtifacts: 'staticsOnly'
-}).init()
+  require('roosevelt')({
+    makeBuildArtifacts: 'staticsOnly'
+  }).init()
   ```
 
 You will also need to set `viewEngine` if you want to render HTML templates into static pages and supply data to the templates:
 
   ```javascript
-require('roosevelt')({
-  makeBuildArtifacts: 'staticsOnly',
-  viewEngine: 'html: teddy',
-  onServerInit: (app) => {
-    app.get('htmlModels')['index.html'] = {
-      hello: 'world!'
+  require('roosevelt')({
+    makeBuildArtifacts: 'staticsOnly',
+    viewEngine: 'html: teddy',
+    onServerInit: (app) => {
+      app.get('htmlModels')['index.html'] = {
+        hello: 'world!'
+      }
     }
-  }
-}).init()
+  }).init()
   ```
 
 If model data is not supplied by configuration, Roosevelt will try to automatically load a model from a JS file with the same name alongside the template if it exists instead. For example if an index.js file exists next to index.html and the model is not defined by configuration like in the example above, then the index.js file will be used to set the model so long as it exports either an object or a function that returns an object.

--- a/lib/preprocessStaticPages.js
+++ b/lib/preprocessStaticPages.js
@@ -8,7 +8,7 @@ const path = require('path')
 const klawSync = require('klaw-sync')
 const gitignoreScanner = require('./tools/gitignoreScanner')
 
-module.exports = (app, callback) => {
+module.exports = async (app, callback) => {
   const params = app.get('params')
   const appName = app.get('appName')
   const htmlPath = app.get('htmlPath')
@@ -94,7 +94,7 @@ module.exports = (app, callback) => {
 
         // validate the html if the validator is enabled
         if (params.htmlValidator.enable) {
-          newHtml = expressValidator(newHtml)
+          newHtml = await expressValidator(newHtml)
         }
 
         // check if html file already exists

--- a/lib/scripts/certsGenerator.js
+++ b/lib/scripts/certsGenerator.js
@@ -1,3 +1,5 @@
+const fse = require('fs-extra')
+
 if (module.parent) {
   module.exports = {
     certsGenerator
@@ -34,55 +36,12 @@ function certsGenerator (appDir, keyFolder) {
 
   const params = sourceParams({ appDir: process.cwd() })
 
-  if (!keyFolder) {
-    keyFolder = params.secretsDir
-  }
+  if (params.https?.authInfoPath?.authCertAndKey) {
+    if (!keyFolder) keyFolder = params.secretsDir
 
-  try {
     // make secrets folder if non-existent
-    const filepath = appDir + '/' + keyFolder
-    if (!fs.existsSync(filepath)) {
-      fs.mkdirSync(filepath)
-    }
-
-    // TODO: use fse instead of the manual implementation
-    if (!fs.existsSync(filepath + '/' + params.https.authInfoPath.authCertAndKey.key)) writeFileSyncRecursive(filepath + '/' + params.https.authInfoPath.authCertAndKey.key, key, 'utf-8')
-    if (!fs.existsSync(filepath + '/' + params.https.authInfoPath.authCertAndKey.cert)) writeFileSyncRecursive(filepath + '/' + params.https.authInfoPath.authCertAndKey.cert, cert, 'utf-8')
-  } catch (err) {
-    console.log(err)
-  }
-
-  // this handy function found on https://gist.github.com/drodsou/de2ba6291aea67ffc5bc4b52d8c32abd
-  // allows the filename to be a path, and will create any missing folders
-  function writeFileSyncRecursive (filename, content, charset) {
-    // normalize path separator to '/' instead of path.sep,
-    // as / works in node for Windows as well, and mixed \\ and / can appear in the path
-    let filepath = filename.replace(/\\/g, '/')
-
-    // preparation to allow absolute paths as well
-    let root = ''
-    if (filepath[0] === '/') {
-      root = '/'
-      filepath = filepath.slice(1)
-    } else if (filepath[1] === ':') {
-      root = filepath.slice(0, 3) // c:\
-      filepath = filepath.slice(3)
-    }
-
-    // create folders all the way down
-    const folders = filepath.split('/').slice(0, -1) // remove last item, file
-    folders.reduce(
-      (acc, folder) => {
-        const folderPath = acc + folder + '/'
-        if (!fs.existsSync(folderPath)) {
-          fs.mkdirSync(folderPath)
-        }
-        return folderPath
-      },
-      root // first 'acc', important
-    )
-
-    // write file
-    fs.writeFileSync(root + filepath, content, charset)
+    const filepath = appDir + '/' + keyFolder + '/'
+    fse.writeFileSync(filepath + params.https.authInfoPath.authCertAndKey.key, key)
+    fse.writeFileSync(filepath + params.https.authInfoPath.authCertAndKey.cert, cert)
   }
 }

--- a/lib/setExpressConfigs.js
+++ b/lib/setExpressConfigs.js
@@ -51,7 +51,7 @@ module.exports = function (app) {
   app.set('morgan', morgan)
 
   // enable express-session
-  if (params.expressSession) {
+  if (params.expressSession && params.makeBuildArtifacts !== 'staticsOnly') {
     const secret = JSON.parse(fs.readFileSync(params.secretsDir + '/sessionSecret.json', 'utf-8')).secret
     let store
 
@@ -107,7 +107,7 @@ module.exports = function (app) {
   }
 
   // enable CSRF protection middleware
-  if (params.csrfProtection) {
+  if (params.csrfProtection && params.makeBuildArtifacts !== 'staticsOnly') {
     const csrfSecrets = JSON.parse(fs.readFileSync(params.secretsDir + '/csrfSecret.json', 'utf-8'))
     const csrfUtilities = doubleCsrf({
       cookieOptions: { signed: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "roosevelt",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.6.0",
         "app-module-path": "2.2.0",
-        "better-sqlite3": "9.5.0",
+        "better-sqlite3": "9.6.0",
         "better-sqlite3-session-store": "0.1.0",
         "clean-css": "5.3.3",
         "compression": "1.7.4",
@@ -55,8 +55,8 @@
         "sinon": "17.0.1",
         "standard": "17.1.0",
         "stylus": "0.63.0",
-        "supertest": "6.3.4",
-        "teddy": "0.6.5",
+        "supertest": "7.0.0",
+        "teddy": "0.6.6",
         "watcher": "2.3.1"
       },
       "engines": {
@@ -65,15 +65,6 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/kethinov"
-      }
-    },
-    "node_modules/@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1238,9 +1229,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.5.0.tgz",
-      "integrity": "sha512-01qVcM4gPNwE+PX7ARNiHINwzVuD6nx0gdldaAAcu+MrzyIAukQ31ZDKEpzRO/CNA9sHpxoTZ8rdjoyAin4dyg==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
@@ -1500,9 +1491,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001611",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001611.tgz",
-      "integrity": "sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==",
+      "version": "1.0.30001614",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001614.tgz",
+      "integrity": "sha512-jmZQ1VpmlRwHgdP1/uiKzgiAuGOfLEJsYFP4+GBou/QQ4U6IOJCB4NP1c+1p9RGLpwObcT94jA5/uO+F1vBbog==",
       "funding": [
         {
           "type": "opencollective",
@@ -2291,9 +2282,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.744",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.744.tgz",
-      "integrity": "sha512-nAGcF0yeKKfrP13LMFr5U1eghfFSvFLg302VUFzWlcjPOnUYd52yU5x6PBYrujhNbc4jYmZFrGZFK+xasaEzVA=="
+      "version": "1.4.750",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.750.tgz",
+      "integrity": "sha512-9ItEpeu15hW5m8jKdriL+BQrgwDTXEL9pn4SkillWFu73ZNNNQ2BKKLS+ZHv2vC9UkNhosAeyfxOf/5OSeTCPA=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2447,14 +2438,14 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.18.tgz",
-      "integrity": "sha512-scxAJaewsahbqTYrGKJihhViaM6DDZDDoucfvzNbK0pOren1g/daDQ3IAhzn+1G14rBG7w+i5N+qul60++zlKA==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.19.tgz",
+      "integrity": "sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.0",
+        "es-abstract": "^1.23.3",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.0.3",
         "function-bind": "^1.1.2",
@@ -2472,9 +2463,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
-      "integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.2.tgz",
+      "integrity": "sha512-l60ETUTmLqbVbVHv1J4/qj+M8nq7AwMzEcg3kmJDt9dCNrTk+yHcYFf/Kw75pMDwd9mPcIGCG5LcS20SxYRzFA=="
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
@@ -4998,9 +4989,9 @@
       "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
     },
     "node_modules/lru-cache": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -5512,9 +5503,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.60.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.60.0.tgz",
-      "integrity": "sha512-zcGgwoXbzw9NczqbGzAWL/ToDYAxv1V8gL1D67ClbdkIfeeDBbY0GelZtC25ayLvVjr2q2cloHeQV1R0QAWqRQ==",
+      "version": "3.62.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.62.0.tgz",
+      "integrity": "sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -5799,17 +5790,17 @@
       }
     },
     "node_modules/optionator": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "dependencies": {
-        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0"
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -7875,9 +7866,9 @@
       }
     },
     "node_modules/superagent": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.1.tgz",
+      "integrity": "sha512-CcRSdb/P2oUVaEpQ87w9Obsl+E9FruRd6b2b7LdiBtJoyMr2DQt7a89anAfiX/EL59j9b2CbRFvf2S91DhuCww==",
       "dev": true,
       "dependencies": {
         "component-emitter": "^1.3.0",
@@ -7885,14 +7876,14 @@
         "debug": "^4.3.4",
         "fast-safe-stringify": "^2.1.1",
         "form-data": "^4.0.0",
-        "formidable": "^2.1.2",
+        "formidable": "^3.5.1",
         "methods": "^1.1.2",
         "mime": "2.6.0",
         "qs": "^6.11.0",
         "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=6.4.0 <13 || >=14"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/superagent/node_modules/debug": {
@@ -7910,21 +7901,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/superagent/node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
-      "dev": true,
-      "dependencies": {
-        "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/superagent/node_modules/mime": {
@@ -7946,16 +7922,16 @@
       "dev": true
     },
     "node_modules/supertest": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
-      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+      "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
       "dev": true,
       "dependencies": {
         "methods": "^1.1.2",
-        "superagent": "^8.1.2"
+        "superagent": "^9.0.1"
       },
       "engines": {
-        "node": ">=6.4.0"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supervisor": {
@@ -8033,9 +8009,9 @@
       }
     },
     "node_modules/teddy": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/teddy/-/teddy-0.6.5.tgz",
-      "integrity": "sha512-v6S12YNOFnwENNCWGHhkzcmql/2uaVBhaYHNvI+h9hQ1eGTH+P5DdCk4LUyZUDN1zYAtH1/a1FIRfZiDyZzPmQ==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/teddy/-/teddy-0.6.6.tgz",
+      "integrity": "sha512-PWE+W/ZaQKc6MjjGDqNN3LQkQAs4ijlsvFUSe9khHua+oq0WdTWUyQofNLiMfgy+hYoGCXH55nGQUkAQIM2wdA==",
       "dev": true,
       "dependencies": {
         "cheerio": "1.0.0-rc.12",
@@ -8066,9 +8042,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.3.tgz",
-      "integrity": "sha512-STdUgOUx8rLbMGO9IOwHLpCqolkDITFFQSMYYwKE1N2lY6MVSaeoi10z/EhWxRc6ybqoVmKSkhKYH/XUpl7vSA==",
+      "version": "5.30.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.4.tgz",
+      "integrity": "sha512-xRdd0v64a8mFK9bnsKVdoNP9GQIKUAaJPTaqEQDL4w/J8WaW4sWXXoMZ+6SimPkfT5bElreXf8m9HnmPc3E1BQ==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -8793,6 +8769,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/workerpool": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.22.4",
+  "version": "0.22.5",
   "files": [
     "defaultErrorPages",
     "lib",
@@ -25,7 +25,7 @@
   "dependencies": {
     "@colors/colors": "1.6.0",
     "app-module-path": "2.2.0",
-    "better-sqlite3": "9.5.0",
+    "better-sqlite3": "9.6.0",
     "better-sqlite3-session-store": "0.1.0",
     "clean-css": "5.3.3",
     "compression": "1.7.4",
@@ -69,8 +69,8 @@
     "sinon": "17.0.1",
     "standard": "17.1.0",
     "stylus": "0.63.0",
-    "supertest": "6.3.4",
-    "teddy": "0.6.5",
+    "supertest": "7.0.0",
+    "teddy": "0.6.6",
     "watcher": "2.3.1"
   },
   "repository": {

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -96,7 +96,7 @@ module.exports = (params, schema) => {
     authInfoPath = httpsParams.authInfoPath
 
     // Runs the certGenerator if httpsParams.enable
-    if (httpsParams.autoCert) {
+    if (httpsParams.autoCert && authInfoPath?.authCertAndKey) {
       const { authCertAndKey } = authInfoPath
 
       if ((!fs.existsSync(params.secretsDir) || (!fs.existsSync(authCertAndKey.key) || (!fs.existsSync(authCertAndKey.cert))))) {

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -78,21 +78,21 @@ module.exports = (params, schema) => {
   // #region certs
 
   // generate express session secret
-  if (params.expressSession) {
+  if (params.expressSession && params.makeBuildArtifacts !== 'staticsOnly') {
     if (!fs.existsSync(params.secretsDir) || !fs.existsSync(params.secretsDir + '/sessionSecret.json')) {
       sessionSecretGenerator()
     }
   }
 
   // generate csrf secret
-  if (params.csrfProtection) {
+  if (params.csrfProtection && params.makeBuildArtifacts !== 'staticsOnly') {
     if (!fs.existsSync(params.secretsDir) || !fs.existsSync(params.secretsDir + '/csrfSecret.json')) {
       csrfSecretGenerator()
     }
   }
 
   // generate https certs
-  if (httpsParams.enable) {
+  if (httpsParams.enable && params.makeBuildArtifacts !== 'staticsOnly') {
     authInfoPath = httpsParams.authInfoPath
 
     // Runs the certGenerator if httpsParams.enable

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -96,7 +96,7 @@ module.exports = (params, schema) => {
     authInfoPath = httpsParams.authInfoPath
 
     // Runs the certGenerator if httpsParams.enable
-    if (appEnv === 'development' && httpsParams.autoCert) {
+    if (httpsParams.autoCert) {
       const { authCertAndKey } = authInfoPath
 
       if ((!fs.existsSync(params.secretsDir) || (!fs.existsSync(authCertAndKey.key) || (!fs.existsSync(authCertAndKey.cert))))) {

--- a/test/errorPages.js
+++ b/test/errorPages.js
@@ -435,7 +435,8 @@ describe('error pages', function () {
       csrfProtection: false,
       https: {
         enable: true,
-        port: 43203
+        port: 43203,
+        autoCert: false
       },
       onServerStart: '(app) => {process.send(app.get("params"))}',
       shutdownTimeout: 7000

--- a/test/rooseveltTest.js
+++ b/test/rooseveltTest.js
@@ -576,7 +576,8 @@ describe('Roosevelt.js Tests', function () {
       localhostOnly: true,
       https: {
         enable: true,
-        port: 43203
+        port: 43203,
+        autoCert: false
       },
       csrfProtection: false,
       onServerStart: '(app) => {process.send(app.get("params"))}'
@@ -754,7 +755,7 @@ describe('Roosevelt.js Tests', function () {
         enable: true,
         port: 43203,
         force: true,
-        autoCert: true
+        autoCert: false
       }
     }, sOptions)
 


### PR DESCRIPTION
- Certs generator will now run in production mode as well if `https` is enabled and if the files do not already exist. This behavior can be suppressed by setting `https.autoCert` to `false`.
- Fixed README formatting typos.
- Updated various dependencies.