### PR TITLE
Update certsGenerator

### DIFF
--- a/lib/scripts/certsGenerator.js
+++ b/lib/scripts/certsGenerator.js
@@ -40,8 +40,8 @@ function certsGenerator (appDir, keyFolder) {
     if (!keyFolder) keyFolder = params.secretsDir
 
     // make secrets folder if non-existent
-    const filepath = appDir + '/' + keyFolder + '/'
-    if (!fs.existsSync(filepath + '/' + params.https.authInfoPath.authCertAndKey.key)) fse.writeFileSync(filepath + params.https.authInfoPath.authCertAndKey.key, key)
-    if (!fs.existsSync(filepath + '/' + params.https.authInfoPath.authCertAndKey.cert)) fse.writeFileSync(filepath + params.https.authInfoPath.authCertAndKey.cert, cert)
+    const filepath = path.join(appDir, keyFolder)
+    if (!fs.existsSync(path.join(filepath, params.https.authInfoPath.authCertAndKey.key))) fse.writeFileSync(path.join(filepath, params.https.authInfoPath.authCertAndKey.key), key)
+    if (!fs.existsSync(path.join(filepath, params.https.authInfoPath.authCertAndKey.cert))) fse.writeFileSync(path.join(filepath, params.https.authInfoPath.authCertAndKey.cert), cert)
   }
 }


### PR DESCRIPTION
Replaced hard coded slashes with `path.join`, fixing an issue with cert generation in production mode.