### PR TITLE
0.22.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Put your changes here...
 
+## 0.22.12
+
+- Added `'unsafe-inline'` option to helmet's `Content-Security-Policy`'s `script-src` directive by default in Roosevelt. This will prevent inline scripts from being blocked in production mode.
+- Updated various dependencies.
+
 ## 0.22.11
 
 - Added `DISABLE_HTTPS` environment variable which when set to `true`, the HTTPS server will be disabled and the app will revert to HTTP regardless of what is set in the `rooseveltConfig`.

--- a/README.md
+++ b/README.md
@@ -599,7 +599,9 @@ Resolves to:
 
 - `helmet`: Parameters to pass to the [helmet](https://github.com/helmetjs/helmet) module. This module helps secure Express apps by setting HTTP response headers.
 
-  - Default: *[Object]* The default options are specified in the [helmet docs](https://helmetjs.github.io/), with the exception of the `upgrade-insecure-requests` option that helmet sets in the `Content-Security-Policy`, which has been removed by default in Roosevelt.
+  - Default: *[Object]* The default options are specified in the [helmet docs](https://helmetjs.github.io/), with the following exceptions:
+    - The `upgrade-insecure-requests` option that helmet sets in the `Content-Security-Policy` has been removed by default in Roosevelt.
+    - The `'unsafe-inline'` option has been added to the `Content-Security-Policy`'s `script-src` directive by default in Roosevelt.
 
 - `logging`: Parameters to pass to [roosevelt-logger](https://github.com/rooseveltframework/roosevelt-logger). See [roosevelt-logger parameters documentation](https://github.com/rooseveltframework/roosevelt-logger#configure-logger) for configuration options.
 

--- a/lib/setExpressConfigs.js
+++ b/lib/setExpressConfigs.js
@@ -148,6 +148,7 @@ module.exports = function (app) {
       contentSecurityPolicy = {}
       contentSecurityPolicy.directives = helmet.contentSecurityPolicy.getDefaultDirectives()
       delete contentSecurityPolicy.directives['upgrade-insecure-requests']
+      contentSecurityPolicy.directives['script-src'].push('\'unsafe-inline\'')
     }
     app.use(helmet({ ...params.helmet, contentSecurityPolicy }))
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.22.11",
+      "version": "0.22.12",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -18,7 +18,7 @@
         "cookie-parser": "1.4.6",
         "csrf-csrf": "3.0.6",
         "es6-template-strings": "2.0.1",
-        "execa": "9.1.0",
+        "execa": "9.2.0",
         "express": "4.19.2",
         "express-html-validator": "0.2.4",
         "express-session": "1.18.0",
@@ -1407,9 +1407,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+      "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1425,10 +1425,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
+        "caniuse-lite": "^1.0.30001629",
+        "electron-to-chromium": "^1.4.796",
         "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "update-browserslist-db": "^1.0.16"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1556,9 +1556,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001628",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001628.tgz",
-      "integrity": "sha512-S3BnR4Kh26TBxbi5t5kpbcUlLJb9lhtDXISDPwOfI+JoC+ik0QksvkZtUVyikw3hjnkgkMPSJ8oIM9yMm9vflA==",
+      "version": "1.0.30001629",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001629.tgz",
+      "integrity": "sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2347,9 +2347,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.790",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.790.tgz",
-      "integrity": "sha512-eVGeQxpaBYbomDBa/Mehrs28MdvCXfJmEFzaMFsv8jH/MJDLIylJN81eTJ5kvx7B7p18OiPK0BkC06lydEy63A=="
+      "version": "1.4.796",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.796.tgz",
+      "integrity": "sha512-NglN/xprcM+SHD2XCli4oC6bWe6kHoytcyLKCWXmRL854F0qhPhaYgUswUsglnPxYaNQIg2uMY4BvaomIf3kLA=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3102,9 +3102,9 @@
       }
     },
     "node_modules/execa": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.1.0.tgz",
-      "integrity": "sha512-lSgHc4Elo2m6bUDhc3Hl/VxvUDJdQWI40RZ4KMY9bKRc+hgMOT7II/JjbNDhI8VnMtrCb7U/fhpJIkLORZozWw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.2.0.tgz",
+      "integrity": "sha512-vpOyYg7UAVKLAWWtRS2gAdgkT7oJbCn0me3gmUmxZih4kd3MF/oo8kNTBTIbkO3yuuF5uB4ZCZfn8BOolITYhg==",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
         "cross-spawn": "^7.0.3",
@@ -3120,7 +3120,7 @@
         "yoctocolors": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^18.19.0 || >=20.5.0"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
@@ -8131,9 +8131,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.31.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
-      "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==",
+      "version": "5.31.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.1.tgz",
+      "integrity": "sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.22.11",
+  "version": "0.22.12",
   "files": [
     "defaultErrorPages",
     "lib",
@@ -32,7 +32,7 @@
     "cookie-parser": "1.4.6",
     "csrf-csrf": "3.0.6",
     "es6-template-strings": "2.0.1",
-    "execa": "9.1.0",
+    "execa": "9.2.0",
     "express": "4.19.2",
     "express-html-validator": "0.2.4",
     "express-session": "1.18.0",


### PR DESCRIPTION
- Added `'unsafe-inline'` option to helmet's `Content-Security-Policy`'s `script-src` directive by default in Roosevelt. This will prevent inline scripts from being blocked in production mode.
- Updated various dependencies.