### PR TITLE
0.22.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Put your changes here...
 
+## 0.22.13
+
+- Altered helmet's defaults again. The `form-action` directive has been set to `null`. This makes it possible to submit forms to other domains in production mode.
+
 ## 0.22.12
 
 - Added `'unsafe-inline'` option to helmet's `Content-Security-Policy`'s `script-src` directive by default in Roosevelt. This will prevent inline scripts from being blocked in production mode.

--- a/README.md
+++ b/README.md
@@ -599,9 +599,11 @@ Resolves to:
 
 - `helmet`: Parameters to pass to the [helmet](https://github.com/helmetjs/helmet) module. This module helps secure Express apps by setting HTTP response headers.
 
-  - Default: *[Object]* The default options are specified in the [helmet docs](https://helmetjs.github.io/), with the following exceptions:
-    - The `upgrade-insecure-requests` option that helmet sets in the `Content-Security-Policy` has been removed by default in Roosevelt.
-    - The `'unsafe-inline'` option has been added to the `Content-Security-Policy`'s `script-src` directive by default in Roosevelt.
+  - Default: *[Object]* The default options are specified in the [helmet docs](https://helmetjs.github.io/), with the following exceptions that Roosevelt makes to the default `Content-Security-Policy` settings:
+    - The `upgrade-insecure-requests` directive has been removed. This change prevents [this bug](https://github.com/rooseveltframework/roosevelt/issues/964).
+    - The `script-src` directive has been set to `'unsafe-inline'`. This makes it possible to use inline scripts.
+    - The `form-action` directive has been set to `null`. This makes it possible to submit forms to other domains.
+    - You can reverse any of these changes by configuring helmet yourself.
 
 - `logging`: Parameters to pass to [roosevelt-logger](https://github.com/rooseveltframework/roosevelt-logger). See [roosevelt-logger parameters documentation](https://github.com/rooseveltframework/roosevelt-logger#configure-logger) for configuration options.
 

--- a/lib/setExpressConfigs.js
+++ b/lib/setExpressConfigs.js
@@ -147,8 +147,9 @@ module.exports = function (app) {
     if (contentSecurityPolicy === undefined) {
       contentSecurityPolicy = {}
       contentSecurityPolicy.directives = helmet.contentSecurityPolicy.getDefaultDirectives()
-      delete contentSecurityPolicy.directives['upgrade-insecure-requests']
-      contentSecurityPolicy.directives['script-src'].push('\'unsafe-inline\'')
+      delete contentSecurityPolicy.directives['upgrade-insecure-requests'] // fixes https://github.com/rooseveltframework/roosevelt/issues/964
+      contentSecurityPolicy.directives['script-src'].push('\'unsafe-inline\'') // allow inline script tags
+      contentSecurityPolicy.directives['form-action'] = null // allow submitting to forms on other domains
     }
     app.use(helmet({ ...params.helmet, contentSecurityPolicy }))
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.22.12",
+  "version": "0.22.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.22.12",
+      "version": "0.22.13",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.22.12",
+  "version": "0.22.13",
   "files": [
     "defaultErrorPages",
     "lib",


### PR DESCRIPTION
- Altered helmet's defaults again. The `form-action` directive has been set to `null`. This makes it possible to submit forms to other domains in production mode.