### PR TITLE
Remove `os` import from rooseveltTest.js

### DIFF
--- a/test/rooseveltTest.js
+++ b/test/rooseveltTest.js
@@ -6,7 +6,6 @@ const { fork } = require('child_process')
 const fs = require('fs-extra')
 const generateTestApp = require('./util/generateTestApp')
 const http = require('http')
-const os = require('os')
 const path = require('path')
 const request = require('supertest')
 


### PR DESCRIPTION
CI was throwing an error from standard that the `os` module was imported in the rooseveltTest.js file but never used. This should bring CI back to all green