### PR TITLE
0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## Next version
 
+- Put your changes here...
+
+## 0.25.0
+
 - Breaking: Supplying an `allowlist` to the views bundler will now implicitly disable `exposeAll`.
 - Breaking: Renamed `secretsDir` param to `secretsPath`.
 - Updated all file path express variables to include full absolute paths.
 - Fixed various bugs in the views bundler feature.
-- Fixed a rare bug where csrf and session secrets could be written to the wrong directory.
-- Fixed a bug where https certs could be automatically generated when they shouldn't be.
+- Fixed a rare bug where CSRF and session secrets could be written to the wrong directory.
+- Fixed a bug where HTTPS certs could be automatically generated when they shouldn't be.
 - Updated various dependencies.
 
 ## 0.24.0

--- a/README.md
+++ b/README.md
@@ -1369,6 +1369,7 @@ Aside from the config auditor, one of the easiest ways to see what you might nee
 
 ### Documentation for previous versions of Roosevelt
 
+- *[0.24.x](https://github.com/rooseveltframework/roosevelt/blob/808198978eddc32fc588528b52ec97beb0f3eaf6/README.md)*
 - *[0.23.x](https://github.com/rooseveltframework/roosevelt/blob/88a3e64cb893bfa813b0e00e2b5aea03c1be5b98/README.md)*
 - *[0.22.x](https://github.com/rooseveltframework/roosevelt/blob/e76256d82ef587d31320bcd52930a5358f9f2953/README.md)*
 - *[0.21.x](https://github.com/rooseveltframework/roosevelt/blob/539e11dc9ce5f4d6340762dedb1a11134fe51b04/README.md)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -334,14 +334,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.6.tgz",
-      "integrity": "sha512-+0TjwR1eAUdZtvv/ir1mGX+v0tUoR3VEPB8Up0LLJC+whRW0GgBBtpbOkg/a/U4Dxa6l5a3l9AJ1aWIQVyoWJA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.11.0",
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10979,9 +10992,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.24.0",
+  "version": "0.25.0",
   "files": [
     "defaultErrorPages",
     "lib",


### PR DESCRIPTION
- Breaking: Supplying an `allowlist` to the views bundler will now implicitly disable `exposeAll`.
- Breaking: Renamed `secretsDir` param to `secretsPath`.
- Updated all file path express variables to include full absolute paths.
- Fixed various bugs in the views bundler feature.
- Fixed a rare bug where CSRF and session secrets could be written to the wrong directory.
- Fixed a bug where HTTPS certs could be automatically generated when they shouldn't be.
- Updated various dependencies.