### PR TITLE
0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@
 
 - Put your changes here...
 
+## 0.26.0
+
+- Breaking: Added new param `preprocessedViewsPath`: Relative path on filesystem to where your preprocessed view files will be written to. Preprocessed view files are view files that have had their uses of web components progressively enhanced using the [progressively-enhance-web-components](https://github.com/rooseveltframework/progressively-enhance-web-components) module.
+  - Default: *[String]* `"mvc/.preprocessed_views"`.
+  - To disable this feature, set the value to `false`.
+  - This is breaking because if you leave it enabled by default (recommended), you will need to add `.preprocessed_views` to your `.gitignore`.
+- Breaking: Switched to external source maps for the CSS preprocessor. This necessitated changing the custom CSS preprocessor API to require returning an object instead of a string.
+  - If you have written a custom CSS preprocessor, the new return value is:
+    ```javascript
+    return {
+      css: 'write code to output css here',
+      sourceMap: 'write code to output source map here (optional)'
+    }
+    ```
+- Added new param `prodSourceMaps` to allow source maps to be generated in prod mode for both CSS and JS.
+- Added IP address to the output when the server starts.
+- Added new CLI script `secretsGenerator.js` that allows you to combine `certsGenerator.js`, `csrfSecretGEnerator.js`, and `sessionSecretGenerator.js` into one command.
+- Added feature to override `appDir` and `secretsPath` for the CLI scripts using `--appDir somewhere` and `--secretsPath somewhere` CLI flags.
+- Added `exceptionRoutes` option to the `frontendReload` param.
+- Added a check for broken symlinks in the public folder, which will be purged if any exist.
+- Added support for placing your Roosevelt config in a `roosevelt.config.json` file in addition to the previous options.
+- Added better error when attempting to start a Roosevelt app on a file system that does not support symlinks.
+- Changed source maps from inline to external.
+- Fixed a bug that caused the JS bundler to not log when it was writing JS files.
+- Fixed a bug that caused a `statics/pages` directory being created when it isn't needed.
+- Fixed a bug that could cause the public folder and statics folder to be created even when `makeBuildArtifacts` is disabled.
+- Fixed a bug that caused the views bundler and isomorphic controllers finder to write a new views bundle to disk even when it wasn't needed.
+- Fixed `frontendReload` not working in Firefox with the default HTTPS config.
+- Updated various dependencies.
+
 ## 0.25.0
 
 - Breaking: Supplying an `allowlist` to the views bundler will now implicitly disable `exposeAll`.

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -35,9 +35,10 @@
   },
   "frontendReload": {
     "enable": true,
-    "port": 9856,
-    "httpsPort": 9857,
-    "verbose": false
+    "exceptionRoutes": [],
+    "expressBrowserReloadParams": {
+      "skipDeletingConnections": true
+    }
   },
   "shutdownTimeout": 30000,
   "https": {
@@ -65,6 +66,7 @@
   "secretsPath": "secrets",
   "modelsPath": "mvc/models",
   "viewsPath": "mvc/views",
+  "preprocessedViewsPath": "mvc/.preprocessed_views",
   "viewEngine": "none",
   "controllersPath": "mvc/controllers",
   "errorPages": {
@@ -118,6 +120,7 @@
   "publicFolder": "public",
   "favicon": "none",
   "symlinks": [],
+  "prodSourceMaps": false,
   "versionedPublic": false,
   "hostPublic": true,
   "clientViews": {

--- a/lib/generateSymlinks.js
+++ b/lib/generateSymlinks.js
@@ -8,12 +8,40 @@ module.exports = app => {
   const fsr = require('./tools/fsr')(app)
   const logger = app.get('logger')
 
-  // generate public and statics directories
-  fsr.ensureDirSync(params.publicFolder)
-  fsr.ensureDirSync(params.staticsRoot)
-
   // process symlinks
   if (params.makeBuildArtifacts) {
+    // test that symlink creation works in general; fixes https://github.com/rooseveltframework/roosevelt/issues/1484
+    const source = '.gitignore'
+    const dest = 'testIfSymlinksWork'
+    try {
+      if (process.platform === 'win32') {
+        fs.ensureLinkSync(source, dest)
+      } else {
+        fs.ensureSymlinkSync(source, dest, 'junction')
+      }
+      fs.rmSync('testIfSymlinksWork')
+    } catch (e) {
+      logger.error('Unable to create symlinks. Please ensure you are using a file system that supports symlinks and you have the proper permissions to make them.')
+    }
+
+    // generate public and statics directories
+    fsr.ensureDirSync(params.publicFolder)
+    fsr.ensureDirSync(params.staticsRoot)
+
+    // remove broken symlinks
+    const publicFiles = fsr.getAllFilesRecursivelySync(params.publicFolder)
+    for (const file of publicFiles) {
+      if (fs.lstatSync(file).isSymbolicLink()) {
+        try {
+          const targetPath = fs.readlinkSync(file)
+          if (!fs.existsSync(path.resolve(path.dirname(file), targetPath))) fs.rmSync(file) // remove broken symlink
+        } catch (err) {
+          fs.rmSync(file) // remove broken symlink
+        }
+      }
+    }
+
+    // make symlinks
     for (const symlink of params.symlinks) {
       // append appDir to each path that is relative
       const source = path.isAbsolute(symlink.source) ? symlink.source : path.join(app.get('appDir'), symlink.source)
@@ -23,21 +51,22 @@ module.exports = app => {
       if (fs.pathExistsSync(source)) {
         // then check if the destination already exists
         if (fs.pathExistsSync(dest)) {
-          // then check if the destination is a symlink
-          if (!fs.lstatSync(dest).isSymbolicLink()) {
+          if (fs.lstatSync(dest).isSymbolicLink()) {
+            continue // symlink exists, skip making it
+          } else {
             logger.error(`Symlink destination "${dest}" is already a file that exists. Skipping symlink creation.`)
+            continue
           }
-        } else {
-          try {
-            if (process.platform === 'win32' && !fs.lstatSync(source).isDirectory()) {
-              fs.ensureLinkSync(source, dest)
-            } else {
-              fs.ensureSymlinkSync(source, dest, 'junction')
-            }
-            logger.info('📁', `${appName} making new symlink `.cyan + `${dest}`.yellow + (' pointing to ').cyan + `${source}`.yellow)
-          } catch (e) {
-            logger.error('It appears your Roosevelt app has been moved/renamed. You may want to delete the "./public" folder to remove the broken symlinks.')
+        }
+        try {
+          if (process.platform === 'win32' && !fs.lstatSync(source).isDirectory()) {
+            fs.ensureLinkSync(source, dest)
+          } else {
+            fs.ensureSymlinkSync(source, dest, 'junction')
           }
+          logger.info('📁', `${appName} making new symlink `.cyan + `${dest}`.yellow + (' pointing to ').cyan + `${source}`.yellow)
+        } catch (e) {
+          logger.error('It appears your Roosevelt app has been moved/renamed. You may want to delete the "./public" folder to remove the broken symlinks.')
         }
       } else {
         logger.error(`Symlink source "${source}" does not exist. Skipping symlink creation.`)

--- a/lib/injectReload.js
+++ b/lib/injectReload.js
@@ -1,3 +1,5 @@
+const wildcardMatch = require('./tools/wildcardMatch')
+
 // injects <script> tag containing "reload.js"
 module.exports = app => {
   const reloadParams = app.get('params').frontendReload
@@ -5,18 +7,13 @@ module.exports = app => {
   // check that reload is enabled and app is running in development mode
   if (app.get('env') === 'development' && reloadParams.enable) {
     app.use(require('tamper')((req, res) => {
-      if (res.getHeader('Content-Type') && res.getHeader('Content-Type').includes('text/html')) {
+      if (!wildcardMatch(req.url, reloadParams.exceptionRoutes) && res.getHeader('Content-Type') && res.getHeader('Content-Type').includes('text/html')) {
         return (body) => {
           const pos = body.lastIndexOf('</body>')
-          body = body.substring(0, pos) + `<!-- Injected by Roosevelt for frontend reload functionality -->\n<script src='/reload${getProtocol(req.protocol)}/reload.js'></script>\n</body>` + body.substring(pos + 7)
+          body = body.substring(0, pos) + `<!-- Injected by Roosevelt for frontend reload functionality -->\n<script src="${reloadParams?.expressBrowserReloadParams?.route ? reloadParams?.expressBrowserReloadParams?.route : '/express-browser-reload.js'}"></script>\n</body>` + body.substring(pos + 7)
           return body
         }
       }
     }))
   }
-}
-
-// capitalize first letter of string and return modified string
-function getProtocol (protocol) {
-  return protocol.charAt(0).toUpperCase() + protocol.slice(1)
 }

--- a/lib/isomorphicControllersFinder.js
+++ b/lib/isomorphicControllersFinder.js
@@ -13,13 +13,19 @@ module.exports = async app => {
     let fileData = '/* Do not edit; generated automatically by Roosevelt */\n\n/* eslint-disable */\n\n'
     fileData += 'module.exports = function (router) {\n'
     for (const filePath of await walk(app.get('params').controllersPath)) {
-      const contents = await fs.readFile(filePath.path, 'utf8')
+      const contents = fs.readFileSync(filePath.path, 'utf8')
       if (contents.includes('.isoRequire(')) {
         fileData += '  require(\'' + (filePath.path.replace(app.get('params').appDir + path.sep, '')).replaceAll('\\', '\\\\') + '\')(router)\n'
       }
     }
     fileData += '}'
     const writePath = path.join(output, file)
-    fsr.writeFileSync(writePath, fileData, ['📝', `${appName} writing new JS file ${writePath}`.green])
+    let oldFileData
+    try {
+      oldFileData = fs.readFileSync(writePath, 'utf8')
+    } catch (e) {
+      oldFileData = ''
+    }
+    if (oldFileData !== fileData) fsr.writeFileSync(writePath, fileData, ['📝', `${appName} writing new JS file ${writePath}`.green])
   }
 }

--- a/lib/jsBundler.js
+++ b/lib/jsBundler.js
@@ -37,6 +37,8 @@ module.exports = async app => {
             if (!config.devtool) config.devtool = 'source-map' // only add this if devtool isn't already set in the user's config
           }
 
+          if (params.prodSourceMaps) config.devtool = 'source-map' // enable source maps in prod mode if the setting is set
+
           // run webpack with specified config
           webpack(config, (err, stats) => {
             if (err) {
@@ -49,6 +51,7 @@ module.exports = async app => {
               return
             }
 
+            stats.toJson().assets.map(asset => path.join(config.output.path, asset.name)).forEach(file => logger.log('📝', `${app.get('appName')} writing new JS file ${file}`.green))
             resolve()
           })
         })

--- a/lib/mapRoutes.js
+++ b/lib/mapRoutes.js
@@ -45,7 +45,23 @@ module.exports = async app => {
   if (params.makeBuildArtifacts && params.makeBuildArtifacts !== 'staticsOnly') {
     fsr.ensureDirSync(app.get('modelsPath'))
     fsr.ensureDirSync(app.get('viewsPath'))
+    if (app.get('preprocessedViewsPath')) fsr.ensureDirSync(app.get('preprocessedViewsPath'))
     fsr.ensureDirSync(app.get('controllersPath'))
+  }
+
+  // progressively enhance web components
+  if (app.get('preprocessedViewsPath') && fs.existsSync(app.get('viewsPath')) && fs.existsSync(app.get('preprocessedViewsPath'))) {
+    const editedFiles = require('progressively-enhance-web-components')({
+      templatesDir: app.get('viewsPath')
+    })
+
+    // copy unmodified templates to a modified templates directory
+    fs.copySync(app.get('viewsPath'), app.get('preprocessedViewsPath'))
+
+    // update the relevant templates
+    for (const file in editedFiles) {
+      fs.writeFileSync(file.replace(app.get('viewsPath'), app.get('preprocessedViewsPath')), editedFiles[file])
+    }
   }
 
   // map statics for developer mode

--- a/lib/preprocessCss.js
+++ b/lib/preprocessCss.js
@@ -63,33 +63,29 @@ module.exports = async app => {
         versionCode: app => `@${params.css.versionFile.varName}: '${app.get('appVersion')}';\n`,
         parse: (app, file) => {
           return new Promise((resolve, reject) => {
-            const compilerOptions = params.css.compiler.options
-            const env = app.get('env')
-
-            // set less options based on roosevelt config
             const options = {
-              ...compilerOptions,
+              ...params.css.compiler.options,
               paths: app.get('cssPath'),
               filename: path.basename(file)
             }
 
-            // get file contents
-            const lessString = fs.readFileSync(file, 'utf8')
-
-            // enable inline source mapping in dev mode
-            if (env === 'development') {
+            // enable source mapping in dev mode
+            if (app.get('env') === 'development' || params.prodSourceMaps) {
               options.sourceMap = {
-                sourceMapFileInline: true,
+                sourceMapFileInline: false,
                 outputSourceFiles: true
               }
-            } else {
+            } else if (!params.prodSourceMaps) {
               // disable source mapping in prod mode
               options.sourceMap = undefined
             }
 
-            module.render(lessString, options, (err, output) => {
+            module.render(fs.readFileSync(file, 'utf8'), options, (err, output) => {
               if (err) return reject(err)
-              resolve(output.css)
+              resolve({
+                css: output.css,
+                sourceMap: output.map
+              })
             })
           })
         }
@@ -99,32 +95,21 @@ module.exports = async app => {
         versionCode: app => `$${params.css.versionFile.varName}: '${app.get('appVersion')}';\n`,
         parse: (app, file) => {
           return new Promise((resolve, reject) => {
-            const env = app.get('env')
-            const compilerOptions = params.css.compiler.params
             const options = {
-              ...compilerOptions,
+              ...params.css.compiler.params,
               includePaths: [app.get('cssPath')]
             }
 
-            // enable inline source mapping in dev mode
-            if (env === 'development') options.sourceMap = true
+            // enable source mapping in dev mode
+            if (app.get('env') === 'development' || params.prodSourceMaps) options.sourceMap = true
             // disable source mapping in prod mode
-            else options.sourceMap = undefined
+            else if (!params.prodSourceMaps) options.sourceMap = undefined
 
             const { css, sourceMap } = module.compile(file, options)
-            let output = ''
-
-            if (sourceMap) {
-              // the latest version of sass dropped the ability to embed sourcemaps so we now have to do it manually
-              // this method of adding it was derived from https://github.com/sass/dart-sass/issues/1594#issuecomment-1013208452
-              const smBase64 = (Buffer.from(JSON.stringify(sourceMap), 'utf8') || '').toString('base64')
-              const smComment = '/*# sourceMappingURL=data:application/json;charset=utf-8;base64,' + smBase64 + ' */'
-              output = css.toString() + '\n'.repeat(2) + smComment
-            } else {
-              output = css
-            }
-
-            resolve(output)
+            resolve({
+              css,
+              sourceMap
+            })
           })
         }
       }
@@ -133,33 +118,30 @@ module.exports = async app => {
         versionCode: app => `${params.css.versionFile.varName} = '${app.get('appVersion')}';\n`,
         parse: (app, file) => {
           return new Promise((resolve, reject) => {
-            const compilerOptions = params.css.compiler.options
-            const env = app.get('env')
-
-            // set less options based on roosevelt config
             const options = {
-              ...compilerOptions,
+              ...params.css.compiler.options,
               paths: [app.get('cssPath')],
               filename: file
             }
 
-            // get file contents
-            const stylusInput = fs.readFileSync(file, 'utf8')
+            // create stylus style object
+            const style = module(fs.readFileSync(file, 'utf8'), options)
 
-            // enable inline source mapping in dev mode
-            if (env === 'development') {
-              options.sourcemap = {
+            // enable source mapping in dev mode
+            if (app.get('env') === 'development' || params.prodSourceMaps) {
+              style.set('sourcemap', {
                 comment: false,
-                inline: true
-              }
-            } else {
-              // disable source mapping in prod mode
-              options.sourcemap = undefined
+                inline: false
+              })
             }
 
-            module.render(stylusInput, options, (err, css) => {
+            style.render(function (err, css) {
+              // generated sourcemap object
               if (err) return reject(err)
-              resolve(css)
+              resolve({
+                css,
+                sourceMap: style.sourcemap
+              })
             })
           })
         }
@@ -240,7 +222,9 @@ module.exports = async app => {
               }
 
               // run file through the preprocessor
-              let newCSS = await preprocessorModule.parse(app, file)
+              const cssObj = await preprocessorModule.parse(app, file)
+              let newCSS = cssObj.css
+              const newSourceMap = cssObj.sourceMap
 
               // construct destination for compiled css
               const { name, dir } = path.parse(file)
@@ -263,6 +247,10 @@ module.exports = async app => {
               // also, check existing file for matching content before writing
               if (newCSS !== '' && (!content || content !== newCSS)) {
                 fsr.writeFileSync(outpath, newCSS, ['📝', `${appName} writing new CSS file ${outpath}`.green])
+                if (newSourceMap) {
+                  const sourceMapOutpath = outpath.endsWith('.css') ? outpath.slice(0, -4) + '.map' : outpath
+                  fsr.writeFileSync(sourceMapOutpath, typeof newSourceMap === 'string' ? newSourceMap : JSON.stringify(newSourceMap), ['📝', `${appName} writing new CSS source map file ${sourceMapOutpath}`.green])
+                }
               }
               resolve()
             } catch (e) {

--- a/lib/preprocessStaticPages.js
+++ b/lib/preprocessStaticPages.js
@@ -24,87 +24,84 @@ module.exports = async app => {
   // skip parsing static pages if feature is disabled or makeBuildArtifacts is false
   if (!params.html.sourcePath || !params.makeBuildArtifacts) return
 
+  // change process directory to the statics pages directory so that templates located there can reference other templates using relative paths
   const oldDir = process.cwd()
   if (fs.pathExistsSync(params.html.sourcePath)) process.chdir(params.html.sourcePath)
 
-  // TODO: remove this; the tests need to be altered to permit it
-  fsr.ensureDirSync(htmlPath)
-
-  // generate html output directory
-  fsr.ensureDirSync(htmlRenderedOutput)
-
   // process each html file
-  for (let file of await walk(htmlPath)) {
-    // handle cases where file is an object provided by fsWalk
-    file = file.path || file
+  if (fs.existsSync(htmlPath)) {
+    for (let file of await walk(htmlPath)) {
+      // handle cases where file is an object provided by fsWalk
+      file = file.path || file
 
-    // filter out irrelevant files
-    if (file !== '.' && file !== '..' && !gitignoreFiles.includes(path.basename(file)) && !gitignoreFiles.includes(file) && !fs.lstatSync(file).isDirectory()) {
-      try {
-        const baseFile = file.replace(app.get('params').html.sourcePath + path.sep, '')
-        if ((allowlist && allowlist.length > 0 && !wildcardMatch(baseFile, allowlist)) || (blocklist && blocklist.length > 0 && wildcardMatch(baseFile, blocklist))) {
-          // skip this file if it's not on the allowlist
-          // but only if an allowlist exists
-          // also skip it if it's on the blocklist
-          continue
-        }
-
-        let extension = file.split('.')
-        extension = extension[extension.length - 1]
-        if (extension === 'js' || extension === 'json') continue
-
-        const renderer = app.get('view: ' + extension)
-        if (!renderer) {
-          logger.error(`${appName} failed to parse ${file}. There is no view engine for file type "${extension}" registered with the app.`)
-          continue
-        }
-
-        let modelFile = file.slice(0, file.length - extension.length) + 'js'
-        if (!fs.pathExistsSync(modelFile)) modelFile = file.slice(0, file.length - extension.length) + 'json'
-        let modelData = app.get('htmlModels')[path.normalize(file.replace(app.get('htmlPath') + path.sep, ''))]
-        if (!modelData && fs.pathExistsSync(modelFile)) {
-          modelData = require(modelFile)
-          if (typeof modelData === 'function') modelData = modelData(app)
-          else logger.error(`${appName} failed to load ${modelFile} model. Please ensure that it is coded correctly.`)
-        }
-        const model = modelData || {}
-        let newHtml = renderer(baseFile, model)
-
-        // construct destination for rendered html
-        const { name, dir } = path.parse(file)
-        let content
-        const outpath = path.join(htmlRenderedOutput, dir.replace(htmlPath, ''), `${name}.html`)
-
-        // minify the html if minification is enabled
-        if (params.minify && params.html.minifier.enable) {
-          newHtml = await htmlMinifier(newHtml, minifyOptions)
-        }
-
-        // validate the html if the validator is enabled
-        if (params.htmlValidator.enable) {
-          newHtml = await expressValidator(newHtml)
-        }
-
-        // check if html file already exists
-        if (fs.pathExistsSync(outpath)) {
-          content = fs.readFileSync(outpath, 'utf8')
-        }
-
-        // check existing file for matching content before writing
-        if (newHtml !== '' && (!content || content !== newHtml)) {
-          fsr.writeFileSync(outpath, newHtml, ['📝', `${appName} writing new HTML file ${outpath}`.green])
-          if (params.htmlValidator.enable && newHtml.includes('<title>HTML did not pass validation</title>') && newHtml.includes('<code class="validatorErrors">')) {
-            logger.error(`↳ The file has HTML validation errors. Open ${outpath} in your browser to see the details.`)
+      // filter out irrelevant files
+      if (file !== '.' && file !== '..' && !gitignoreFiles.includes(path.basename(file)) && !gitignoreFiles.includes(file) && !fs.lstatSync(file).isDirectory()) {
+        try {
+          const baseFile = file.replace(app.get('params').html.sourcePath + path.sep, '')
+          if ((allowlist && allowlist.length > 0 && !wildcardMatch(baseFile, allowlist)) || (blocklist && blocklist.length > 0 && wildcardMatch(baseFile, blocklist))) {
+            // skip this file if it's not on the allowlist
+            // but only if an allowlist exists
+            // also skip it if it's on the blocklist
+            continue
           }
+
+          let extension = file.split('.')
+          extension = extension[extension.length - 1]
+          if (extension === 'js' || extension === 'json') continue
+
+          const renderer = app.get('view: ' + extension)
+          if (!renderer) {
+            logger.error(`${appName} failed to parse ${file}. There is no view engine for file type "${extension}" registered with the app.`)
+            continue
+          }
+
+          let modelFile = file.slice(0, file.length - extension.length) + 'js'
+          if (!fs.pathExistsSync(modelFile)) modelFile = file.slice(0, file.length - extension.length) + 'json'
+          let modelData = app.get('htmlModels')[path.normalize(file.replace(app.get('htmlPath') + path.sep, ''))]
+          if (!modelData && fs.pathExistsSync(modelFile)) {
+            modelData = require(modelFile)
+            if (typeof modelData === 'function') modelData = modelData(app)
+            else logger.error(`${appName} failed to load ${modelFile} model. Please ensure that it is coded correctly.`)
+          }
+          const model = modelData || {}
+          let newHtml = renderer(baseFile, model)
+
+          // construct destination for rendered html
+          const { name, dir } = path.parse(file)
+          let content
+          const outpath = path.join(htmlRenderedOutput, dir.replace(htmlPath, ''), `${name}.html`)
+
+          // minify the html if minification is enabled
+          if (params.minify && params.html.minifier.enable) {
+            newHtml = await htmlMinifier(newHtml, minifyOptions)
+          }
+
+          // validate the html if the validator is enabled
+          if (params.htmlValidator.enable) {
+            newHtml = await expressValidator(newHtml)
+          }
+
+          // check if html file already exists
+          fsr.ensureDirSync(htmlRenderedOutput)
+          if (fs.pathExistsSync(outpath)) {
+            content = fs.readFileSync(outpath, 'utf8')
+          }
+
+          // check existing file for matching content before writing
+          if (newHtml !== '' && (!content || content !== newHtml)) {
+            fsr.writeFileSync(outpath, newHtml, ['📝', `${appName} writing new HTML file ${outpath}`.green])
+            if (params.htmlValidator.enable && newHtml.includes('<title>HTML did not pass validation</title>') && newHtml.includes('<code class="validatorErrors">')) {
+              logger.error(`↳ The file has HTML validation errors. Open ${outpath} in your browser to see the details.`)
+            }
+          }
+          continue
+        } catch (e) {
+          logger.error(`${appName} failed to parse ${file}. Please ensure that it is coded correctly.`)
+          logger.error(e)
         }
-        continue
-      } catch (e) {
-        logger.error(`${appName} failed to parse ${file}. Please ensure that it is coded correctly.`)
-        logger.error(e)
       }
     }
   }
 
-  // TODO: see if we can eliminate changing the process directory like this by using module configuration or even executing child processes
   process.chdir(oldDir)
 }

--- a/lib/scripts/certsGenerator.js
+++ b/lib/scripts/certsGenerator.js
@@ -2,10 +2,44 @@ const path = require('path')
 const fs = require('fs-extra')
 const selfsigned = require('selfsigned')
 
+let appDir
+let secretsPath
+
+// source from CLI
+for (const i in process.argv) {
+  const flag = process.argv[i]
+  if (flag === '--appDir') appDir = process.argv[parseInt(i) + 1]
+  if (flag === '--secretsPath') secretsPath = process.argv[parseInt(i) + 1]
+}
+
+// source from rooseveltConfig.json
+if (!appDir) {
+  try {
+    const rooseveltConfig = require(path.join(__dirname, '../../../../rooseveltConfig.json'))
+    if (rooseveltConfig && rooseveltConfig.appDir) appDir = rooseveltConfig.appDir
+  } catch (e) {
+    // swallow error
+  }
+}
+
+// source from roosevelt.config.json
+if (!appDir) {
+  try {
+    const rooseveltConfig = require(path.join(__dirname, '../../../../roosevelt.config.json'))
+    if (rooseveltConfig && rooseveltConfig.appDir) appDir = rooseveltConfig.appDir
+  } catch (e) {
+    // swallow error
+  }
+}
+
+// set default value
+if (!appDir) appDir = path.join(__dirname, '../../../../')
+
 if (module.parent) module.exports = certsGenerator
 else certsGenerator()
 
-function certsGenerator (secretsPath, httpsParams) {
+function certsGenerator (setSecretsPath, httpsParams) {
+  if (setSecretsPath) secretsPath = setSecretsPath
   const pem = selfsigned.generate(null, {
     keySize: 2048, // the size for the private key in bits (default: 1024)
     days: 365000, // how long till expiry of the signed certificate (default: 10,000)
@@ -19,9 +53,8 @@ function certsGenerator (secretsPath, httpsParams) {
   const cert = pem.cert
 
   // source the relevant user params from sourceParams when running in CLI mode
-  // TODO: expose the ability to supply these as command line flags
   if (!secretsPath) {
-    const params = require('../sourceParams')({ appDir: process.cwd() })
+    const params = require('../sourceParams')({ appDir })
     secretsPath = params.secretsPath
     httpsParams = params.https
   }

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -40,8 +40,9 @@ async function configAudit (appDir) {
   }
 
   try {
-    // check for existence of rooseveltConfig.json
-    cfg = require(path.join(appDir, 'rooseveltConfig.json'))
+    // check for existence of rooseveltConfig.json or roosevelt.config.json
+    if (fs.existsSync(path.join(appDir, 'rooseveltConfig.json'))) cfg = require(path.join(appDir, 'rooseveltConfig.json'))
+    else if (fs.existsSync(path.join(appDir, 'roosevelt.config.json'))) cfg = require(path.join(appDir, 'roosevelt.config.json'))
   } catch (e) {
     // skip audit if package config was also not found
     if (!pkg.rooseveltConfig) {
@@ -240,6 +241,9 @@ async function configAudit (appDir) {
         case 'symlinks':
           checkTypes(userParam, key, ['array'])
           break
+        case 'prodSourceMaps':
+          checkTypes(userParam, key, ['boolean'])
+          break
         case 'versionedPublic':
           checkTypes(userParam, key, ['boolean'])
           break
@@ -248,6 +252,9 @@ async function configAudit (appDir) {
           break
         case 'viewsPath':
           checkTypes(userParam, key, ['string'])
+          break
+        case 'preprocessedViewsPath':
+          checkTypes(userParam, key, ['boolean', 'string'])
           break
         case 'helmet':
           checkTypes(userParam, key, ['object'])
@@ -430,14 +437,11 @@ async function configAudit (appDir) {
               case 'enable':
                 checkTypes(reloadParam[reloadKey], reloadKey, ['boolean'])
                 break
-              case 'port':
-                checkTypes(reloadParam[reloadKey], reloadKey, ['number'])
+              case 'exceptionRoutes':
+                checkTypes(reloadParam[reloadKey], reloadKey, ['array'])
                 break
-              case 'httpsPort':
-                checkTypes(reloadParam[reloadKey], reloadKey, ['number'])
-                break
-              case 'verbose':
-                checkTypes(reloadParam[reloadKey], reloadKey, ['boolean'])
+              case 'expressBrowserReloadParams':
+                checkTypes(reloadParam[reloadKey], reloadKey, ['object'])
                 break
               default:
                 foundExtra(['rooseveltConfig', ...keyStack])
@@ -612,8 +616,8 @@ async function configAudit (appDir) {
     }
 
     if (errors) {
-      logger.error(`Issues have been detected in ${source === 'package' ? 'package.json' : 'rooseveltConfig.json'}, please consult https://github.com/rooseveltframework/roosevelt#configure-your-app-with-parameters for details on each param.`.bold)
-      logger.error('Or see https://github.com/rooseveltframework/roosevelt/blob/master/lib/defaults/config.json for the latest sample rooseveltConfig.'.bold)
+      logger.error('Issues have been detected in your Roosevelt config, please consult https://github.com/rooseveltframework/roosevelt#configure-your-app-with-parameters for details on each param.'.bold)
+      logger.error('Or see https://github.com/rooseveltframework/roosevelt/blob/master/lib/defaults/config.json for the latest sample Roosevelt config.'.bold)
     } else {
       logger.info('✅', 'rooseveltConfig audit completed with no errors found.'.green)
     }

--- a/lib/scripts/csrfSecretGenerator.js
+++ b/lib/scripts/csrfSecretGenerator.js
@@ -2,19 +2,52 @@ const fs = require('fs-extra')
 const path = require('path')
 const { randomBytes } = require('crypto')
 
+let appDir
+let secretsPath
+
+// source from CLI
+for (const i in process.argv) {
+  const flag = process.argv[i]
+  if (flag === '--appDir') appDir = process.argv[parseInt(i) + 1]
+  if (flag === '--secretsPath') secretsPath = process.argv[parseInt(i) + 1]
+}
+
+// source from rooseveltConfig.json
+if (!appDir) {
+  try {
+    const rooseveltConfig = require(path.join(__dirname, '../../../../rooseveltConfig.json'))
+    if (rooseveltConfig && rooseveltConfig.appDir) appDir = rooseveltConfig.appDir
+  } catch (e) {
+    // swallow error
+  }
+}
+
+// source from roosevelt.config.json
+if (!appDir) {
+  try {
+    const rooseveltConfig = require(path.join(__dirname, '../../../../roosevelt.config.json'))
+    if (rooseveltConfig && rooseveltConfig.appDir) appDir = rooseveltConfig.appDir
+  } catch (e) {
+    // swallow error
+  }
+}
+
+// set default value
+if (!appDir) appDir = path.join(__dirname, '../../../../')
+
 if (module.parent) module.exports = csrfSecretGenerator
 else csrfSecretGenerator()
 
-function csrfSecretGenerator (secretsPath) {
+function csrfSecretGenerator (setSecretsPath) {
+  if (setSecretsPath) secretsPath = setSecretsPath
   const csrfSecret = {
     csrfSecret: randomBytes(64).toString('base64').slice(0, 64),
     cookieParserSecret: randomBytes(64).toString('base64').slice(0, 64)
   }
 
   // source the relevant user params from sourceParams when running in CLI mode
-  // TODO: expose the ability to supply these as command line flags
   if (!secretsPath) {
-    const params = require('../sourceParams')({ appDir: process.cwd() })
+    const params = require('../sourceParams')({ appDir })
     secretsPath = params.secretsPath
   }
 

--- a/lib/scripts/secretsGenerator.js
+++ b/lib/scripts/secretsGenerator.js
@@ -1,0 +1,8 @@
+if (module.parent) module.exports = secretsGenerator
+else secretsGenerator()
+
+function secretsGenerator (secretsPath, httpsParams) {
+  require('./certsGenerator')(secretsPath, httpsParams)
+  require('./csrfSecretGenerator')(secretsPath)
+  require('./sessionSecretGenerator')(secretsPath)
+}

--- a/lib/scripts/sessionSecretGenerator.js
+++ b/lib/scripts/sessionSecretGenerator.js
@@ -2,16 +2,49 @@ const crypto = require('crypto')
 const fs = require('fs-extra')
 const path = require('path')
 
+let appDir
+let secretsPath
+
+// source from CLI
+for (const i in process.argv) {
+  const flag = process.argv[i]
+  if (flag === '--appDir') appDir = process.argv[parseInt(i) + 1]
+  if (flag === '--secretsPath') secretsPath = process.argv[parseInt(i) + 1]
+}
+
+// source from rooseveltConfig.json
+if (!appDir) {
+  try {
+    const rooseveltConfig = require(path.join(__dirname, '../../../../rooseveltConfig.json'))
+    if (rooseveltConfig && rooseveltConfig.appDir) appDir = rooseveltConfig.appDir
+  } catch (e) {
+    // swallow error
+  }
+}
+
+// source from roosevelt.config.json
+if (!appDir) {
+  try {
+    const rooseveltConfig = require(path.join(__dirname, '../../../../roosevelt.config.json'))
+    if (rooseveltConfig && rooseveltConfig.appDir) appDir = rooseveltConfig.appDir
+  } catch (e) {
+    // swallow error
+  }
+}
+
+// set default value
+if (!appDir) appDir = path.join(__dirname, '../../../../')
+
 if (module.parent) module.exports = sessionSecretGenerator
 else sessionSecretGenerator()
 
-function sessionSecretGenerator (secretsPath) {
+function sessionSecretGenerator (setSecretsPath) {
+  if (setSecretsPath) secretsPath = setSecretsPath
   const sessionSecret = { secret: crypto.randomUUID() }
 
   // source the relevant user params from sourceParams when running in CLI mode
-  // TODO: expose the ability to supply these as command line flags
   if (!secretsPath) {
-    const params = require('../sourceParams')({ appDir: process.cwd() })
+    const params = require('../sourceParams')({ appDir })
     secretsPath = params.secretsPath
   }
 

--- a/lib/setExpressConfigs.js
+++ b/lib/setExpressConfigs.js
@@ -159,7 +159,7 @@ module.exports = app => {
       logger.warn('viewEngine has been disabled.')
     }
   }
-  app.set('views', app.get('viewsPath')) // this alternative spelling of this express variable is used internally by express and should be kept in parity with roosevelt's list
+  app.set('views', app.get('preprocessedViewsPath') || app.get('viewsPath')) // this alternative spelling of this express variable is used internally by express and should be kept in parity with roosevelt's list
   if (Array.isArray(viewEngineParam)) viewEngineParam.forEach(registerViewEngine)
   else if (viewEngineParam !== 'none' && viewEngineParam !== null) registerViewEngine(viewEngineParam)
   else logger.warn('No view engine specified. viewEngine has been disabled.')

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -167,14 +167,11 @@ module.exports = (params, appSchema) => {
       enable: {
         default: defaults.frontendReload.enable
       },
-      port: {
-        default: defaults.frontendReload.port
+      exceptionRoutes: {
+        default: defaults.frontendReload.exceptionRoutes
       },
-      httpsPort: {
-        default: defaults.frontendReload.httpsPort
-      },
-      verbose: {
-        default: defaults.frontendReload.verbose
+      expressBrowserReloadParams: {
+        default: defaults.frontendReload.expressBrowserReloadParams
       }
     },
     shutdownTimeout: {
@@ -218,6 +215,9 @@ module.exports = (params, appSchema) => {
     },
     viewsPath: {
       default: defaults.viewsPath
+    },
+    preprocessedViewsPath: {
+      default: defaults.preprocessedViewsPath
     },
     viewEngine: {
       default: defaults.viewEngine
@@ -331,6 +331,9 @@ module.exports = (params, appSchema) => {
     symlinks: {
       default: defaults.symlinks
     },
+    prodSourceMaps: {
+      default: defaults.prodSourceMaps
+    },
     versionedPublic: {
       default: defaults.versionedPublic
     },
@@ -403,6 +406,7 @@ module.exports = (params, appSchema) => {
   params.secretsPath = path.join(appDir, params.secretsPath)
   params.modelsPath = path.join(appDir, params.modelsPath)
   params.viewsPath = path.join(appDir, params.viewsPath)
+  if (params.preprocessedViewsPath) params.preprocessedViewsPath = path.join(appDir, params.preprocessedViewsPath)
   params.controllersPath = path.join(appDir, params.controllersPath)
   params.unversionedPublic = path.join(appDir, params.publicFolder)
   params.publicFolder = path.join(params.unversionedPublic, params.versionedPublic ? pkg.version || '' : '')

--- a/lib/tools/fsr.js
+++ b/lib/tools/fsr.js
@@ -1,6 +1,7 @@
 // internal Roosevelt file system module
 
 const fs = require('fs-extra')
+const path = require('path')
 const Logger = require('roosevelt-logger')
 
 // writing files and folders is routed through this module so that if the user disables makeBuildArtifacts, the file/folder writing will not occur
@@ -17,6 +18,17 @@ const fsr = function (app) {
     generate = true
     logger = new Logger()
     appName = 'Roosevelt Express'
+  }
+
+  function getAllFilesRecursivelySync (dir) {
+    let fileList = []
+    const files = fs.readdirSync(dir, { withFileTypes: true })
+    files.forEach(file => {
+      const filePath = path.join(dir, file.name)
+      if (file.isDirectory()) fileList = fileList.concat(getAllFilesRecursivelySync(filePath)) // recurse dirs
+      else fileList.push(filePath)
+    })
+    return fileList
   }
 
   function ensureDirSync (dir, log) {
@@ -42,6 +54,7 @@ const fsr = function (app) {
   }
 
   return {
+    getAllFilesRecursivelySync,
     ensureDirSync,
     writeFileSync
   }

--- a/lib/viewsBundler.js
+++ b/lib/viewsBundler.js
@@ -29,7 +29,7 @@ module.exports = async app => {
   const allowlistRegex = /<!--+\s*roosevelt-allowlist\s*([\w-/.]+\.?(js)?)\s*--+>/ // regular expression to grab filename from <!-- roosevelt-allowlist --> tags
   for (const file of allViewsFiles) {
     const templateName = path.relative(viewsPath, file)
-    const contents = (await fs.readFile(file, 'utf8')).trim()
+    const contents = fs.readFileSync(file, 'utf8').trim()
     const templateComment = contents.split('\n')[0]
     if (templateComment.includes('roosevelt-blocklist')) {
       finalBlocklist.add(templateName)
@@ -58,7 +58,7 @@ module.exports = async app => {
 
       for (const file of bundleFiles) {
         const templatePath = path.join(viewsPath, file)
-        let templateContent = (await fs.readFile(templatePath, 'utf8')).trim()
+        let templateContent = fs.readFileSync(templatePath, 'utf8').trim()
         let templateName = path.relative(viewsPath, templatePath)
 
         // chop the extension off the template name if the file extension matches the configured view engine
@@ -78,7 +78,13 @@ module.exports = async app => {
       }
 
       fileDataToWrite += `module.exports = ${JSON.stringify(bundleDataStructure)}`
-      fsr.writeFileSync(writePath, fileDataToWrite, ['📝', `${appName} writing new JS file ${writePath}`.green])
+      let oldFileData
+      try {
+        oldFileData = fs.readFileSync(writePath, 'utf8')
+      } catch (e) {
+        oldFileData = ''
+      }
+      if (oldFileData !== fileDataToWrite) fsr.writeFileSync(writePath, fileDataToWrite, ['📝', `${appName} writing new JS file ${writePath}`.green])
     } catch (err) {
       logger.error(`Failed to create view bundle with the following configuration! ${bundles}`)
       logger.error(err)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -20,6 +20,7 @@
         "csrf-csrf": "3.1.0",
         "execa": "9.5.2",
         "express": "4.21.2",
+        "express-browser-reload": "4.0.0",
         "express-html-validator": "0.2.5",
         "express-session": "1.18.1",
         "formidable": "3.5.2",
@@ -27,13 +28,14 @@
         "glob": "11.0.1",
         "helmet": "8.0.0",
         "html-minifier-terser": "7.2.0",
+        "ip": "2.0.1",
         "method-override": "3.0.0",
         "minimatch": "10.0.1",
         "morgan": "1.10.0",
         "node-forge": "1.3.1",
         "page": "1.11.6",
         "page-express-mapper": "2.0.2",
-        "reload": "3.3.0",
+        "progressively-enhance-web-components": "1.0.3",
         "roosevelt-logger": "0.2.3",
         "selfsigned": "2.4.1",
         "serve-favicon": "2.5.0",
@@ -43,18 +45,18 @@
       "devDependencies": {
         "c8": "10.1.3",
         "codecov": "3.8.3",
-        "eslint": "9.20.1",
+        "eslint": "9.21.0",
         "eslint-plugin-mocha": "10.5.0",
         "less": "4.2.2",
         "mocha": "11.1.0",
         "prompts": "2.4.2",
         "proxyquire": "2.1.3",
-        "sass": "1.85.0",
+        "sass": "1.85.1",
         "sinon": "19.0.2",
         "standard": "17.1.2",
         "stylus": "0.64.0",
         "supertest": "7.0.0",
-        "teddy": "0.6.21",
+        "teddy": "0.6.23",
         "watcher": "2.3.1"
       },
       "engines": {
@@ -70,6 +72,25 @@
       "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-2.8.3.tgz",
+      "integrity": "sha512-GIc76d9UI1hCvOATjZPyHFmE5qhRccp3/zGfMPapK3jBi+yocEzp6BBB0UnfRYP9NP4FANqUZYb0hnfs3TM3hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.1",
+        "@csstools/css-color-parser": "^3.0.7",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
@@ -88,6 +109,116 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.2.tgz",
+      "integrity": "sha512-TklMyb3uBB28b5uQdxjReG4L80NxAqgrECqLZFQbyLekwwlcDDS8r3f07DKqeo8C4926Br0gf/ZDe17Zv4wIuw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.8.tgz",
+      "integrity": "sha512-pdwotQjCCnRPuNi06jFuP68cykU1f3ZWExLe/8MQ1LOs8Xq+fTkYgd+2V8mWUWMrOn9iS2HftPVaMZDaXzGbhQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
+      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
+      "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -208,9 +339,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/core": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
-      "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -221,9 +352,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -314,9 +445,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
-      "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
+      "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -342,19 +473,6 @@
       "dependencies": {
         "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -630,6 +748,12 @@
       "engines": {
         "node": ">=18.18.0"
       }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "license": "MIT"
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
@@ -1111,9 +1235,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "version": "22.13.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
+      "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -1299,6 +1423,15 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1344,42 +1477,13 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
-    },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -1477,6 +1581,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -1716,7 +1821,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
@@ -1803,6 +1907,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1875,6 +1980,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2087,9 +2193,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001700",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
-      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
+      "version": "1.0.30001701",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
+      "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2171,6 +2277,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -2195,6 +2302,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2228,22 +2336,6 @@
       },
       "engines": {
         "node": ">= 10.0"
-      }
-    },
-    "node_modules/cli-color": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.4.tgz",
-      "integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.64",
-        "es6-iterator": "^2.0.3",
-        "memoizee": "^0.4.15",
-        "timers-ext": "^0.1.7"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/cliui": {
@@ -2412,7 +2504,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2474,7 +2565,18 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2605,6 +2707,19 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.2.1.tgz",
+      "integrity": "sha512-9+vem03dMXG7gDmZ62uqmRiMRNtinIZ9ZyuF6BdxzfOD+FdN5hretzynkn0ReS2DO2GSw76RWHs0UmJPI2zUjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^2.8.2",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/d": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
@@ -2616,6 +2731,19 @@
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -2707,6 +2835,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "license": "MIT"
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -2756,15 +2890,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
@@ -2787,7 +2912,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2950,6 +3074,39 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
+    "node_modules/editorconfig": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
+      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2957,9 +3114,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.102",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.102.tgz",
-      "integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==",
+      "version": "1.5.109",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.109.tgz",
+      "integrity": "sha512-AidaH9JETVRr9DIPGfp1kAarm/W6hRJTPuCnkF+2MqhF4KaAgRIcBc8nvjk+YMXZhwfISof/7WG29eS4iGxQLQ==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -3202,7 +3359,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3310,18 +3466,6 @@
         "esniff": "^1.1"
       }
     },
-    "node_modules/es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3351,22 +3495,22 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.20.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.20.1.tgz",
-      "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.21.0.tgz",
+      "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.11.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.20.0",
-        "@eslint/plugin-kit": "^0.2.5",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.21.0",
+        "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -4109,6 +4253,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-browser-reload": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/express-browser-reload/-/express-browser-reload-4.0.0.tgz",
+      "integrity": "sha512-Fli4H+kpyiz0vO9o9TpyZOuqQsa3eoB3SFUbIpAlaON2td0Y5kDHQGX2YKA+yPiHmKdaclEdm9o6mt+8gTpwzw==",
+      "license": "CC-BY-4.0",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://www.paypal.com/donate/?hosted_button_id=2L2X8GRXZCGJ6"
+      }
+    },
     "node_modules/express-html-validator": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/express-html-validator/-/express-html-validator-0.2.5.tgz",
@@ -4246,9 +4402,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
-      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4312,6 +4468,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4409,12 +4566,12 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -4428,7 +4585,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
       "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4503,6 +4659,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4564,17 +4721,17 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -4817,7 +4974,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4867,6 +5023,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/html-escaper": {
@@ -5076,25 +5244,22 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/http-proxy-agent/node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5112,28 +5277,25 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent/node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5151,7 +5313,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/human-signals": {
@@ -5204,12 +5365,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-      "license": "ISC"
     },
     "node_modules/ignore-walk": {
       "version": "3.0.4",
@@ -5332,6 +5487,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+      "license": "MIT"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5406,6 +5567,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -5495,25 +5657,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5567,6 +5715,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5592,6 +5741,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5646,10 +5796,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -5828,18 +5978,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -5911,9 +6049,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.3.tgz",
-      "integrity": "sha512-oSwM7q8PTHQWuZAlp995iPpPJ4Vkl7qT0ZRD+9duL9j2oBy6KcTfyxc8mEuHJYC+z/kbps80aJLkaNzTOrf/kw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -5954,6 +6092,108 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5973,6 +6213,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.0.0.tgz",
+      "integrity": "sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.1",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -6295,15 +6575,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es5-ext": "~0.10.2"
-      }
-    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -6336,25 +6607,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/memoizee": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
-      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.2",
-        "es5-ext": "^0.10.64",
-        "es6-weak-map": "^2.0.3",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.2.2",
-        "lru-queue": "^0.1.0",
-        "next-tick": "^1.1.0",
-        "timers-ext": "^0.1.7"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/merge-descriptors": {
@@ -6891,6 +7143,31 @@
         }
       }
     },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -6906,104 +7183,26 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
     },
-    "node_modules/nodemon": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
-      "integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^4",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^7.5.3",
-        "simple-update-notifier": "^2.0.0",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/nodemon/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nodemon/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/nodemon/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/nodemon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7049,6 +7248,12 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.18.tgz",
+      "integrity": "sha512-p1TRH/edngVEHVbwqWnxUViEmq5znDvyB+Sik5cmuLpGOIfDf/39zLiq3swPF8Vakqn+gvNiOQAZu8djYlQILA==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7208,23 +7413,6 @@
       "license": "MIT",
       "dependencies": {
         "fn.name": "1.x.x"
-      }
-    },
-    "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -7414,7 +7602,6 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
       "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^4.5.0"
@@ -7537,6 +7724,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -7705,6 +7893,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/progressively-enhance-web-components": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/progressively-enhance-web-components/-/progressively-enhance-web-components-1.0.3.tgz",
+      "integrity": "sha512-ZRC0GT0Nm/I+SO/0rEeP/p5B68A9oWRpHN8UNRaeR6LDQvWjbc7ZRZjDZ+HHjoqHbp3zZ3fK8Uq87blf8S2K1w==",
+      "license": "CC-BY-4.0",
+      "dependencies": {
+        "js-beautify": "1.15.4",
+        "jsdom": "26.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://www.paypal.com/donate/?hosted_button_id=2L2X8GRXZCGJ6"
+      }
+    },
     "node_modules/promise-make-counter": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/promise-make-counter/-/promise-make-counter-1.0.2.tgz",
@@ -7756,6 +7960,12 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "license": "ISC"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7788,12 +7998,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.2",
@@ -7947,6 +8151,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -8021,106 +8226,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/reload": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/reload/-/reload-3.3.0.tgz",
-      "integrity": "sha512-TObPRTy5dPlw9DS8n8ROd2BLnxI+RvVn4r0WBARVAfJ493jjcN70NI5TdkcrJmex2aQh5bfQJbFbr1NapU7Lnw==",
-      "license": "MIT",
-      "dependencies": {
-        "cli-color": "~2.0.0",
-        "commander": "~12.1.0",
-        "finalhandler": "~1.2.0",
-        "minimist": "~1.2.0",
-        "nodemon": "~3.1.4",
-        "open": "^8.0.0",
-        "serve-static": "~1.15.0",
-        "ws": "~8.18.0"
-      },
-      "bin": {
-        "reload": "bin/reload"
-      }
-    },
-    "node_modules/reload/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/reload/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/reload/node_modules/finalhandler": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.1.tgz",
-      "integrity": "sha512-NpHDfiu6jURpO56pYkM6DEvnBEA9jNrwj4v05Vjs5hmdqEB2/kRA3wugct7BMyqYydjN+kWunMhtTn+itVmxpA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/reload/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/reload/node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/reload/node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.18.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8172,9 +8277,9 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -8270,6 +8375,12 @@
       "engines": {
         "node": ">=0.1.90"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -8385,9 +8496,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.85.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.85.0.tgz",
-      "integrity": "sha512-3ToiC1xZ1Y8aU7+CkgCI/tqyuPXEmYGJXO7H4uqp0xkLXUqp88rQQ4j1HmP37xSJLbCJPaIiv+cT1y+grssrww==",
+      "version": "1.85.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.85.1.tgz",
+      "integrity": "sha512-Uk8WpxM5v+0cMR0XjX9KfRIacmSG86RH4DCCZjLU2rFh5tyutt9siAXJ7G+YfxQ99Q6wrRMbMlVl6KqUms71ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8441,6 +8552,18 @@
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/schema-utils": {
       "version": "4.3.0",
@@ -8830,18 +8953,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "license": "MIT"
-    },
-    "node_modules/simple-update-notifier": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
-      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/sinon": {
       "version": "19.0.2",
@@ -9916,6 +10027,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tamper": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tamper/-/tamper-1.1.0.tgz",
@@ -9959,9 +10076,9 @@
       }
     },
     "node_modules/teddy": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/teddy/-/teddy-0.6.21.tgz",
-      "integrity": "sha512-chjyLwsaQV0Y7ZjY/w0rDHZyp8E28+jsWZS6yKuScsjwaabDu9fMK/z9ynW73VS4XZMvOVk9oo+WmEzI1fltXA==",
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/teddy/-/teddy-0.6.23.tgz",
+      "integrity": "sha512-UOhWbs4nAsDUwihlAxcL+Fx/lh/4LzyMjWsiU6H8PGrit6UWdXA1YR62IU71GET5WirzDFCxLn+LNG9P1LS9iw==",
       "dev": true,
       "license": "CC-BY-4.0",
       "dependencies": {
@@ -9991,6 +10108,73 @@
         "node": ">=10"
       }
     },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teeny-request/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/terser": {
       "version": "5.39.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
@@ -10010,9 +10194,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
-      "integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.12.tgz",
+      "integrity": "sha512-jDLYqo7oF8tJIttjXO6jBY5Hk8p3A8W4ttih7cCEq64fQFWmgJ4VqAQjKr7WwIDlmXKEc6QeoRb5ecjZ+2afcg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -10154,19 +10338,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/timers-ext": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
-      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
-      "license": "ISC",
-      "dependencies": {
-        "es5-ext": "^0.10.64",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/tiny-readdir": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/tiny-readdir/-/tiny-readdir-2.7.4.tgz",
@@ -10177,10 +10348,29 @@
         "promise-make-counter": "^1.0.2"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.82",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.82.tgz",
+      "integrity": "sha512-KCTjNL9F7j8MzxgfTgjT+v21oYH38OidFty7dH00maWANAI2IsLw2AnThtTJi9HKALHZKQQWnNebYheadacD+g==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.82"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.82",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.82.tgz",
+      "integrity": "sha512-Jabl32m21tt/d/PbDO88R43F8aY98Piiz6BVH9ShUlOAiiAELhEqwrAmBocjAqnCfoUeIsRU+h3IEzZd318F3w==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -10198,21 +10388,29 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/touch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
-      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
-      "license": "ISC",
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/triple-beam": {
       "version": "1.4.1",
@@ -10415,12 +10613,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-      "license": "MIT"
-    },
     "node_modules/undici": {
       "version": "6.21.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
@@ -10468,9 +10660,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "funding": [
         {
           "type": "opencollective",
@@ -10575,6 +10767,18 @@
         "node": ">=0.10.48"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watcher": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/watcher/-/watcher-2.3.1.tgz",
@@ -10600,11 +10804,13 @@
       }
     },
     "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/webpack": {
       "version": "5.98.0",
@@ -10687,7 +10893,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -10700,7 +10905,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -10713,21 +10917,22 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.1.tgz",
+      "integrity": "sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==",
       "license": "MIT",
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -11021,6 +11226,21 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.25.0",
+  "version": "0.26.0",
   "files": [
     "defaultErrorPages",
     "lib",
@@ -40,13 +40,15 @@
     "glob": "11.0.1",
     "helmet": "8.0.0",
     "html-minifier-terser": "7.2.0",
+    "ip": "2.0.1",
     "method-override": "3.0.0",
     "minimatch": "10.0.1",
     "morgan": "1.10.0",
     "node-forge": "1.3.1",
     "page": "1.11.6",
     "page-express-mapper": "2.0.2",
-    "reload": "3.3.0",
+    "progressively-enhance-web-components": "1.0.3",
+    "express-browser-reload": "4.0.0",
     "roosevelt-logger": "0.2.3",
     "selfsigned": "2.4.1",
     "serve-favicon": "2.5.0",
@@ -56,18 +58,18 @@
   "devDependencies": {
     "c8": "10.1.3",
     "codecov": "3.8.3",
-    "eslint": "9.20.1",
+    "eslint": "9.21.0",
     "eslint-plugin-mocha": "10.5.0",
     "less": "4.2.2",
     "mocha": "11.1.0",
     "prompts": "2.4.2",
     "proxyquire": "2.1.3",
-    "sass": "1.85.0",
+    "sass": "1.85.1",
     "sinon": "19.0.2",
     "standard": "17.1.2",
     "stylus": "0.64.0",
     "supertest": "7.0.0",
-    "teddy": "0.6.21",
+    "teddy": "0.6.23",
     "watcher": "2.3.1"
   },
   "repository": {

--- a/test/configAuditor.js
+++ b/test/configAuditor.js
@@ -184,7 +184,6 @@ describe('config auditor', () => {
     const { stderr } = await execaNode('../../../lib/scripts/configAuditor.js', { cwd: appDir })
 
     // check stderr to ensure it found all the problems
-    assert(stderr.includes('Issues have been detected in rooseveltConfig.json'))
-    assert(stderr.includes('Issues have been detected in package.json'))
+    assert(stderr.includes('Issues have been detected in '))
   })
 })

--- a/test/cssCompiler.js
+++ b/test/cssCompiler.js
@@ -302,7 +302,7 @@ describe('css preprocessors', () => {
               return `@coolAppVersion: ${app.get('version')}`
             },
             parse: (app, filePath) => {
-              return filePath
+              return { css: filePath }
             }
           }
         }
@@ -384,7 +384,7 @@ describe('css preprocessors', () => {
       assert.deepStrictEqual(lessOutput.css, buildOutput)
     })
 
-    it('should enable inline sourcemaps in dev mode', async () => {
+    it('should enable source maps in dev mode', async () => {
       const app = roosevelt({
         ...appConfig,
         mode: 'development',
@@ -401,11 +401,30 @@ describe('css preprocessors', () => {
       })
 
       await app.initServer()
+      const buildOutput = fs.readFileSync(path.join(appDir, 'public/css/styles.map'), 'utf8')
+      assert(buildOutput.includes('"mappings"'), 'build file is missing source map')
+    })
 
-      const buildOutput = fs.readFileSync(path.join(appDir, 'public/css/styles.css'), 'utf8')
+    it('should enable source maps in prod mode with prodSourceMaps param', async () => {
+      const app = roosevelt({
+        ...appConfig,
+        mode: 'development',
+        prodSourceMaps: true,
+        css: {
+          compiler: {
+            enable: true,
+            module: 'less'
+          },
+          minifier: {
+            enable: false
+          },
+          output: 'css'
+        }
+      })
 
-      // check that the build file includes a source map
-      assert(buildOutput.includes('/*# sourceMappingURL=data:application/json;base64'), 'build file is missing source map')
+      await app.initServer()
+      const buildOutput = fs.readFileSync(path.join(appDir, 'public/css/styles.map'), 'utf8')
+      assert(buildOutput.includes('"mappings"'), 'build file is missing source map')
     })
 
     it('should write a version file when enabled', async () => {
@@ -498,7 +517,7 @@ describe('css preprocessors', () => {
       assert.deepStrictEqual(scssOutput.css.toString(), buildOutput)
     })
 
-    it('should enable inline sourcemaps in dev mode', async () => {
+    it('should enable source maps in dev mode', async () => {
       const app = roosevelt({
         ...appConfig,
         mode: 'development',
@@ -515,11 +534,30 @@ describe('css preprocessors', () => {
       })
 
       await app.initServer()
+      const buildOutput = fs.readFileSync(path.join(appDir, 'public/css/styles.map'), 'utf8')
+      assert(buildOutput.includes('"mappings"'), 'build file is missing source map')
+    })
 
-      const buildOutput = fs.readFileSync(path.join(appDir, 'public/css/styles.css'), 'utf8')
+    it('should enable source maps in prod mode with prodSourceMaps param', async () => {
+      const app = roosevelt({
+        ...appConfig,
+        mode: 'development',
+        prodSourceMaps: true,
+        css: {
+          compiler: {
+            enable: true,
+            module: 'sass'
+          },
+          minifier: {
+            enable: false
+          },
+          output: 'css'
+        }
+      })
 
-      // check that the build file includes a source map
-      assert(buildOutput.includes('/*# sourceMappingURL=data:application/json'), 'build file is missing source map')
+      await app.initServer()
+      const buildOutput = fs.readFileSync(path.join(appDir, 'public/css/styles.map'), 'utf8')
+      assert(buildOutput.includes('"mappings"'), 'build file is missing source map')
     })
 
     it('should write a version file when enabled', async () => {
@@ -598,7 +636,7 @@ describe('css preprocessors', () => {
 
       await app.initServer()
 
-      // manually render less file
+      // manually render styl file
       const stylusOutput = await renderFile()
       const buildOutput = fs.readFileSync(path.join(appDir, 'public/css/styles.css'), 'utf8')
 
@@ -618,7 +656,7 @@ describe('css preprocessors', () => {
       }
     })
 
-    it('should enable inline sourcemaps in dev mode', async () => {
+    it('should enable source maps in dev mode', async () => {
       const app = roosevelt({
         ...appConfig,
         mode: 'development',
@@ -635,11 +673,30 @@ describe('css preprocessors', () => {
       })
 
       await app.initServer()
+      const buildOutput = fs.readFileSync(path.join(appDir, 'public/css/styles.map'), 'utf8')
+      assert(buildOutput.includes('"mappings"'), 'build file is missing source map')
+    })
 
-      const buildOutput = fs.readFileSync(path.join(appDir, 'public/css/styles.css'), 'utf8')
+    it('should enable source maps in prod mode with prodSourceMaps param', async () => {
+      const app = roosevelt({
+        ...appConfig,
+        mode: 'development',
+        prodSourceMaps: true,
+        css: {
+          compiler: {
+            enable: true,
+            module: 'stylus'
+          },
+          minifier: {
+            enable: false
+          },
+          output: 'css'
+        }
+      })
 
-      // check that the build file includes a source map
-      assert(buildOutput.includes('/*# sourceMappingURL=data:application/json;base64'), 'build file is missing source map')
+      await app.initServer()
+      const buildOutput = fs.readFileSync(path.join(appDir, 'public/css/styles.map'), 'utf8')
+      assert(buildOutput.includes('"mappings"'), 'build file is missing source map')
     })
 
     it('should write a version file when enabled', async () => {

--- a/test/sourceParams.js
+++ b/test/sourceParams.js
@@ -23,6 +23,7 @@ describe('sourceParams', () => {
     const blocklist = [
       'appDir',
       'cssCompiler',
+      'preprocessedViewsPath',
       'onClientViewsProcess',
       'onServerInit',
       'onBeforeMiddleware',

--- a/test/util/mvc/controllers/plainHTMLController.js
+++ b/test/util/mvc/controllers/plainHTMLController.js
@@ -7,4 +7,18 @@ module.exports = (router) => {
     // send the plain HTML page back
     res.sendFile(htmlPath)
   })
+
+  router.route('/HTMLTest/nested').get((req, res) => {
+    // save the path of the plain HTML page
+    const htmlPath = path.join(__dirname, '../views/plainHTMLTest.html')
+    // send the plain HTML page back
+    res.sendFile(htmlPath)
+  })
+
+  router.route('/HTMLTest2').get((req, res) => {
+    // save the path of the plain HTML page
+    const htmlPath = path.join(__dirname, '../views/plainHTMLTest.html')
+    // send the plain HTML page back
+    res.sendFile(htmlPath)
+  })
 }

--- a/test/util/sampleConfig.json
+++ b/test/util/sampleConfig.json
@@ -68,6 +68,7 @@
   "secretsPath": "secrets",
   "modelsPath": "value",
   "viewsPath": "value",
+  "preprocessedViewsPath": "value",
   "controllersPath": "value",
   "viewEngine": "none",
   "errorPages": {
@@ -115,13 +116,13 @@
   "symlinks": "value",
   "publicFolder": "value",
   "favicon": "value",
+  "prodSourceMaps": "value",
   "versionedPublic": "value",
   "hostPublic": "value",
   "frontendReload": {
     "enable": false,
-    "port": 9000,
-    "httpsPort": "value",
-    "verbose": "value"
+    "exceptionRoutes": "value",
+    "expressBrowserReloadParams": "value"
   },
   "cleanTimer": "value",
   "clientViews": {


### PR DESCRIPTION
- Breaking: Added new param `preprocessedViewsPath`: Relative path on filesystem to where your preprocessed view files will be written to. Preprocessed view files are view files that have had their uses of web components progressively enhanced using the [progressively-enhance-web-components](https://github.com/rooseveltframework/progressively-enhance-web-components) module.
  - Default: *[String]* `"mvc/.preprocessed_views"`.
  - To disable this feature, set the value to `false`.
  - This is breaking because if you leave it enabled by default (recommended), you will need to add `.preprocessed_views` to your `.gitignore`.
- Breaking: Switched to external source maps for the CSS preprocessor. This necessitated changing the custom CSS preprocessor API to require returning an object instead of a string.
  - If you have written a custom CSS preprocessor, the new return value is: ```javascript return { css: 'write code to output css here', sourceMap: 'write code to output source map here (optional)' } ```
- Added new param `prodSourceMaps` to allow source maps to be generated in prod mode for both CSS and JS.
- Added IP address to the output when the server starts.
- Added new CLI script `secretsGenerator.js` that allows you to combine `certsGenerator.js`, `csrfSecretGEnerator.js`, and `sessionSecretGenerator.js` into one command.
- Added feature to override `appDir` and `secretsPath` for the CLI scripts using `--appDir somewhere` and `--secretsPath somewhere` CLI flags.
- Added `exceptionRoutes` option to the `frontendReload` param.
- Added a check for broken symlinks in the public folder, which will be purged if any exist.
- Added support for placing your Roosevelt config in a `roosevelt.config.json` file in addition to the previous options.
- Added better error when attempting to start a Roosevelt app on a file system that does not support symlinks.
- Changed source maps from inline to external.
- Fixed a bug that caused the JS bundler to not log when it was writing JS files.
- Fixed a bug that caused a `statics/pages` directory being created when it isn't needed.
- Fixed a bug that could cause the public folder and statics folder to be created even when `makeBuildArtifacts` is disabled.
- Fixed a bug that caused the views bundler and isomorphic controllers finder to write a new views bundle to disk even when it wasn't needed.
- Fixed `frontendReload` not working in Firefox with the default HTTPS config.
- Updated various dependencies.

closes https://github.com/rooseveltframework/roosevelt/issues/1494

closes https://github.com/rooseveltframework/roosevelt/issues/1484

closes https://github.com/rooseveltframework/roosevelt/issues/1277

closes https://github.com/rooseveltframework/roosevelt/issues/1086

closes https://github.com/rooseveltframework/roosevelt/issues/1150

closes https://github.com/rooseveltframework/roosevelt/pull/1457/files

closes https://github.com/rooseveltframework/roosevelt/issues/1483