### PR TITLE
0.27.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,52 @@
 
 ## Next version
 
-- Breaking: `port` is now `http.port` and changed the default to `43763`.
-- Breaking: `https.force` was removed in favor of `http.enable`.
-- Breaking:  `authInfoPath`, `passphrase`, `caCert`, `requestCert`, and `rejectUnauthorized` have all been removed from `https` and replaced with `options` where you can pass any [native option](https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions).
-  - The `ca`, `cert`, `key`, and `pfx` params can take file paths relative to your secretsDir in addition to everything else natively supported (strings, buffers, and arrays of strings or buffers).
-  - The file paths get resolved within arrays if you pass arrays to any of those as well.
-- Breaking: `NODE_PORT` env var now sets https port when https is enabled and falls back to http if https is disabled.
-- Breaking: Moved the versioning of webpack from Roosevelt itself to the app.
-- Changed default of `preprocessedViewsPath` param from `'mvc/.preprocessed_views'` to `'.build/.preprocessed_views'`.
-- Changed default of `preprocessedStaticsPath` param from `.preprocessed_statics'` to `'.build/.preprocessed_statics'`.
-- Updated various dependencies.
+- Put your changes here...
+
+## 0.27.0
+
+- Breaking: Changed `http/s` param structure:
+  - Changed `port` param to `http.port` and changed the default to `43763`.
+  - Changed `https.port` param default to `43711`.
+  - Removed `https.force` param. Non-secure `http` can now be disabled via `http.enable` being set to false.
+  - Removed `authInfoPath`, `passphrase`, `caCert`, `requestCert`, and `rejectUnauthorized` params. Replaced them with `options` where you can pass any [native option](https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions).
+    - The `ca`, `cert`, `key`, and `pfx` params can take file paths relative to your `secretsDir` in addition to everything else natively supported (strings, buffers, and arrays of strings or buffers).
+    - The file paths get resolved within arrays if you pass arrays to any of those as well.
+  - These collective changes mean most Roosevelt apps will need to alter their Roosevelt configs from something that looks like:
+    
+    ```
+    "port": 19679,
+    "https": {
+      "enable": true,
+      "port": 19679,
+      "force": true,
+      "authInfoPath": {
+        "authCertAndKey": {
+          "cert": "cert.pem",
+          "key": "key.pem"
+        }
+      }
+    },
+    ```
+  - To be something like this instead:
+    
+    ```
+    "http": {
+      "enable": false
+    },
+    "https": {
+      "enable": true,
+      "port": 19679,
+      "options": {
+        "cert": "cert.pem",
+        "key": "key.pem"
+      }
+    },
+    ```
+- Breaking: Changed behavior of `NODE_PORT` environment variable to now set `https` port when `https` is enabled and fall back to `http` if `https` is disabled.
+- Breaking: Moved the versioning of webpack from Roosevelt itself to the app. You will need to declare webpack as a dependency in your app if you intend to use the JS bundler feature in Roosevelt.
+- Breaking: Changed default of `preprocessedViewsPath` param from `'mvc/.preprocessed_views'` to `'.build/.preprocessed_views'` and changed default of `preprocessedStaticsPath` param from `'.preprocessed_statics'` to `'.build/.preprocessed_statics'`. Collectively these changes mean most Roosevelt apps should remove `.preprocessed_views` and `.preprocessed_statics` from `.gitignore` and add `.build` instead.
+- Updated dependencies.
 
 ## 0.26.1
 
@@ -30,6 +66,7 @@
     - `minifyHtmlAttributesParams`: Params to pass to [minify-html-attributes](https://github.com/rooseveltframework/minify-html-attributes).
       - Default: *[Object]* `{}`
   - Default: *[Object]*
+    
     ```json
     {
       "enable": true,
@@ -56,6 +93,7 @@
   - This is breaking because if you leave it enabled by default (recommended), you will need to add `.preprocessed_views` to your `.gitignore`.
 - Breaking: Switched to external source maps for the CSS preprocessor. This necessitated changing the custom CSS preprocessor API to require returning an object instead of a string.
   - If you have written a custom CSS preprocessor, the new return value is:
+    
     ```javascript
     return {
       css: 'write code to output css here',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
     - The `ca`, `cert`, `key`, and `pfx` params can take file paths relative to your `secretsDir` in addition to everything else natively supported (strings, buffers, and arrays of strings or buffers).
     - The file paths get resolved within arrays if you pass arrays to any of those as well.
   - These collective changes mean most Roosevelt apps will need to alter their Roosevelt configs from something that looks like:
-    
+
     ```
     "port": 19679,
     "https": {
@@ -30,7 +30,7 @@
     },
     ```
   - To be something like this instead:
-    
+
     ```
     "http": {
       "enable": false
@@ -46,7 +46,12 @@
     ```
 - Breaking: Changed behavior of `NODE_PORT` environment variable to now set `https` port when `https` is enabled and fall back to `http` if `https` is disabled.
 - Breaking: Moved the versioning of webpack from Roosevelt itself to the app. You will need to declare webpack as a dependency in your app if you intend to use the JS bundler feature in Roosevelt.
+- Breaking: Changed `js.webpack.bundles.env` param to require values `development` or `production` instead of `dev` or `prod`.
+- Breaking: Changed `js.webpack.bundles.verbose` param to `js.verbose`.
+- Breaking: Changed `--webpack`, `--wp`, and `--w` CLI flags to `--jsbundler`, `--jsb`, and `--j` respectively.
 - Breaking: Changed default of `preprocessedViewsPath` param from `'mvc/.preprocessed_views'` to `'.build/.preprocessed_views'` and changed default of `preprocessedStaticsPath` param from `'.preprocessed_statics'` to `'.build/.preprocessed_statics'`. Collectively these changes mean most Roosevelt apps should remove `.preprocessed_views` and `.preprocessed_statics` from `.gitignore` and add `.build` instead.
+- Added new param `js.customBundler` that will let you define a custom JS bundler.
+- Added new param `js[bundler].customBundlerFunction` that will let you define custom behavior for default supported JS bundlers like Webpack.
 - Updated dependencies.
 
 ## 0.26.1
@@ -66,7 +71,7 @@
     - `minifyHtmlAttributesParams`: Params to pass to [minify-html-attributes](https://github.com/rooseveltframework/minify-html-attributes).
       - Default: *[Object]* `{}`
   - Default: *[Object]*
-    
+
     ```json
     {
       "enable": true,
@@ -93,7 +98,7 @@
   - This is breaking because if you leave it enabled by default (recommended), you will need to add `.preprocessed_views` to your `.gitignore`.
 - Breaking: Switched to external source maps for the CSS preprocessor. This necessitated changing the custom CSS preprocessor API to require returning an object instead of a string.
   - If you have written a custom CSS preprocessor, the new return value is:
-    
+
     ```javascript
     return {
       css: 'write code to output css here',

--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ Below is the default directory structure for an app created using the Roosevelt 
 
 - Built files:
   - `.build`:
-    - `.preprocessed_views`: View files that have had their uses of web components progressively enhanced using the [progressively-enhance-web-components](https://github.com/rooseveltframework/progressively-enhance-web-components) module.
+    - `.preprocessed_statics`: Static files that have been preprocessed by the [minify-html-attributes](https://github.com/rooseveltframework/minify-html-attributes) module, if you have `minifyHtmlAttributes` enabled.
+    - `.preprocessed_views`: View files that have had their uses of web components progressively enhanced using the [progressively-enhance-web-components](https://github.com/rooseveltframework/progressively-enhance-web-components) module and/or preprocessed by the [minify-html-attributes](https://github.com/rooseveltframework/minify-html-attributes) module, if you have `minifyHtmlAttributes` enabled.
 
 - Application infrastructure:
   - `.gitignore`: A standard file which contains a list of files and folders to ignore if your project is in a [git](https://git-scm.com/) repo. Delete it if you're not using git. The default `.gitignore` file contains many common important things to ignore, however you may need to tweak it to your liking before committing a fresh Roosevelt app to your git repo.
@@ -424,7 +425,7 @@ Resolves to:
 
   - `port`: The port your app will run the HTTPS server on.
 
-    - Default: *[Number]* `43733`.
+    - Default: *[Number]* `43711`.
 
   - `autoCert`: Will create self-signed HTTPS certificates in development mode as long as they don't already exist.
 
@@ -1119,7 +1120,7 @@ Resolves to:
 
     - `jsDir` will always be set to Roosevelt's `preprocessedStaticsPath`.
 
-- `preprocessedStaticsPath`: Relative path on filesystem to where your preprocessed static files will be written to. Preprocessed static files are view files that have been preprocessed by the [minify-html-attributes](https://github.com/rooseveltframework/minify-html-attributes) module, if you have `minifyHtmlAttributes` enabled.
+- `preprocessedStaticsPath`: Relative path on filesystem to where your preprocessed static files will be written to. Preprocessed static files are static files that have been preprocessed by the [minify-html-attributes](https://github.com/rooseveltframework/minify-html-attributes) module, if you have `minifyHtmlAttributes` enabled.
 
   - Default: *[String]* `".build/.preprocessed_statics"`.
 

--- a/README.md
+++ b/README.md
@@ -162,14 +162,14 @@ Roosevelt apps created with the app generator come with the following notable [n
 - `node app.js --build`: Only runs the build scripts and doesn't start the app.
   - Default shorthands:
     - `-b`
-- `node app.js --webpack=verbose`: Enables webpack to print verbose errors to the console.
+- `node app.js --jsbundler=verbose`: Enables JS bundler to print verbose errors to the console.
   - Default shorthands:
-    - `--wp=verbose`
-    - `-w=verbose`
-- `node app.js --webpack=verbose-file`: Enables webpack to print verbose errors to the console as well as write a webpackError file to the app's root directory containing the full error.
+    - `--jsb=verbose`
+    - `-j=verbose`
+- `node app.js --jsbundler=verbose-file`: Enables JS bundler to print verbose errors to the console as well as write a jsBundlerError.txt file to the app's root directory containing the full error.
   - Default shorthands:
-    - `--wp=verbose-file`
-    - `-w=verbose-file`
+    - `--jsb=verbose-file`
+    - `-j=verbose-file`
 - `node app.js --production-proxy-mode`: Runs the app in production mode, but with `localhostOnly` set to true and `hostPublic` set to false. This mode will make it so your app only listens to requests coming from localhost and does not serve anything in the public folder. This mode is useful when you want to host your app behind a reverse proxy from a web server like Apache or nginx and [is considered a best practice for Node.js deployments](https://expressjs.com/en/advanced/best-practice-performance.html#use-a-reverse-proxy).
   - Default shorthands:
     - `--prodproxy`
@@ -931,78 +931,34 @@ Resolves to:
 
   - `sourcePath`: Subdirectory within `staticsRoot` where your JS files are located. By default this folder will not be made public, but is instead meant to store unminified JS source files which will be minified and written to the `public` folder when the app is started.
 
-  - `webpack`: Parameters related to bundling JS with [Webpack](https://webpack.js.org/):
+  - `[bundler]`: Parameters related to bundling JS the specified bundler module:
+    - Values you can supply to `bundler`:
+      - `webpack`: See [Webpack site](https://webpack.js.org/) for more details about [Webpack configuration](https://webpack.js.org/configuration/).
+      - `customBundler`: Allows you to define your own custom bundler.
 
-    - `enable`: Enable Webpack bundling.
+    - Params you can pass to your chosen bundler:
+      - `enable`: Enable the bundler.
 
-    - `bundles`: *[Array]* Declare one or more Webpack configurations to bundle JS with.
+      - `bundles`: *[Array]* of *[Objects]* Declare one or more JavaScript bundle files.
 
-      - `env`: *[String]* Bundle only in `dev` or `prod` mode. Omitting `env` will result in bundling in both modes.
+        - `env`: *[String]* Bundle only in development or production mode.
+          - Accepted values:
+            - `'development'`: Development mode.
+            - `'production'`: Production mode.
+            - If no value is set, it will bundle in both modes.
 
-      - `config`: *[Object]* or *[String]* The [Webpack configuration](https://webpack.js.org/configuration/) to send to Webpack. Can also be a path to a [Webpack config file](https://webpack.js.org/configuration/#use-different-config-file) relative to the app directory.
+        - `config`: *[Object]* or *[String]* The config to send to the module bundler. Can also be a path to a config file relative to the app directory.
 
-      - Examples: *[Array]* of *[Objects]*
+        - `customBundlerFunction`: *[Function]* A custom async function to execute for this bundler instead of executing the default one supplied by Roosevelt. This param is required if your bundler is set to `customBundler`.
+          - Arguments provided:
+            - `bundle`: The bundle object supplied by Roosevelt.
+            - `config`: The config object after it has been postprocessed by Roosevelt.
+            - `app`: The Roosevelt app.
 
-        - Webpack bundle example declaring one bundle:
-
-          ```json
-          [
-            {
-              "config": {
-                "entry": "${js.sourcePath}/main.js",
-                "output": {
-                  "path": "${publicFolder}/js",
-                  "filename": "bundle.js"
-                }
-              }
-            }
-          ]
-          ```
-
-        - Webpack bundle example declaring one bundle only used in `dev` mode:
-
-          ```json
-          [
-            {
-              "env": "dev",
-              "config": {
-                "entry": "${js.sourcePath}/main.js",
-                "output": {
-                  "path": "${publicFolder}/js",
-                  "filename": "bundle.js"
-                }
-              }
-            }
-          ]
-          ```
-
-        - Webpack bundle example declaring multiple bundles:
-
-          ```json
-          [
-            {
-              "config": {
-                "entry": "${js.sourcePath}/main.js",
-                "output": {
-                  "path": "${publicFolder}/js",
-                  "filename": "bundle.js"
-                }
-              }
-            },
-            {
-              "config": {
-                "entry": "${js.sourcePath}/moreStuff.js",
-                "output": {
-                  "path": "${publicFolder}/js",
-                  "filename": "bundle2.js"
-                }
-              }
-            },
-            etc...
-          ]
-          ```
-
-    - `verbose`: *[string]* Enable Webpack verbose error handler.
+  - `verbose`: *[String]* Enable verbose error handling.
+    - Accepted values:
+      - `true`: Will print verbose logs to the console.
+      - `'file'`: Will print verbose logs to the console and write them to a file for debugging.
 
   - Default: *[Object]* for manually created apps.
 
@@ -1011,9 +967,9 @@ Resolves to:
       "sourcePath": "js",
       "webpack": {
         "enable": false,
-        "bundles": [],
-        "verbose": false
-      }
+        "bundles": []
+      },
+      "verbose": false
     }
     ```
 

--- a/lib/controllersBundler.js
+++ b/lib/controllersBundler.js
@@ -21,7 +21,7 @@ module.exports = async app => {
   const allControllersFiles = (await walk(controllersPath, { stats: true, entryFilter: item => !finalBlocklist.has(item.path) && !item.stats.isDirectory() })).map(file => file.path)
   const allowlistRegex = /\/\/\s*roosevelt-allowlist\s*([\w-/.]+\.?(js)?)\s*/ // regular expression to grab filename from `// roosevelt-allowlist` tags
   for (const file of allControllersFiles) {
-    const controllerName = path.relative(controllersPath, file)
+    const controllerName = path.relative(controllersPath, file).replace(/\\/g, '/') // windows fix
     const contents = fs.readFileSync(file, 'utf8').trim()
     const controllerComment = contents.split('\n')[0]
     if (controllerComment.includes('roosevelt-blocklist')) {

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -6,7 +6,7 @@
   "https": {
     "enable": false,
     "autoCert": true,
-    "port": 43733,
+    "port": 43711,
     "options": {}
   },
   "mode": "production",

--- a/lib/defaults/config.json
+++ b/lib/defaults/config.json
@@ -113,8 +113,14 @@
     "webpack": {
       "enable": false,
       "bundles": [],
-      "verbose": false
-    }
+      "customBundlerFunction": null
+    },
+    "customBundler": {
+      "enable": false,
+      "bundles": [],
+      "customBundlerFunction": null
+    },
+    "verbose": false
   },
   "publicFolder": "public",
   "favicon": "none",

--- a/lib/jsBundler.js
+++ b/lib/jsBundler.js
@@ -7,77 +7,106 @@ module.exports = async app => {
   const logger = app.get('logger')
 
   // use existence of bundles array members to determine if bundler is enabled
-  if (!params.js.webpack.bundles.length || !params.makeBuildArtifacts) return
+  if (!params.makeBuildArtifacts) return
+  if (params.js?.webpack.enable && !params.js.webpack.bundles.length) return
+  if (params.js?.customBundler.enable && !params.js.customBundler.bundles.length) return
 
-  // check if app was launched in dev or prod mode
-  let bundleEnv
-  if (params.mode === 'development') bundleEnv = 'dev'
-  else bundleEnv = 'prod'
+  if (params.js.webpack) {
+    let webpack
+    if (params.js.webpack) {
+      try {
+        webpack = require('webpack')
+      } catch (err) {
+        logger.error(`${app.get('appName')} failed to include your Webpack JS bundle! Please ensure Webpack is declared properly in your package.json and that it has been properly installed to node_modules.`)
+        logger.warn('JS bundling has been disabled')
+        return
+      }
+    }
+    for (const bundle of params.js.webpack.bundles) {
+      if (bundle.env === params.mode || !bundle.env) {
+        try {
+          await (async () => {
+            let config
 
-  let webpack
-  try {
-    webpack = require('webpack')
-  } catch (err) {
-    logger.error(`${app.get('appName')} failed to include your Webpack JS bundle! Please ensure Webpack is declared properly in your package.json and that it has been properly installed to node_modules.`)
-    logger.warn('JS bundling has been disabled')
-    return
-  }
-
-  // process each bundle
-  const promises = []
-  for (const bundle of params.js.webpack.bundles) {
-    if (bundle.env === bundleEnv || !bundle.env) {
-      promises.push(
-        new Promise((resolve, reject) => {
-          let config
-
-          if (typeof bundle.config === 'string') {
-            // process config as a file path
-            config = require(path.join(app.get('appDir'), bundle.config))
-          } else {
-            // process as config object
-            config = bundle.config
-          }
-
-          // add dev tools to webpack config if in development mode
-          if (app.get('env') === 'development') {
-            if (!config.mode) config.mode = 'development' // only add this if mode isn't already set in the user's config
-            if (!config.devtool) config.devtool = 'source-map' // only add this if devtool isn't already set in the user's config
-          }
-
-          if (params.prodSourceMaps) config.devtool = 'source-map' // enable source maps in prod mode if the setting is set
-
-          // run webpack with specified config
-          webpack(config, (err, stats) => {
-            if (err) {
-              reject(err)
-              return
+            if (typeof bundle.config === 'string') {
+              // process config as a file path
+              config = require(path.join(app.get('appDir'), bundle.config))
+            } else {
+              // process as config object
+              config = bundle.config
             }
 
-            if (stats.hasErrors()) {
-              reject(stats.toJson().errors[0])
-              return
+            if (params.js.webpack.customBundlerFunction) {
+              await params.js.webpack.customBundlerFunction(bundle, config, app)
+            } else {
+              // add dev tools to webpack config if in development mode
+              if (params.mode === 'development') {
+                if (!config.mode) config.mode = 'development' // only add this if mode isn't already set in the user's config
+                if (!config.devtool) config.devtool = 'source-map' // only add this if devtool isn't already set in the user's config
+              }
+
+              if (params.prodSourceMaps) config.devtool = 'source-map' // enable source maps in prod mode if the setting is set
+
+              await new Promise((resolve, reject) => {
+                webpack(config, (err, stats) => {
+                  if (err) {
+                    reject(err)
+                    return
+                  }
+
+                  if (stats.hasErrors()) {
+                    reject(stats.toJson().errors[0])
+                    return
+                  }
+
+                  stats.toJson().assets.map(asset => path.join(config.output.path, asset.name)).forEach(file => logger.log('📝', `${app.get('appName')} writing new JS file ${file}`.green))
+                  resolve()
+                })
+              })
+            }
+          })()
+        } catch (err) {
+          handleBundlingError(err)
+        }
+      }
+    }
+  } else if (params.js.customBundler) {
+    for (const bundle of params.js.customBundler.bundles) {
+      if (bundle.env === params.mode || !bundle.env) {
+        try {
+          await (async () => {
+            let config
+
+            if (typeof bundle.config === 'string') {
+              // process config as a file path
+              config = require(path.join(app.get('appDir'), bundle.config))
+            } else {
+              // process as config object
+              config = bundle.config
             }
 
-            stats.toJson().assets.map(asset => path.join(config.output.path, asset.name)).forEach(file => logger.log('📝', `${app.get('appName')} writing new JS file ${file}`.green))
-            resolve()
-          })
-        })
-      )
+            if (params.js.customBundler.customBundlerFunction) {
+              await params.js.customBundler.customBundlerFunction(bundle, config, app)
+            } else {
+              throw new Error('No customBundlerFunction defined.')
+            }
+          })()
+        } catch (err) {
+          handleBundlingError(err)
+        }
+      }
     }
   }
 
-  try {
-    await Promise.all(promises)
-  } catch (err) {
-    if (params.js.webpack.verbose) {
-      logger.error('Webpack bundling error:')
+  function handleBundlingError (err) {
+    if (params.js.verbose) {
+      logger.error('JS bundling error:')
       logger.error(err)
-      if (params.js.webpack.verbose === 'file') {
-        fs.writeFileSync('./webpackError', JSON.stringify(err), err => { if (err) logger.error(err) }) // else file written successfully
+      if (params.js.verbose === 'file') {
+        fs.writeFileSync('./jsBundlerError.txt', JSON.stringify(err), err => { if (err) logger.error(err) }) // else file written successfully
       }
     } else {
-      logger.error(`Webpack bundling error: ${err.message}`)
+      logger.error(`JS bundling error: ${err.message}`)
     }
   }
 }

--- a/lib/jsBundler.js
+++ b/lib/jsBundler.js
@@ -1,6 +1,6 @@
 require('@colors/colors')
 const path = require('path')
-const fs = require('fs')
+const fs = require('fs-extra')
 
 module.exports = async app => {
   const params = app.get('params')

--- a/lib/scripts/configAuditor.js
+++ b/lib/scripts/configAuditor.js
@@ -574,6 +574,25 @@ async function configAudit (appDir) {
                 }
                 break
               }
+              case 'customBundler': {
+                checkTypes(jsParam[jsKey], jsKey, ['object'])
+                const bundlerParam = jsParam[jsKey] || {}
+                for (const bundlerKey of Object.keys(bundlerParam)) {
+                  keyStack.push(bundlerKey)
+                  switch (bundlerKey) {
+                    case 'enable':
+                      checkTypes(bundlerParam[bundlerKey], bundlerKey, ['boolean'])
+                      break
+                    case 'bundles':
+                      checkTypes(bundlerParam[bundlerKey], bundlerKey, ['array'])
+                      break
+                    default:
+                      foundExtra(['rooseveltConfig', ...keyStack])
+                  }
+                  keyStack.pop(bundlerKey)
+                }
+                break
+              }
               default:
                 foundExtra(['rooseveltConfig', ...keyStack])
             }

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -543,9 +543,9 @@ module.exports = (params, appSchema) => {
   for (const row in configTemplateLiterals) {
     extract = configTemplateLiterals[row].match(/\${(.*)}/).pop()
     const ex = getOrSetObjectByDotNotation(params, extract)
-    // TODO: This warning gets thrown in two instances when it shouldn't and is exposed by the tests:
-    // 1. For top level params that are falsey
-    // 2. Any time more complicated templating logic is used, e.g., ${(http.port + 1)} or ${css.allowlist[0]}
+    // TODO: this warning gets thrown in two instances when it shouldn't and is exposed by the tests:
+    // 1. for top level params that are falsey
+    // 2. any time more complicated templating logic is used, e.g., ${(http.port + 1)} or ${css.allowlist[0]}
     if (!ex) console.warn(`⚠️ Config variable ${extract} does not exist.`)
   }
   return params

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -53,12 +53,12 @@ module.exports = (params, appSchema) => {
         params.makeBuildArtifacts = 'staticsOnly'
       }
 
-      // handle --webpack, --wp, -w cli flags
-      if (flags.webpack === 'verbose' || flags.wp === 'verbose' || flags.w === 'verbose') {
-        params.js.webpack.verbose = true
+      // handle --jsbundler, --jsb, -j cli flags
+      if (flags.jsbundler === 'verbose' || flags.jsb === 'verbose' || flags.j === 'verbose') {
+        params.js.verbose = true
       }
-      if (flags.webpack === 'verbose-file' || flags.wp === 'verbose-file' || flags.w === 'verbose-file') {
-        params.js.webpack.verbose = 'file'
+      if (flags.jsbundler === 'verbose-file' || flags.jsb === 'verbose-file' || flags.j === 'verbose-file') {
+        params.js.verbose = 'file'
       }
 
       // handle --disable-validator, --raw, -r cli flags
@@ -310,9 +310,23 @@ module.exports = (params, appSchema) => {
         bundles: {
           default: defaults.js.webpack.bundles
         },
-        verbose: {
-          default: defaults.js.webpack.verbose
+        customBundlerFunction: {
+          default: defaults.js.webpack.customBundlerFunction
         }
+      },
+      customBundler: {
+        enable: {
+          default: defaults.js.customBundler.enable
+        },
+        bundles: {
+          default: defaults.js.customBundler.bundles
+        },
+        customBundlerFunction: {
+          default: defaults.js.customBundler.customBundlerFunction
+        }
+      },
+      verbose: {
+        default: defaults.js.verbose
       }
     },
     publicFolder: {

--- a/lib/viewsBundler.js
+++ b/lib/viewsBundler.js
@@ -28,7 +28,7 @@ module.exports = async app => {
   const allViewsFiles = (await walk(viewsPath, { stats: true, entryFilter: item => !finalBlocklist.has(item.path) && !item.stats.isDirectory() })).map(file => file.path)
   const allowlistRegex = /<!--+\s*roosevelt-allowlist\s*([\w-/.]+\.?(js)?)\s*--+>/ // regular expression to grab filename from <!-- roosevelt-allowlist --> tags
   for (const file of allViewsFiles) {
-    const templateName = path.relative(viewsPath, file)
+    const templateName = path.relative(viewsPath, file).replace(/\\/g, '/') // windows fix
     const contents = fs.readFileSync(file, 'utf8').trim()
     const templateComment = contents.split('\n')[0]
     if (templateComment.includes('roosevelt-blocklist')) {
@@ -59,7 +59,7 @@ module.exports = async app => {
       for (const file of bundleFiles) {
         const templatePath = path.join(viewsPath, file)
         let templateContent = fs.readFileSync(templatePath, 'utf8').trim()
-        let templateName = path.relative(viewsPath, templatePath)
+        let templateName = path.relative(viewsPath, templatePath).replace(/\\/g, '/') // windows fix
 
         // chop the extension off the template name if the file extension matches the configured view engine
         if (templateName.endsWith(viewEngine)) templateName = file.slice(0, -(viewEngine.length + 1))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.26.1",
+      "version": "0.27.0",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -7069,15 +7069,16 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
-      "integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9709,9 +9710,9 @@
       }
     },
     "node_modules/tr46": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
-      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.0.tgz",
+      "integrity": "sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==",
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -10223,12 +10224,12 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.1.tgz",
-      "integrity": "sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "license": "MIT",
       "dependencies": {
-        "tr46": "^5.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.26.1",
+  "version": "0.27.0",
   "files": [
     "defaultErrorPages",
     "lib",

--- a/test/configAuditor.js
+++ b/test/configAuditor.js
@@ -34,7 +34,7 @@ describe('config auditor', () => {
 
   // wipe out the test app directory after each test
   afterEach(async () => {
-    await fs.remove(path.join(__dirname, 'app'))
+    fs.rmSync(path.join(__dirname, 'app'), { recursive: true, force: true })
   })
 
   it('should start the config audit automatically on first app run', async () => {

--- a/test/configAuditor.js
+++ b/test/configAuditor.js
@@ -78,6 +78,7 @@ describe('config auditor', () => {
     pkgJson.rooseveltConfig.logging.extraParam = true
     pkgJson.rooseveltConfig.js.extraParam = true
     pkgJson.rooseveltConfig.js.webpack.extraParam = true
+    pkgJson.rooseveltConfig.js.customBundler.extraParam = true
 
     // write package.json to app directory
     fs.ensureDirSync(path.join(appDir))
@@ -97,6 +98,7 @@ describe('config auditor', () => {
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js.webpack,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js.customBundler,'))
   })
 
   it('should detect and complain about a missing script', async () => {
@@ -147,6 +149,7 @@ describe('config auditor', () => {
     configFile.logging.extraParam = true
     configFile.js.extraParam = true
     configFile.js.webpack.extraParam = true
+    configFile.js.customBundler.extraParam = true
 
     // write rooseveltConfig.json to app directory
     fs.ensureDirSync(path.join(appDir))
@@ -166,6 +169,7 @@ describe('config auditor', () => {
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.htmlValidator,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js,'))
     assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js.webpack,'))
+    assert(stderr.includes('Extra param "extraParam" found in rooseveltConfig.js.customBundler,'))
   })
 
   it('should scan and detect problems in both package.json and rooseveltConfig.json', async () => {

--- a/test/cssCompiler.js
+++ b/test/cssCompiler.js
@@ -61,7 +61,7 @@ describe('css preprocessors', () => {
     })
 
     afterEach(async () => {
-      await fs.remove(path.join(__dirname, 'app'))
+      fs.rmSync(path.join(__dirname, 'app'), { recursive: true, force: true })
     })
 
     it('should compile all static css files including subdirectories', async () => {
@@ -355,7 +355,7 @@ describe('css preprocessors', () => {
     })
 
     afterEach(async () => {
-      await fs.remove(path.join(__dirname, 'app'))
+      fs.rmSync(path.join(__dirname, 'app'), { recursive: true, force: true })
     })
 
     it('should compile less source file', async () => {
@@ -488,7 +488,7 @@ describe('css preprocessors', () => {
     })
 
     afterEach(async () => {
-      await fs.remove(path.join(__dirname, 'app'))
+      fs.rmSync(path.join(__dirname, 'app'), { recursive: true, force: true })
     })
 
     it('should compile scss source file', async () => {
@@ -615,7 +615,7 @@ describe('css preprocessors', () => {
     })
 
     afterEach(async () => {
-      await fs.remove(path.join(__dirname, 'app'))
+      fs.rmSync(path.join(__dirname, 'app'), { recursive: true, force: true })
     })
 
     it('should compile styl source file', async () => {

--- a/test/errorPages.js
+++ b/test/errorPages.js
@@ -28,7 +28,7 @@ describe('error pages', () => {
   })
 
   afterEach(async () => {
-    await fs.remove(appDir)
+    fs.rmSync(appDir, { recursive: true, force: true })
   })
 
   it('should render the default 404 page if there is a request for an invalid route', done => {

--- a/test/errorPages.js
+++ b/test/errorPages.js
@@ -84,14 +84,6 @@ describe('error pages', () => {
     // fork and run app.js as a child process
     const testApp = fork(path.join(appDir, 'app.js'), { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] })
 
-    // testApp.stdout.on('data', data => {
-    //   console.log(data.toString())
-    // })
-
-    // testApp.stderr.on('data', data => {
-    //   console.log(data.toString())
-    // })
-
     // when the app starts and sends a message back to the parent try and request an invalid route
     testApp.on('message', params => {
       request(`http://localhost:${params.http.port}`)

--- a/test/fileGeneration.js
+++ b/test/fileGeneration.js
@@ -11,7 +11,7 @@ describe('file creation', () => {
 
   afterEach(async () => {
     // wipe out test app
-    await fs.remove(path.join(__dirname, 'app'))
+    fs.rmSync(path.join(__dirname, 'app'), { recursive: true, force: true })
   })
 
   it('should generate several directories at runtime', async () => {

--- a/test/htmlMinify.js
+++ b/test/htmlMinify.js
@@ -54,7 +54,7 @@ describe('HTML minification', () => {
   afterEach(async () => {
     app.stopServer({ persistProcess: true })
 
-    await fs.remove(appDir)
+    fs.rmSync(appDir, { recursive: true, force: true })
   })
 
   it('should minify HTML when enabled', done => {

--- a/test/multipart.js
+++ b/test/multipart.js
@@ -99,14 +99,14 @@ describe('multipart/formidable', () => {
 
   afterEach(() => {
     // wipe out contents of 'complete' directory
-    fs.emptyDirSync(completeDir)
+    fs.rmSync(completeDir, { recursive: true, force: true })
   })
 
   after(done => {
     // stop the server
     context.app.get('httpServer').close(() => {
       // wipe out the app directory
-      fs.removeSync(appDir)
+      fs.rmSync(appDir, { recursive: true, force: true })
 
       done()
     })

--- a/test/paramFunctions.js
+++ b/test/paramFunctions.js
@@ -20,7 +20,7 @@ describe('Method params', () => {
 
   // delete the test app Directory and start with a clean state after each test
   afterEach(async () => {
-    await fs.remove(appDir)
+    fs.rmSync(appDir, { recursive: true, force: true })
   })
 
   it('should execute what is in onServerInit', done => {

--- a/test/publicFolder.js
+++ b/test/publicFolder.js
@@ -25,7 +25,7 @@ describe('Public directory', () => {
 
   // clean up the test app directory after each test
   afterEach(async () => {
-    await fs.remove(appDir)
+    fs.rmSync(appDir, { recursive: true, force: true })
   })
 
   it('should allow for a custom favicon and GET that favicon on request', done => {

--- a/test/rooseveltTest.js
+++ b/test/rooseveltTest.js
@@ -17,7 +17,7 @@ describe('Roosevelt.js', () => {
 
   // clean up the test app directory after each test
   afterEach(async () => {
-    await fs.remove(appDir)
+    fs.rmSync(appDir, { recursive: true, force: true })
   })
 
   it('should compile and run what is on initServer even though we haven\'t passed a parameter object to roosevelt', done => {

--- a/test/routing.js
+++ b/test/routing.js
@@ -36,7 +36,7 @@ describe('routing', () => {
     // stop the server
     context.app.get('httpServer').close(() => {
       // wipe out the app directory
-      fs.removeSync(appDir)
+      fs.rmSync(appDir, { recursive: true, force: true })
       done()
     })
   })

--- a/test/sourceParams.js
+++ b/test/sourceParams.js
@@ -497,7 +497,7 @@ describe('sourceParams', () => {
       assert.deepStrictEqual(appConfig.htmlValidator.enable, false)
     })
 
-    it('should set webpack verbose error handler to false when running in development mode withought webpack argument ', () => {
+    it('should set js bundler verbose error handler to false when running in development mode without argument ', () => {
       // add the cli flag
       process.argv.push('--development')
 
@@ -509,10 +509,10 @@ describe('sourceParams', () => {
 
       const appConfig = app.expressApp.get('params')
 
-      assert.deepStrictEqual(appConfig.js.webpack.verbose, false)
+      assert.deepStrictEqual(appConfig.js.verbose, false)
     })
 
-    it('should set webpack verbose error handler to false when running --dev mode withought webpack argument ', () => {
+    it('should set js bundler verbose error handler to false when running --dev mode without argument ', () => {
       // add the cli flag
       process.argv.push('--dev')
 
@@ -524,10 +524,10 @@ describe('sourceParams', () => {
 
       const appConfig = app.expressApp.get('params')
 
-      assert.deepStrictEqual(appConfig.js.webpack.verbose, false)
+      assert.deepStrictEqual(appConfig.js.verbose, false)
     })
 
-    it('should set webpack verbose error handler to false when running -d mode withought webpack argument ', () => {
+    it('should set js bundler verbose error handler to false when running -d mode without argument ', () => {
       // add the cli flag
       process.argv.push('-d')
 
@@ -539,12 +539,12 @@ describe('sourceParams', () => {
 
       const appConfig = app.expressApp.get('params')
 
-      assert.deepStrictEqual(appConfig.js.webpack.verbose, false)
+      assert.deepStrictEqual(appConfig.js.verbose, false)
     })
 
-    it('should enable webpack verbose error handler via -- --webpack=verbose', () => {
+    it('should enable js bundler verbose error handler via -- --jsbundler=verbose', () => {
       // add the cli flag
-      process.argv.push('--webpack=verbose')
+      process.argv.push('--jsbundler=verbose')
 
       // initialize roosevelt with inverse configs
       const app = require('../roosevelt')({
@@ -553,12 +553,12 @@ describe('sourceParams', () => {
       })
 
       const appConfig = app.expressApp.get('params')
-      assert.deepStrictEqual(appConfig.js.webpack.verbose, true)
+      assert.deepStrictEqual(appConfig.js.verbose, true)
     })
 
-    it('should enable webpack verbose error handler via -- --wp=verbose', () => {
+    it('should enable js bundler verbose error handler via -- --jsb=verbose', () => {
       // add the cli flag
-      process.argv.push('--wp=verbose')
+      process.argv.push('--jsb=verbose')
 
       // initialize roosevelt with inverse configs
       const app = require('../roosevelt')({
@@ -567,12 +567,12 @@ describe('sourceParams', () => {
       })
 
       const appConfig = app.expressApp.get('params')
-      assert.deepStrictEqual(appConfig.js.webpack.verbose, true)
+      assert.deepStrictEqual(appConfig.js.verbose, true)
     })
 
-    it('should enable webpack verbose error handler via -- -w=verbose', () => {
+    it('should enable js bundler verbose error handler via -- -j=verbose', () => {
       // add the cli flag
-      process.argv.push('-w=verbose')
+      process.argv.push('-j=verbose')
 
       // initialize roosevelt with inverse configs
       const app = require('../roosevelt')({
@@ -581,27 +581,12 @@ describe('sourceParams', () => {
       })
 
       const appConfig = app.expressApp.get('params')
-      assert.deepStrictEqual(appConfig.js.webpack.verbose, true)
+      assert.deepStrictEqual(appConfig.js.verbose, true)
     })
 
-    it('should enable webpack verbose error handler via -- --webpack=verbose-file', () => {
+    it('should enable js bundler verbose error handler via -- --jsbundler=verbose-file', () => {
       // add the cli flag
-      process.argv.push('--webpack=verbose-file')
-
-      // initialize roosevelt with inverse configs
-      const app = require('../roosevelt')({
-        mode: 'development',
-        ...config
-      })
-
-      const appConfig = app.expressApp.get('params')
-
-      assert.deepStrictEqual(appConfig.js.webpack.verbose, 'file')
-    })
-
-    it('should enable webpack verbose error handler via -- --wp=verbose-file', () => {
-      // add the cli flag
-      process.argv.push('--wp=verbose-file')
+      process.argv.push('--jsbundler=verbose-file')
 
       // initialize roosevelt with inverse configs
       const app = require('../roosevelt')({
@@ -611,12 +596,12 @@ describe('sourceParams', () => {
 
       const appConfig = app.expressApp.get('params')
 
-      assert.deepStrictEqual(appConfig.js.webpack.verbose, 'file')
+      assert.deepStrictEqual(appConfig.js.verbose, 'file')
     })
 
-    it('should enable webpack verbose error handler via -- -w=verbose-file', () => {
+    it('should enable js bundler verbose error handler via -- --jsb=verbose-file', () => {
       // add the cli flag
-      process.argv.push('-w=verbose-file')
+      process.argv.push('--jsb=verbose-file')
 
       // initialize roosevelt with inverse configs
       const app = require('../roosevelt')({
@@ -626,7 +611,22 @@ describe('sourceParams', () => {
 
       const appConfig = app.expressApp.get('params')
 
-      assert.deepStrictEqual(appConfig.js.webpack.verbose, 'file')
+      assert.deepStrictEqual(appConfig.js.verbose, 'file')
+    })
+
+    it('should enable js bundler verbose error handler via -- -j=verbose-file', () => {
+      // add the cli flag
+      process.argv.push('-j=verbose-file')
+
+      // initialize roosevelt with inverse configs
+      const app = require('../roosevelt')({
+        mode: 'development',
+        ...config
+      })
+
+      const appConfig = app.expressApp.get('params')
+
+      assert.deepStrictEqual(appConfig.js.verbose, 'file')
     })
   })
 

--- a/test/sourceParams.js
+++ b/test/sourceParams.js
@@ -38,7 +38,7 @@ describe('sourceParams', () => {
 
     afterEach(async () => {
       // wipe out the test app directory
-      await fs.remove(path.join(__dirname, 'app'))
+      fs.rmSync(path.join(__dirname, 'app'), { recursive: true, force: true })
     })
 
     it('should set params from package.json', () => {

--- a/test/util/sampleConfig.json
+++ b/test/util/sampleConfig.json
@@ -109,8 +109,14 @@
     "webpack": {
       "enable": "value",
       "bundles": "value",
-      "verbose" : false
-    }
+      "customBundlerFunction": null
+    },
+    "customBundler": {
+      "enable": "value",
+      "bundles": "value",
+      "customBundlerFunction": null
+    },
+    "verbose" : false
   },
   "symlinks": "value",
   "publicFolder": "value",

--- a/test/viewEngine.js
+++ b/test/viewEngine.js
@@ -19,7 +19,7 @@ describe('view engines', () => {
   })
 
   afterEach(async () => {
-    await fs.remove(appDir)
+    fs.rmSync(appDir, { recursive: true, force: true })
   })
 
   it('should render the teddy test page', done => {

--- a/test/viewsBundler.js
+++ b/test/viewsBundler.js
@@ -49,7 +49,7 @@ describe('views bundler', () => {
   `
 
   afterEach(async () => {
-    await fs.remove(appDir)
+    fs.rmSync(appDir, { recursive: true, force: true })
   })
 
   it('should bundle templates in allowlist while ignoring templates in the blocklist', async () => {

--- a/test/webpack.js
+++ b/test/webpack.js
@@ -10,7 +10,7 @@ describe('webpack', () => {
   const appDir = path.join(__dirname, 'app/webpack')
   const webpackConfig = [
     {
-      env: 'prod',
+      env: 'production',
       config: {
         mode: 'production',
         entry: '${js.sourcePath}/a.js',
@@ -21,7 +21,7 @@ describe('webpack', () => {
       }
     },
     {
-      env: 'dev',
+      env: 'development',
       config: {
         entry: '${js.sourcePath}/a.js',
         output: {
@@ -87,7 +87,7 @@ describe('webpack', () => {
       appDir,
       makeBuildArtifacts: true,
       js: {
-        sourceDir: 'js',
+        sourcePath: 'js',
         webpack: {
           enable: true,
           bundles: webpackConfig
@@ -118,7 +118,7 @@ describe('webpack', () => {
       appDir,
       makeBuildArtifacts: true,
       js: {
-        sourceDir: 'js',
+        sourcePath: 'js',
         webpack: {
           enable: true,
           bundles: webpackConfig
@@ -146,7 +146,7 @@ describe('webpack', () => {
       appDir,
       makeBuildArtifacts: true,
       js: {
-        sourceDir: 'js',
+        sourcePath: 'js',
         webpack: {
           enable: true,
           bundles: [
@@ -187,7 +187,7 @@ describe('webpack', () => {
         enable: false
       },
       js: {
-        sourceDir: 'js',
+        sourcePath: 'js',
         webpack: {
           enable: true,
           bundles: [
@@ -228,7 +228,7 @@ describe('webpack', () => {
         enable: false
       },
       js: {
-        sourceDir: 'js',
+        sourcePath: 'js',
         webpack: {
           enable: true,
           bundles: [

--- a/test/webpack.js
+++ b/test/webpack.js
@@ -69,7 +69,7 @@ describe('webpack', () => {
 
   afterEach(async () => {
     // wipe out the test app directory
-    await fs.remove(path.join(__dirname, 'app'))
+    fs.rmSync(path.join(__dirname, 'app'), { recursive: true, force: true })
   })
 
   it('should build prod bundle using supplied webpack config', async () => {


### PR DESCRIPTION
- Breaking: Changed `http/s` param structure:
  - Changed `port` param to `http.port` and changed the default to `43763`.
  - Changed `https.port` param default to `43711`.
  - Removed `https.force` param. Non-secure `http` can now be disabled via `http.enable` being set to false.
  - Removed `authInfoPath`, `passphrase`, `caCert`, `requestCert`, and `rejectUnauthorized` params. Replaced them with `options` where you can pass any [native option](https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions).
    - The `ca`, `cert`, `key`, and `pfx` params can take file paths relative to your `secretsDir` in addition to everything else natively supported (strings, buffers, and arrays of strings or buffers).
    - The file paths get resolved within arrays if you pass arrays to any of those as well.
  - These collective changes mean most Roosevelt apps will need to alter their Roosevelt configs from something that looks like:

    ```
    "port": 19679,
    "https": {
      "enable": true,
      "port": 19679,
      "force": true,
      "authInfoPath": {
        "authCertAndKey": {
          "cert": "cert.pem",
          "key": "key.pem"
        }
      }
    },
    ```
  - To be something like this instead:

    ```
    "http": {
      "enable": false
    },
    "https": {
      "enable": true,
      "port": 19679,
      "options": {
        "cert": "cert.pem",
        "key": "key.pem"
      }
    },
    ```
- Breaking: Changed behavior of `NODE_PORT` environment variable to now set `https` port when `https` is enabled and fall back to `http` if `https` is disabled.
- Breaking: Moved the versioning of webpack from Roosevelt itself to the app. You will need to declare webpack as a dependency in your app if you intend to use the JS bundler feature in Roosevelt.
- Breaking: Changed `js.webpack.bundles.env` param to require values `development` or `production` instead of `dev` or `prod`.
- Breaking: Changed `js.webpack.bundles.verbose` param to `js.verbose`.
- Breaking: Changed `--webpack`, `--wp`, and `--w` CLI flags to `--jsbundler`, `--jsb`, and `--j` respectively.
- Breaking: Changed default of `preprocessedViewsPath` param from `'mvc/.preprocessed_views'` to `'.build/.preprocessed_views'` and changed default of `preprocessedStaticsPath` param from `'.preprocessed_statics'` to `'.build/.preprocessed_statics'`. Collectively these changes mean most Roosevelt apps should remove `.preprocessed_views` and `.preprocessed_statics` from `.gitignore` and add `.build` instead.
- Added new param `js.customBundler` that will let you define a custom JS bundler.
- Added new param `js[bundler].customBundlerFunction` that will let you define custom behavior for default supported JS bundlers like Webpack.
- Updated dependencies.

closes https://github.com/rooseveltframework/roosevelt/issues/1503 by dropping CI support for Node.js 18.