### PR TITLE
0.29.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Put your changes here...
 
+## 0.29.2
+
+- Fixed a bug that would cause `MAKE_BUILD_ARTIFACTS` to supersede the `--build` CLI flag.
+- Fixed a bug that would cause an error to falsely print about not being able to create symlinks.
+- Updated dependencies.
+
 ## 0.29.1
 
 - Fixed bugs associated with `MAKE_BUILD_ARTIFACTS` sometimes not working properly.

--- a/lib/generateSymlinks.js
+++ b/lib/generateSymlinks.js
@@ -11,7 +11,7 @@ module.exports = app => {
   // process symlinks
   if (params.makeBuildArtifacts) {
     // test that symlink creation works in general; fixes https://github.com/rooseveltframework/roosevelt/issues/1484
-    const source = '.gitignore'
+    const source = 'package.json'
     const dest = 'testIfSymlinksWork'
     try {
       if (process.platform === 'win32') {

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -8,6 +8,11 @@ const template = require('./tools/templateLiteralRenderer')
 module.exports = (params, appSchema) => {
   const appDir = params.appDir
 
+  // set makeBuildArtifacts by env var
+  if (process.env.MAKE_BUILD_ARTIFACTS === 'true') params.makeBuildArtifacts = true
+  if (process.env.MAKE_BUILD_ARTIFACTS === 'false') params.makeBuildArtifacts = false
+  if (process.env.MAKE_BUILD_ARTIFACTS === 'staticsOnly') params.makeBuildArtifacts = 'staticsOnly'
+
   // determine if app has a package.json
   let pkg
   try {
@@ -521,11 +526,6 @@ module.exports = (params, appSchema) => {
   if (process.env.DISABLE_HTTPS === 'true') {
     params.https.enable = false
   }
-
-  // set makeBuildArtifacts by env var
-  if (process.env.MAKE_BUILD_ARTIFACTS === 'true') params.makeBuildArtifacts = true
-  if (process.env.MAKE_BUILD_ARTIFACTS === 'false') params.makeBuildArtifacts = false
-  if (process.env.MAKE_BUILD_ARTIFACTS === 'staticsOnly') params.makeBuildArtifacts = 'staticsOnly'
 
   // hostPublic always true in dev mode
   if (params.mode === 'development') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.29.1",
+  "version": "0.29.2",
   "files": [
     "defaultErrorPages",
     "lib",


### PR DESCRIPTION
- Fixed a bug that would cause `MAKE_BUILD_ARTIFACTS` to supersede the `--build` CLI flag.
- Fixed a bug that would cause an error to falsely print about not being able to create symlinks.
- Updated dependencies.