### PR TITLE
0.31.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.31.3
+
+- Added warning to the debug markup on 403 "forbidden" POST error pages instructing the user to include the CSRF token in their request.
+- Fixed a bug that could cause `undefined` to print on error pages in certain circumstances.
+- Updated dependencies.
+
 ## 0.31.2
 
 - Fixed bug that caused cookie parser to not load under certain circumstances.

--- a/CODING-APPS.md
+++ b/CODING-APPS.md
@@ -57,7 +57,7 @@ To do that, include the CSRF token in your HTML form as a hidden input `_csrf`:
 module.exports = (router, app) => {
   router.route('/form').get((req, res) => {
     const model = require('models/dataModel')()
-    model.token = req.csrfToken() // add CSRF token to the model
+    model.csrfToken = req.csrfToken() // add CSRF token to the model
     res.render('about', model)
   })
 }
@@ -66,7 +66,7 @@ module.exports = (router, app) => {
 ```html
 <!-- form that include the token in a request body -->
 <form action="/some-protected-endpoint" method="post">
-  <input type="hidden" name="_csrf" value="{token}">
+  <input type="hidden" name="_csrf" value="{csrfToken}">
 </form>
 ```
 
@@ -77,7 +77,7 @@ You can also add the token as a request header when performing fetch requests by
 const response = await fetch('/some-protected-endpoint', {
   method: 'POST',
   headers: {
-    'X-CSRF-TOKEN': token
+    'X-CSRF-TOKEN': csrfToken // extract it from the DOM or something
   }
 })
 ```

--- a/defaultErrorPages/controllers/403.js
+++ b/defaultErrorPages/controllers/403.js
@@ -10,7 +10,9 @@ module.exports = (app, req, res) => {
     appVersion: req.app.get('appVersion') ? ` ${req.app.get('appVersion')}` : ''
   }
   let errorTemplate = template(errorPage, model)
-  if (process.env.NODE_ENV === 'development' && req.app.get('routes').length) errorTemplate = errorTemplate.replace('</footer>', `${req.app.get('debugMarkup')}</footer>`)
+  let csrfWarning = ''
+  if (req.app.get('params').csrfProtection && req.method === 'POST') csrfWarning = '<p><strong>The most common cause of this error is forgetting to include the CSRF token in the request. See <a href="https://rooseveltframework.org/docs/latest/coding-apps/#examplepostroute">example POST route</a> for more information about how to make POST requests.</strong></p>'
+  if (process.env.NODE_ENV === 'development' && req.app.get('routes').length) errorTemplate = errorTemplate.replace('</footer>', `${csrfWarning}${req.app.get('debugMarkup') || ''}</footer>`)
   res.setHeader('Connection', 'close')
   res.status(403)
   res.send(errorTemplate)

--- a/defaultErrorPages/controllers/404.js
+++ b/defaultErrorPages/controllers/404.js
@@ -11,7 +11,7 @@ module.exports = app => {
       appVersion: req.app.get('appVersion') ? ` ${req.app.get('appVersion')}` : ''
     }
     let errorTemplate = template(errorPage, model)
-    if (process.env.NODE_ENV === 'development' && req.app.get('routes').length) errorTemplate = errorTemplate.replace('</footer>', `${req.app.get('debugMarkup')}</footer>`)
+    if (process.env.NODE_ENV === 'development' && req.app.get('routes').length) errorTemplate = errorTemplate.replace('</footer>', `${req.app.get('debugMarkup') || ''}</footer>`)
     res.status(404)
     res.send(errorTemplate)
   })

--- a/defaultErrorPages/controllers/503.js
+++ b/defaultErrorPages/controllers/503.js
@@ -10,7 +10,7 @@ module.exports = (app, req, res) => {
     appVersion: req.app.get('appVersion') ? ` ${req.app.get('appVersion')}` : ''
   }
   let errorTemplate = template(errorPage, model)
-  if (process.env.NODE_ENV === 'development' && req.app.get('routes').length) errorTemplate = errorTemplate.replace('</footer>', `${req.app.get('debugMarkup')}</footer>`)
+  if (process.env.NODE_ENV === 'development' && req.app.get('routes').length) errorTemplate = errorTemplate.replace('</footer>', `${req.app.get('debugMarkup') || ''}</footer>`)
   res.setHeader('Connection', 'close')
   res.status(503)
   res.send(errorTemplate)

--- a/defaultErrorPages/controllers/5xx.js
+++ b/defaultErrorPages/controllers/5xx.js
@@ -12,7 +12,7 @@ module.exports = (app, err, req, res) => {
     appVersion: req.app.get('appVersion') ? ` ${req.app.get('appVersion')}` : ''
   }
   let errorTemplate = template(errorPage, model)
-  if (process.env.NODE_ENV === 'development' && req.app.get('routes').length) errorTemplate = errorTemplate.replace('</footer>', `${req.app.get('debugMarkup')}</footer>`)
+  if (process.env.NODE_ENV === 'development' && req.app.get('routes').length) errorTemplate = errorTemplate.replace('</footer>', `${req.app.get('debugMarkup') || ''}</footer>`)
   res.status(status)
   res.send(errorTemplate)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.31.2",
+      "version": "0.31.3",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -2903,9 +2903,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.180",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.180.tgz",
-      "integrity": "sha512-ED+GEyEh3kYMwt2faNmgMB0b8O5qtATGgR4RmRsIp4T6p7B8vdMbIedYndnvZfsaXvSzegtpfqRMDNCjjiSduA==",
+      "version": "1.5.181",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.181.tgz",
+      "integrity": "sha512-+ISMj8OIQ+0qEeDj14Rt8WwcTOiqHyAB+5bnK1K7xNNLjBJ4hRCQfUkw8RWtcLbfBzDwc15ZnKH0c7SNOfwiyA==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.31.2",
+  "version": "0.31.3",
   "files": [
     "defaultErrorPages",
     "lib",

--- a/test/csrfProtection.js
+++ b/test/csrfProtection.js
@@ -52,8 +52,8 @@ describe('CSRF', () => {
         onServerInit: app => {
           const router = app.get('router')
           router.get('/', (req, res) => {
-            const token = req.csrfToken()
-            res.json({ token })
+            const csrfToken = req.csrfToken()
+            res.json({ csrfToken })
           })
           router.post('/protected', (req, res) => {
             res.json({ message: 'protected' })
@@ -91,12 +91,12 @@ describe('CSRF', () => {
         .expect(200)
         .end((err, res) => {
           if (err) throw err
-          const token = res.body.token
-          assert(token)
+          const csrfToken = res.body.csrfToken
+          assert(csrfToken)
 
           request(context.app)
             .post('/protected')
-            .set('X-CSRF-TOKEN', token)
+            .set('X-CSRF-TOKEN', csrfToken)
             .expect(200)
             .end((err, res) => {
               if (err) throw (err)
@@ -227,8 +227,8 @@ describe('CSRF', () => {
         onServerInit: app => {
           const router = app.get('router')
           router.get('/', (req, res) => {
-            const token = req.csrfToken()
-            res.json({ token })
+            const csrfToken = req.csrfToken()
+            res.json({ csrfToken })
           })
 
           router.post('/protected', (req, res) => {
@@ -331,12 +331,12 @@ describe('CSRF', () => {
             .expect(200)
             .end((err, res) => {
               if (err) throw err
-              const token = res.body.token
-              assert(token)
+              const csrfToken = res.body.csrfToken
+              assert(csrfToken)
 
               request(context.app)
                 .post('/protected')
-                .set('X-CSRF-TOKEN', token)
+                .set('X-CSRF-TOKEN', csrfToken)
                 .expect(200)
                 .end((err, res) => {
                   if (err) throw (err)


### PR DESCRIPTION
- Added warning to the debug markup on 403 "forbidden" POST error pages instructing the user to include the CSRF token in their request.
- Fixed a bug that could cause `undefined` to print on error pages in certain circumstances.
- Updated dependencies.