### PR TITLE
0.31.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.31.5",
+  "version": "0.31.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.31.5",
+      "version": "0.31.6",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.31.5",
+  "version": "0.31.6",
   "files": [
     "defaultErrorPages",
     "lib",


### PR DESCRIPTION
- Fixed hardcoded express 4 dependency mistakenly set to express 5.
- Updated dependencies.