### PR TITLE
Configure renovate to keep express4 within 4.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,9 @@
     ":ignoreUnstable",
     ":respectLatest",
     ":disableDependencyDashboard"
-  ]
+  ],
+  "packageRules": {
+    "matchPackageNames": ["express4"],
+    "allowedVersions": "^4.0.0"
+  }
 }


### PR DESCRIPTION
As per [the renovate docs](https://docs.renovatebot.com/configuration-options/#allowedversions) this should prevent renovate trying to update express4 to 5+.