### PR TITLE
0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.33.1
+
+- Fixed the `--build` and `-b` command line flags starting a server instead of only running the build. Serving a static site was added in 0.33.0 by keying off `makeBuildArtifacts` being `staticsOnly`, which is also what `--build` sets, so the two behaviors could not be told apart and `--build` began serving the app it had just built.
+- Added `buildOnly` param, which is what `--build` and `-b` set now. What gets built and whether the app then serves it are separate questions, so they are separate params. Calling `initServer` (`init`) rather than `startServer` does the same thing and is the better fit for a build script that drives Roosevelt directly.
+- Updated dependencies.
+
 ## 0.33.0
 
 - Breaking: Added `watchStatics` param, defaulted to true. In development mode Roosevelt now rebuilds your static files as you edit the files they are built from, then tells the browser to reload. To migrate:

--- a/CONFIG-APP-BEHAVIOR.md
+++ b/CONFIG-APP-BEHAVIOR.md
@@ -144,20 +144,19 @@ Default: *[Object]*
   - Only those repeating notices are held back. Anything reporting an actual problem, such as a missing favicon or a file that failed to compile, always prints.
   - Roosevelt remembers which notices it has shown in your system's temp directory, so restarting the app does not bring them all back. Rebooting, or waiting a day, does.
   - Can also be set with the `--quieter-startup` or `-q` command line flags, or the `QUIETER_STARTUP` environment variable.
-
 - `makeBuildArtifacts` *[Boolean or String]*: When enabled Roosevelt will generate user-specified directories, CSS/JS bundles, etc.
   - Defaults to `false` for apps created manually.
   - Will be set to `true` in apps generated with the app generator.
   - Can also accept a value of `"staticsOnly"` which will allow Roosevelt to create static files but skip the creation of the MVC directories.
-
+- `buildOnly` *[Boolean]*: When enabled `startServer` builds the app and stops there rather than listening for requests. Use it for a build step in CI or a deploy, which has to finish and exit rather than sit on a port. Default: `false`.
+  - Set by the `--build` and `-b` command line flags, which also set `makeBuildArtifacts` to `"staticsOnly"`.
+  - Calling `initServer` (`init`) instead of `startServer` has the same effect, and is the better fit when your build script drives Roosevelt directly rather than being handed command line flags.
 - `incrementalBuilds` *[Boolean]*: When enabled Roosevelt will skip regenerating a static file if none of the source files it was built from have changed since the last build. This applies to files declared in the `copy` param too, which are left alone when neither the source nor the copy has changed. Default: `true`.
   - Set to `false` to disable the feature and rebuild everything on every start. Deleting your `buildFolder` has the same one-time effect.
-
 - `routePrefix` *[String]*: A prefix prepended to your application's routes. Applies to all routes and static files. Default: `null`.
   - Example: When set to `"foo"` a route bound to `/` will be instead be bound to `/foo/`.
   - This prefix is exposed via the `routePrefix` Express variable which should be used for resolving the absolute paths to statics programmatically.
     - Example: An image located at `/images/teddy.jpg` can be resolved in a prefix-agnostic way via `${app.get('routePrefix')}/images/teddy.jpg`.
-
 - `viewEngine` *[String]*: What templating engine to use, formatted as `"fileExtension: nodeModule"`.
   - Defaults to `"none"` for apps created manually.
   - Will be set to `"html: teddy"` in apps generated with the app generator.

--- a/lib/sourceParams.js
+++ b/lib/sourceParams.js
@@ -78,7 +78,10 @@ module.exports = (params, appSchema) => {
 
       // handle the build flags, e.g. --build, -b
       const makeBuildArtifacts = suppliedSwitch(flags, commandLineFlags.makeBuildArtifacts)
-      if (makeBuildArtifacts !== undefined) params.makeBuildArtifacts = makeBuildArtifacts
+      if (makeBuildArtifacts !== undefined) {
+        params.makeBuildArtifacts = makeBuildArtifacts
+        params.buildOnly = true
+      }
 
       // handle the js bundler flags, e.g. --jsbundler verbose, --jsb verbose-file
       const jsBundler = suppliedValue(flags, commandLineFlags.js.verbose)
@@ -147,6 +150,9 @@ module.exports = (params, appSchema) => {
       default: 'development-mode'
     },
     makeBuildArtifacts: {
+      default: false
+    },
+    buildOnly: {
       default: false
     },
     localhostOnly: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roosevelt",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roosevelt",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "license": "CC-BY-4.0",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -2460,9 +2460,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
+      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3131,9 +3131,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.18",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.18.tgz",
-      "integrity": "sha512-1iEmLEYSiE1SeBoAfPo/Mnx3PzfzHUkDK61ASkCpuk3YXugYLH5DYK1SzqV55F8FMI6s0F+/tCP7Polz1QRjxw==",
+      "version": "2.11.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+      "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3424,9 +3424,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001809",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
-      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -4278,9 +4278,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.412",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.412.tgz",
-      "integrity": "sha512-z4rMe3esBzlzovKHj4gxJnsCGZRK5l4baUvm+gCGJBPE+gsyUMKsuU9tnEUtI1dOebXz1ytAPGjvXhmQ7rIPwA==",
+      "version": "1.5.414",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.414.tgz",
+      "integrity": "sha512-aYlviXiaXBbzvKgyALpcMmqa3Np3sDr0XnZbEG62n2UpZFbEcjQ4EEMOLGzVPhwVnwTz0lvKY+GcARbunuHekw==",
       "dev": true,
       "license": "ISC"
     },
@@ -8566,9 +8566,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/roosevelt/graphs/contributors"
     }
   ],
-  "version": "0.33.0",
+  "version": "0.33.1",
   "files": [
     "*.md",
     "config.js",

--- a/roosevelt.js
+++ b/roosevelt.js
@@ -237,6 +237,9 @@ const roosevelt = (options = {}, schema) => {
   async function startServer (args) {
     if (args) throw new Error('Roosevelt\'s startServer method does not take arguments. You may have meant to pass parameters to Roosevelt\'s constructor instead.')
     await initServer()
+
+    if (params.buildOnly) return
+
     let listeningServers = 0
     let numberOfServers = 0
     if (params.http.enable) numberOfServers++

--- a/test/routing.js
+++ b/test/routing.js
@@ -147,13 +147,14 @@ describe('routing', () => {
         logging: { methods: { http: false } }, // morgan writes straight to the console rather than through roosevelt's logger, so it cannot be collected and would print during the run
         appDir,
         expressSession: false,
+        http: { port: 30152 }, // an explicit port rather than the default, which sits inside the range the os hands out for outbound connections and so can be taken by another process on the machine
         onServerStart: app => {
           context.app = app
         }
       })
       await rooseveltApp.startServer()
       finish(capturedLogs => {
-        if (capturedLogs.includes('Roosevelt Express HTTP server listening on port 43763 (production mode)')) pass = true
+        if (capturedLogs.includes('Roosevelt Express HTTP server listening on port 30152 (production mode)')) pass = true
         else pass = false
         if (pass) done()
         else done(new Error('server did not properly respond to the request'))

--- a/test/sourceParams.js
+++ b/test/sourceParams.js
@@ -265,6 +265,34 @@ describe('sourceParams', () => {
       process.argv = processArgv.slice()
     })
 
+    it('should build and not serve via --build', () => {
+      // --build has always meant "build the app and stop there"
+      // it sets two separate things: what gets built, and whether the app serves it afterwards
+      process.argv.push('--build')
+
+      const appConfig = require('../roosevelt')({ ...config }).expressApp.get('params')
+
+      assert.strictEqual(appConfig.makeBuildArtifacts, 'staticsOnly')
+      assert.strictEqual(appConfig.buildOnly, true)
+    })
+
+    it('should build and not serve via -b', () => {
+      process.argv.push('-b')
+
+      const appConfig = require('../roosevelt')({ ...config }).expressApp.get('params')
+
+      assert.strictEqual(appConfig.makeBuildArtifacts, 'staticsOnly')
+      assert.strictEqual(appConfig.buildOnly, true)
+    })
+
+    it('should not turn a static site into a build only run just because it is a static site', () => {
+      // a static site says staticsOnly in its config for good, and still wants to be served when run without --build
+      const appConfig = require('../roosevelt')({ ...config, makeBuildArtifacts: 'staticsOnly' }).expressApp.get('params')
+
+      assert.strictEqual(appConfig.makeBuildArtifacts, 'staticsOnly')
+      assert.strictEqual(appConfig.buildOnly, false)
+    })
+
     it('should set production proxy mode via --production-proxy-mode', () => {
       // add the cli flag
       process.argv.push('--production-proxy-mode')

--- a/test/staticsPipeline.js
+++ b/test/staticsPipeline.js
@@ -412,4 +412,83 @@ describe('statics pipeline', () => {
       assert.ok(captured.includes('will not generate build artifacts'), `expected a warning, got: ${JSON.stringify(captured.slice(0, 300))}`)
     })
   })
+
+  describe('building without serving', () => {
+    // startServer serves a staticsOnly app as of 0.33.0, where it used to build and then stop short of listening
+    // init is what builds without listening, and a build step in ci or a deploy has to finish and exit rather than sit on a port
+    it('should build a static site without starting a server', async () => {
+      fs.outputFileSync(path.join(appDir, 'statics/pages/index.html'), '<p>a static site</p>')
+
+      const app = roosevelt({
+        ...appConfig,
+        makeBuildArtifacts: 'staticsOnly',
+        viewEngine: 'html: teddy',
+        http: { enable: true, port: 30141 }
+      })
+      await app.init()
+
+      assert.ok(fs.readFileSync(path.join(appDir, 'public/index.html'), 'utf8').includes('a static site'), 'the site should have been built')
+      await assert.rejects(fetch('http://localhost:30141/'), 'nothing should be listening on the port it would have used')
+
+      // init builds the server object but never binds it, which is the difference between it and startServer
+      assert.strictEqual(app.expressApp.get('httpServer').listening, false)
+    })
+
+    it('should build and stop there when buildOnly is set, which is what the --build flag sets', async () => {
+      // --build has always meant build the app and do not serve it
+      // this is deliberately separate from makeBuildArtifacts, which says what gets built rather than whether it is served
+      fs.outputFileSync(path.join(appDir, 'statics/pages/index.html'), '<p>a static site</p>')
+
+      const app = roosevelt({
+        ...appConfig,
+        makeBuildArtifacts: 'staticsOnly',
+        buildOnly: true,
+        viewEngine: 'html: teddy',
+        http: { enable: true, port: 30143 }
+      })
+      await app.startServer()
+
+      assert.ok(fs.readFileSync(path.join(appDir, 'public/index.html'), 'utf8').includes('a static site'), 'the site should have been built')
+      await assert.rejects(fetch('http://localhost:30143/'), 'startServer should not have listened')
+      assert.strictEqual(app.expressApp.get('httpServer').listening, false)
+    })
+
+    it('should serve a static site that has not asked for a build only run', async () => {
+      // being a static site is not the same as being a build, so this one does listen
+      fs.outputFileSync(path.join(appDir, 'statics/pages/index.html'), '<p>a static site</p>')
+
+      // development mode so that shutting down destroys the connection this test opens rather than waiting on it
+      const app = roosevelt({
+        ...appConfig,
+        mode: 'development',
+        makeBuildArtifacts: 'staticsOnly',
+        frontendReload: { enable: false },
+        viewEngine: 'html: teddy',
+        http: { enable: true, port: 30144 }
+      })
+      await app.startServer()
+
+      const res = await fetch('http://localhost:30144/')
+      assert.strictEqual(res.status, 200)
+      assert.ok((await res.text()).includes('a static site'))
+
+      await app.stopServer({ persistProcess: true })
+    })
+
+    it('should build an app that is not a static site without starting a server either', async () => {
+      fs.outputFileSync(path.join(appDir, 'statics/css/main.css'), 'p { color: red; }')
+
+      const app = roosevelt({
+        ...appConfig,
+        viewEngine: 'html: teddy',
+        http: { enable: true, port: 30142 }
+      })
+      await app.init()
+
+      assert.ok(fs.pathExistsSync(path.join(appDir, 'public')), 'the build should have run')
+      await assert.rejects(fetch('http://localhost:30142/'), 'nothing should be listening on the port it would have used')
+
+      assert.strictEqual(app.expressApp.get('httpServer').listening, false)
+    })
+  })
 })

--- a/test/util/sampleConfig.json
+++ b/test/util/sampleConfig.json
@@ -6,6 +6,7 @@
   "mode": "production",
   "deprecationChecks": "development-mode",
   "makeBuildArtifacts": false,
+  "buildOnly": false,
   "localhostOnly": "value",
   "trustProxy": "value",
   "logging": {

--- a/test/watchStatics.js
+++ b/test/watchStatics.js
@@ -172,12 +172,12 @@ describe('watching statics', () => {
     const app = await start({
       mode: 'development',
       frontendReload: { enable: true },
-      http: { enable: true, port: 43766 }
+      http: { enable: true, port: 30150 }
     })
     await app.startServer()
 
     // the reload script in the browser reloads the page when its socket closes and reopens, so closing it is the signal
-    const socket = new globalThis.WebSocket('ws://localhost:43766')
+    const socket = new globalThis.WebSocket('ws://localhost:30150')
     let closed = false
     socket.addEventListener('close', () => { closed = true })
     const opened = await eventually(() => socket.readyState === globalThis.WebSocket.OPEN)
@@ -193,7 +193,7 @@ describe('watching statics', () => {
 
   it('should close its watchers when the app shuts down', async () => {
     writePage('<p>before</p>')
-    const app = await start({ mode: 'development', http: { enable: true, port: 43765 } })
+    const app = await start({ mode: 'development', http: { enable: true, port: 30151 } })
     await app.startServer()
     assert.ok(app.expressApp.get('staticsWatchers').length > 0)
 


### PR DESCRIPTION
- Fixed the `--build` and `-b` command line flags starting a server instead of only running the build. Serving a static site was added in 0.33.0 by keying off `makeBuildArtifacts` being `staticsOnly`, which is also what `--build` sets, so the two behaviors could not be told apart and `--build` began serving the app it had just built.
- Added `buildOnly` param, which is what `--build` and `-b` set now. What gets built and whether the app then serves it are separate questions, so they are separate params. Calling `initServer` (`init`) rather than `startServer` does the same thing and is the better fit for a build script that drives Roosevelt directly.
- Updated dependencies.